### PR TITLE
Extend TH support to parametrised types

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -37,21 +37,12 @@ jobs:
             haskell/lambda-pi/src/Language/LambdaPi/Syntax/Lex.hs
             haskell/lambda-pi/src/Language/LambdaPi/Syntax/Par.hs
 
-      - name: Check Syntax files exist
-        if: steps.restore-syntax-files.outputs.cache-hit == 'true'
-        shell: bash
-        id: check-syntax-files
-        run: |
-          source scripts/lib.sh
-          check_syntax_files_exist
-          printf "SYNTAX_FILES_EXIST=$SYNTAX_FILES_EXIST\n" >> $GITHUB_OUTPUT
-
       - name: 🧰 Setup Stack
         uses: freckle/stack-action@v5
         with:
           stack-build-arguments: --pedantic
           stack-build-arguments-build: --dry-run
-          stack-build-arguments-test: --ghc-options -O2 ${{ steps.check-syntax-files.outputs.SYNTAX_FILES_EXIST == 'true' && ' ' || '--reconfigure --force-dirty --ghc-options -fforce-recomp' }}
+          stack-build-arguments-test: --ghc-options -O2 ${{ steps.restore-syntax-files.outputs.cache-hit == 'true' && ' ' || '--reconfigure --force-dirty --ghc-options -fforce-recomp' }}
 
       - name: Save Syntax files
         uses: actions/cache/save@v4

--- a/haskell/free-foil/free-foil.cabal
+++ b/haskell/free-foil/free-foil.cabal
@@ -36,6 +36,7 @@ library
       Control.Monad.Foil.TH.MkFromFoil
       Control.Monad.Foil.TH.MkInstancesFoil
       Control.Monad.Foil.TH.MkToFoil
+      Control.Monad.Foil.TH.Util
       Control.Monad.Free.Foil
       Control.Monad.Free.Foil.Example
   other-modules:

--- a/haskell/free-foil/src/Control/Monad/Foil/TH/MkFoilData.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/TH/MkFoilData.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE QuasiQuotes           #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
@@ -9,6 +8,7 @@ module Control.Monad.Foil.TH.MkFoilData (mkFoilData) where
 import           Language.Haskell.TH
 
 import qualified Control.Monad.Foil.Internal as Foil
+import Control.Monad.Foil.TH.Util
 
 -- | Generate scope-safe variants given names of types for the raw representation.
 mkFoilData
@@ -20,20 +20,18 @@ mkFoilData
 mkFoilData termT nameT scopeT patternT = do
   n <- newName "n"
   l <- newName "l"
-  TyConI (DataD _ctx _name _tvars _kind patternCons _deriv) <- reify patternT
-  TyConI (DataD _ctx _name _tvars _kind scopeCons _deriv) <- reify scopeT
-  TyConI (DataD _ctx _name _tvars _kind termCons _deriv) <- reify termT
+  TyConI (DataD _ctx _name patternTVars _kind patternCons _deriv) <- reify patternT
+  TyConI (DataD _ctx _name scopeTVars _kind scopeCons _deriv) <- reify scopeT
+  TyConI (DataD _ctx _name termTVars _kind termCons _deriv) <- reify termT
 
-  foilPatternCons <- mapM (toPatternCon n) patternCons
-  let foilScopeCons = map (toScopeCon n) scopeCons
-  let foilTermCons = map (toTermCon n l) termCons
+  foilPatternCons <- mapM (toPatternCon patternTVars n) patternCons
+  let foilScopeCons = map (toScopeCon scopeTVars n) scopeCons
+  let foilTermCons = map (toTermCon termTVars n l) termCons
 
   return
-    [ DataD [] foilTermT [PlainTV n ()] Nothing foilTermCons []
-    , StandaloneDerivD Nothing [] (AppT (ConT ''Show) (AppT (ConT foilTermT) (VarT n)))
-    , DataD [] foilScopeT [PlainTV n ()] Nothing foilScopeCons [DerivClause Nothing [ConT ''Show]]
-    , DataD [] foilPatternT [PlainTV n (), PlainTV l ()] Nothing foilPatternCons []
-    , StandaloneDerivD Nothing [] (AppT (ConT ''Show) (AppT (AppT (ConT foilPatternT) (VarT n)) (VarT l)))
+    [ DataD [] foilTermT (termTVars ++ [KindedTV n () (PromotedT ''Foil.S)]) Nothing foilTermCons []
+    , DataD [] foilScopeT (scopeTVars ++ [KindedTV n () (PromotedT ''Foil.S)]) Nothing foilScopeCons []
+    , DataD [] foilPatternT (patternTVars ++ [KindedTV n () (PromotedT ''Foil.S), KindedTV l () (PromotedT ''Foil.S)]) Nothing foilPatternCons []
     ]
   where
     foilTermT = mkName ("Foil" ++ nameBase termT)
@@ -43,13 +41,14 @@ mkFoilData termT nameT scopeT patternT = do
     -- | Convert a constructor declaration for a raw pattern type
     -- into a constructor for the scope-safe pattern type.
     toPatternCon
-      :: Name   -- ^ Name for the starting scope type variable.
+      :: [TyVarBndr ()]
+      -> Name   -- ^ Name for the starting scope type variable.
       -> Con    -- ^ Raw pattern constructor.
       -> Q Con
-    toPatternCon n (NormalC conName params) = do
+    toPatternCon tvars n (NormalC conName params) = do
       (lastScopeName, foilParams) <- toPatternConParams 1 n params
       let foilConName = mkName ("Foil" ++ nameBase conName)
-      return (GadtC [foilConName] foilParams (AppT (AppT (ConT foilPatternT) (VarT n)) (VarT lastScopeName)))
+      return (GadtC [foilConName] foilParams (PeelConT foilPatternT (map (VarT . tvarName) tvars ++ [VarT n, VarT lastScopeName])))
       where
         -- | Process type parameters of a pattern,
         -- introducing (existential) type variables for the intermediate scopes,
@@ -64,16 +63,16 @@ mkFoilData termT nameT scopeT patternT = do
           case type_ of
             -- if the current component is a variable identifier
             -- then treat it as a single name binder (see 'Foil.NameBinder')
-            ConT tyName | tyName == nameT -> do
+            PeelConT tyName _tyParams | tyName == nameT -> do
               l <- newName ("n" <> show i)
               let type' = AppT (AppT (ConT ''Foil.NameBinder) (VarT p)) (VarT l)
               (l', conParams') <- toPatternConParams (i+1) l conParams
               return (l', (bang_, type') : conParams')
             -- if the current component is a raw pattern
             -- then convert it into a scope-safe pattern
-            ConT tyName | tyName == patternT -> do
+            PeelConT tyName tyParams | tyName == patternT -> do
               l <- newName ("n" <> show i)
-              let type' = AppT (AppT (ConT foilPatternT) (VarT p)) (VarT l)
+              let type' = PeelConT foilPatternT (tyParams ++ [VarT p, VarT l])
               (l', conParams') <- toPatternConParams (i+1) l conParams
               return (l', (bang_, type') : conParams')
             -- otherwise, ignore the component as non-binding
@@ -83,26 +82,26 @@ mkFoilData termT nameT scopeT patternT = do
 
     -- | Convert a constructor declaration for a raw scoped term
     -- into a constructor for the scope-safe scoped term.
-    toScopeCon :: Name -> Con -> Con
-    toScopeCon n (NormalC conName params) =
+    toScopeCon :: [TyVarBndr ()] -> Name -> Con -> Con
+    toScopeCon _tvars n (NormalC conName params) =
       NormalC foilConName (map toScopeParam params)
       where
         foilConName = mkName ("Foil" ++ nameBase conName)
-        toScopeParam (_bang, ConT tyName)
-          | tyName == termT = (_bang, AppT (ConT foilTermT) (VarT n))
+        toScopeParam (_bang, PeelConT tyName tyParams)
+          | tyName == termT = (_bang, PeelConT foilTermT (tyParams ++ [VarT n]))
         toScopeParam _bangType = _bangType
 
     -- | Convert a constructor declaration for a raw term
     -- into a constructor for the scope-safe term.
-    toTermCon :: Name -> Name -> Con -> Con
-    toTermCon n l (NormalC conName params) =
-      GadtC [foilConName] (map toTermParam params) (AppT (ConT foilTermT) (VarT n))
+    toTermCon :: [TyVarBndr ()] -> Name -> Name -> Con -> Con
+    toTermCon tvars n l (NormalC conName params) =
+      GadtC [foilConName] (map toTermParam params) (PeelConT foilTermT (map (VarT . tvarName) tvars ++ [VarT n]))
       where
         foilNames = [n, l]
         foilConName = mkName ("Foil" ++ nameBase conName)
-        toTermParam (_bang, ConT tyName)
-          | tyName == patternT = (_bang, foldl AppT (ConT foilPatternT) (map VarT foilNames))
+        toTermParam (_bang, PeelConT tyName tyParams)
+          | tyName == patternT = (_bang, PeelConT foilPatternT (tyParams ++ map VarT foilNames))
           | tyName == nameT = (_bang, AppT (ConT ''Foil.Name) (VarT n))
-          | tyName == scopeT = (_bang, AppT (ConT foilScopeT) (VarT l))
-          | tyName == termT = (_bang, AppT (ConT foilTermT) (VarT n))
+          | tyName == scopeT = (_bang, PeelConT foilScopeT (tyParams ++ [VarT l]))
+          | tyName == termT = (_bang, PeelConT foilTermT (tyParams ++ [VarT n]))
         toTermParam _bangType = _bangType

--- a/haskell/free-foil/src/Control/Monad/Foil/TH/Util.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/TH/Util.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE PatternSynonyms                 #-}
+{-# LANGUAGE ViewPatterns                 #-}
+{-# LANGUAGE LambdaCase            #-}
+module Control.Monad.Foil.TH.Util where
+
+import Language.Haskell.TH
+
+peelConT :: Type -> Maybe (Name, [Type])
+peelConT (ConT name) = Just (name, [])
+peelConT (AppT f x) =
+  case peelConT f of
+    Just (g, xs) -> Just (g, xs ++ [x])
+    Nothing -> Nothing
+peelConT _ = Nothing
+
+unpeelConT :: Name -> [Type] -> Type
+unpeelConT = foldl AppT . ConT
+
+pattern PeelConT :: Name -> [Type] -> Type
+pattern PeelConT name types <- (peelConT -> Just (name, types)) where
+  PeelConT name types = unpeelConT name types
+
+tvarName :: TyVarBndr a -> Name
+tvarName = \case
+  PlainTV name _ -> name
+  KindedTV name _ _ -> name

--- a/haskell/lambda-pi/Setup.hs
+++ b/haskell/lambda-pi/Setup.hs
@@ -35,7 +35,7 @@ main =
                 [ "set -ex" ] <>
                 [ "chcp.com" | isWindows ] <>
                 [ "chcp.com 65001" | isWindows ] <>
-                [ "bnfc --haskell -d -p Language.LambdaPi --generic -o src/ grammar/LambdaPi/Syntax.cf"
+                [ "bnfc --haskell -d -p Language.LambdaPi --functor --generic -o src/ grammar/LambdaPi/Syntax.cf"
                 , "cd src/Language/LambdaPi/Syntax"
                 , "alex Lex.x"
                 , "happy Par.y"

--- a/haskell/lambda-pi/src/Language/LambdaPi/Syntax/Abs.hs
+++ b/haskell/lambda-pi/src/Language/LambdaPi/Syntax/Abs.hs
@@ -2,46 +2,107 @@
 
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 -- | The abstract syntax of language Syntax.
 
 module Language.LambdaPi.Syntax.Abs where
 
 import Prelude (String)
-import qualified Prelude as C (Eq, Ord, Show, Read)
+import qualified Prelude as C
+  ( Eq, Ord, Show, Read
+  , Functor, Foldable, Traversable
+  , Int, Maybe(..)
+  )
 import qualified Data.String
 
 import qualified Data.Data    as C (Data, Typeable)
 import qualified GHC.Generics as C (Generic)
 
-data Program = AProgram [Command]
-  deriving (C.Eq, C.Ord, C.Show, C.Read, C.Data, C.Typeable, C.Generic)
+type Program = Program' BNFC'Position
+data Program' a = AProgram a [Command' a]
+  deriving (C.Eq, C.Ord, C.Show, C.Read, C.Functor, C.Foldable, C.Traversable, C.Data, C.Typeable, C.Generic)
 
-data Command = CommandCheck Term Term | CommandCompute Term Term
-  deriving (C.Eq, C.Ord, C.Show, C.Read, C.Data, C.Typeable, C.Generic)
+type Command = Command' BNFC'Position
+data Command' a
+    = CommandCheck a (Term' a) (Term' a)
+    | CommandCompute a (Term' a) (Term' a)
+  deriving (C.Eq, C.Ord, C.Show, C.Read, C.Functor, C.Foldable, C.Traversable, C.Data, C.Typeable, C.Generic)
 
-data Term
-    = Var VarIdent
-    | Pi Pattern Term ScopedTerm
-    | Lam Pattern ScopedTerm
-    | App Term Term
-    | Product Term Term
-    | Pair Term Term
-    | First Term
-    | Second Term
-    | Universe
-  deriving (C.Eq, C.Ord, C.Show, C.Read, C.Data, C.Typeable, C.Generic)
+type Term = Term' BNFC'Position
+data Term' a
+    = Var a VarIdent
+    | Pi a (Pattern' a) (Term' a) (ScopedTerm' a)
+    | Lam a (Pattern' a) (ScopedTerm' a)
+    | App a (Term' a) (Term' a)
+    | Product a (Term' a) (Term' a)
+    | Pair a (Term' a) (Term' a)
+    | First a (Term' a)
+    | Second a (Term' a)
+    | Universe a
+  deriving (C.Eq, C.Ord, C.Show, C.Read, C.Functor, C.Foldable, C.Traversable, C.Data, C.Typeable, C.Generic)
 
-data ScopedTerm = AScopedTerm Term
-  deriving (C.Eq, C.Ord, C.Show, C.Read, C.Data, C.Typeable, C.Generic)
+type ScopedTerm = ScopedTerm' BNFC'Position
+data ScopedTerm' a = AScopedTerm a (Term' a)
+  deriving (C.Eq, C.Ord, C.Show, C.Read, C.Functor, C.Foldable, C.Traversable, C.Data, C.Typeable, C.Generic)
 
-data Pattern
-    = PatternWildcard
-    | PatternVar VarIdent
-    | PatternPair Pattern Pattern
-  deriving (C.Eq, C.Ord, C.Show, C.Read, C.Data, C.Typeable, C.Generic)
+type Pattern = Pattern' BNFC'Position
+data Pattern' a
+    = PatternWildcard a
+    | PatternVar a VarIdent
+    | PatternPair a (Pattern' a) (Pattern' a)
+  deriving (C.Eq, C.Ord, C.Show, C.Read, C.Functor, C.Foldable, C.Traversable, C.Data, C.Typeable, C.Generic)
 
 newtype VarIdent = VarIdent String
   deriving (C.Eq, C.Ord, C.Show, C.Read, C.Data, C.Typeable, C.Generic, Data.String.IsString)
+
+-- | Start position (line, column) of something.
+
+type BNFC'Position = C.Maybe (C.Int, C.Int)
+
+pattern BNFC'NoPosition :: BNFC'Position
+pattern BNFC'NoPosition = C.Nothing
+
+pattern BNFC'Position :: C.Int -> C.Int -> BNFC'Position
+pattern BNFC'Position line col = C.Just (line, col)
+
+-- | Get the start position of something.
+
+class HasPosition a where
+  hasPosition :: a -> BNFC'Position
+
+instance HasPosition Program where
+  hasPosition = \case
+    AProgram p _ -> p
+
+instance HasPosition Command where
+  hasPosition = \case
+    CommandCheck p _ _ -> p
+    CommandCompute p _ _ -> p
+
+instance HasPosition Term where
+  hasPosition = \case
+    Var p _ -> p
+    Pi p _ _ _ -> p
+    Lam p _ _ -> p
+    App p _ _ -> p
+    Product p _ _ -> p
+    Pair p _ _ -> p
+    First p _ -> p
+    Second p _ -> p
+    Universe p -> p
+
+instance HasPosition ScopedTerm where
+  hasPosition = \case
+    AScopedTerm p _ -> p
+
+instance HasPosition Pattern where
+  hasPosition = \case
+    PatternWildcard p -> p
+    PatternVar p _ -> p
+    PatternPair p _ _ -> p
 

--- a/haskell/lambda-pi/src/Language/LambdaPi/Syntax/Par.hs
+++ b/haskell/lambda-pi/src/Language/LambdaPi/Syntax/Par.hs
@@ -29,13 +29,13 @@ import Control.Monad (ap)
 data HappyAbsSyn 
 	= HappyTerminal (Token)
 	| HappyErrorToken Prelude.Int
-	| HappyAbsSyn11 (Language.LambdaPi.Syntax.Abs.VarIdent)
-	| HappyAbsSyn12 (Language.LambdaPi.Syntax.Abs.Program)
-	| HappyAbsSyn13 (Language.LambdaPi.Syntax.Abs.Command)
-	| HappyAbsSyn14 ([Language.LambdaPi.Syntax.Abs.Command])
-	| HappyAbsSyn15 (Language.LambdaPi.Syntax.Abs.Term)
-	| HappyAbsSyn18 (Language.LambdaPi.Syntax.Abs.ScopedTerm)
-	| HappyAbsSyn19 (Language.LambdaPi.Syntax.Abs.Pattern)
+	| HappyAbsSyn11 ((Language.LambdaPi.Syntax.Abs.BNFC'Position, Language.LambdaPi.Syntax.Abs.VarIdent))
+	| HappyAbsSyn12 ((Language.LambdaPi.Syntax.Abs.BNFC'Position, Language.LambdaPi.Syntax.Abs.Program))
+	| HappyAbsSyn13 ((Language.LambdaPi.Syntax.Abs.BNFC'Position, Language.LambdaPi.Syntax.Abs.Command))
+	| HappyAbsSyn14 ((Language.LambdaPi.Syntax.Abs.BNFC'Position, [Language.LambdaPi.Syntax.Abs.Command]))
+	| HappyAbsSyn15 ((Language.LambdaPi.Syntax.Abs.BNFC'Position, Language.LambdaPi.Syntax.Abs.Term))
+	| HappyAbsSyn18 ((Language.LambdaPi.Syntax.Abs.BNFC'Position, Language.LambdaPi.Syntax.Abs.ScopedTerm))
+	| HappyAbsSyn19 ((Language.LambdaPi.Syntax.Abs.BNFC'Position, Language.LambdaPi.Syntax.Abs.Pattern))
 
 {- to allow type-synonyms as our monads (likely
  - with explicitly-specified bind and return)
@@ -168,7 +168,7 @@ happyExpList = Happy_Data_Array.listArray (0,149) ([0,3072,0,32768,1,0,48,0,4,4,
 {-# NOINLINE happyExpListPerState #-}
 happyExpListPerState st =
     token_strs_expected
-  where token_strs = ["error","%dummy","%start_pProgram","%start_pCommand","%start_pListCommand","%start_pTerm2","%start_pTerm","%start_pTerm1","%start_pScopedTerm","%start_pPattern","VarIdent","Program","Command","ListCommand","Term2","Term","Term1","ScopedTerm","Pattern","'('","')'","','","'.'","':'","';'","'_'","'check'","'compute'","'\215'","'\928'","'\955'","'\960\8321'","'\960\8322'","'\8594'","'\120140'","L_VarIdent","%eof"]
+  where token_strs = ["error","%dummy","%start_pProgram_internal","%start_pCommand_internal","%start_pListCommand_internal","%start_pTerm2_internal","%start_pTerm_internal","%start_pTerm1_internal","%start_pScopedTerm_internal","%start_pPattern_internal","VarIdent","Program","Command","ListCommand","Term2","Term","Term1","ScopedTerm","Pattern","'('","')'","','","'.'","':'","';'","'_'","'check'","'compute'","'\215'","'\928'","'\955'","'\960\8321'","'\960\8322'","'\8594'","'\120140'","L_VarIdent","%eof"]
         bit_start = st Prelude.* 37
         bit_end = (st Prelude.+ 1) Prelude.* 37
         read_bit = readArrayBit happyExpList
@@ -577,16 +577,16 @@ action_71 _ = happyFail (happyExpListPerState 71)
 action_72 _ = happyReduce_16
 
 happyReduce_8 = happySpecReduce_1  11 happyReduction_8
-happyReduction_8 (HappyTerminal (PT _ (T_VarIdent happy_var_1)))
+happyReduction_8 (HappyTerminal happy_var_1)
 	 =  HappyAbsSyn11
-		 (Language.LambdaPi.Syntax.Abs.VarIdent happy_var_1
+		 ((uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.LambdaPi.Syntax.Abs.VarIdent (tokenText happy_var_1))
 	)
 happyReduction_8 _  = notHappyAtAll 
 
 happyReduce_9 = happySpecReduce_1  12 happyReduction_9
 happyReduction_9 (HappyAbsSyn14  happy_var_1)
 	 =  HappyAbsSyn12
-		 (Language.LambdaPi.Syntax.Abs.AProgram happy_var_1
+		 ((fst happy_var_1, Language.LambdaPi.Syntax.Abs.AProgram (fst happy_var_1) (snd happy_var_1))
 	)
 happyReduction_9 _  = notHappyAtAll 
 
@@ -594,25 +594,25 @@ happyReduce_10 = happyReduce 4 13 happyReduction_10
 happyReduction_10 ((HappyAbsSyn15  happy_var_4) `HappyStk`
 	_ `HappyStk`
 	(HappyAbsSyn15  happy_var_2) `HappyStk`
-	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
 	 = HappyAbsSyn13
-		 (Language.LambdaPi.Syntax.Abs.CommandCheck happy_var_2 happy_var_4
+		 ((uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.LambdaPi.Syntax.Abs.CommandCheck (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
 	) `HappyStk` happyRest
 
 happyReduce_11 = happyReduce 4 13 happyReduction_11
 happyReduction_11 ((HappyAbsSyn15  happy_var_4) `HappyStk`
 	_ `HappyStk`
 	(HappyAbsSyn15  happy_var_2) `HappyStk`
-	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
 	 = HappyAbsSyn13
-		 (Language.LambdaPi.Syntax.Abs.CommandCompute happy_var_2 happy_var_4
+		 ((uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.LambdaPi.Syntax.Abs.CommandCompute (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
 	) `HappyStk` happyRest
 
 happyReduce_12 = happySpecReduce_0  14 happyReduction_12
 happyReduction_12  =  HappyAbsSyn14
-		 ([]
+		 ((Language.LambdaPi.Syntax.Abs.BNFC'NoPosition, [])
 	)
 
 happyReduce_13 = happySpecReduce_3  14 happyReduction_13
@@ -620,23 +620,23 @@ happyReduction_13 (HappyAbsSyn14  happy_var_3)
 	_
 	(HappyAbsSyn13  happy_var_1)
 	 =  HappyAbsSyn14
-		 ((:) happy_var_1 happy_var_3
+		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_3))
 	)
 happyReduction_13 _ _ _  = notHappyAtAll 
 
 happyReduce_14 = happySpecReduce_1  15 happyReduction_14
 happyReduction_14 (HappyAbsSyn11  happy_var_1)
 	 =  HappyAbsSyn15
-		 (Language.LambdaPi.Syntax.Abs.Var happy_var_1
+		 ((fst happy_var_1, Language.LambdaPi.Syntax.Abs.Var (fst happy_var_1) (snd happy_var_1))
 	)
 happyReduction_14 _  = notHappyAtAll 
 
 happyReduce_15 = happySpecReduce_3  15 happyReduction_15
 happyReduction_15 _
 	(HappyAbsSyn15  happy_var_2)
-	_
+	(HappyTerminal happy_var_1)
 	 =  HappyAbsSyn15
-		 (happy_var_2
+		 ((uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), (snd happy_var_2))
 	)
 happyReduction_15 _ _ _  = notHappyAtAll 
 
@@ -648,20 +648,20 @@ happyReduction_16 ((HappyAbsSyn18  happy_var_8) `HappyStk`
 	_ `HappyStk`
 	(HappyAbsSyn19  happy_var_3) `HappyStk`
 	_ `HappyStk`
-	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
 	 = HappyAbsSyn15
-		 (Language.LambdaPi.Syntax.Abs.Pi happy_var_3 happy_var_5 happy_var_8
+		 ((uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.LambdaPi.Syntax.Abs.Pi (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_8))
 	) `HappyStk` happyRest
 
 happyReduce_17 = happyReduce 4 16 happyReduction_17
 happyReduction_17 ((HappyAbsSyn18  happy_var_4) `HappyStk`
 	_ `HappyStk`
 	(HappyAbsSyn19  happy_var_2) `HappyStk`
-	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
 	 = HappyAbsSyn15
-		 (Language.LambdaPi.Syntax.Abs.Lam happy_var_2 happy_var_4
+		 ((uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.LambdaPi.Syntax.Abs.Lam (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
 	) `HappyStk` happyRest
 
 happyReduce_18 = happySpecReduce_3  16 happyReduction_18
@@ -669,7 +669,7 @@ happyReduction_18 (HappyAbsSyn15  happy_var_3)
 	_
 	(HappyAbsSyn15  happy_var_1)
 	 =  HappyAbsSyn15
-		 (Language.LambdaPi.Syntax.Abs.Product happy_var_1 happy_var_3
+		 ((fst happy_var_1, Language.LambdaPi.Syntax.Abs.Product (fst happy_var_1) (snd happy_var_1) (snd happy_var_3))
 	)
 happyReduction_18 _ _ _  = notHappyAtAll 
 
@@ -678,42 +678,43 @@ happyReduction_19 (_ `HappyStk`
 	(HappyAbsSyn15  happy_var_4) `HappyStk`
 	_ `HappyStk`
 	(HappyAbsSyn15  happy_var_2) `HappyStk`
-	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
 	 = HappyAbsSyn15
-		 (Language.LambdaPi.Syntax.Abs.Pair happy_var_2 happy_var_4
+		 ((uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.LambdaPi.Syntax.Abs.Pair (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
 	) `HappyStk` happyRest
 
 happyReduce_20 = happyReduce 4 16 happyReduction_20
 happyReduction_20 (_ `HappyStk`
 	(HappyAbsSyn15  happy_var_3) `HappyStk`
 	_ `HappyStk`
-	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
 	 = HappyAbsSyn15
-		 (Language.LambdaPi.Syntax.Abs.First happy_var_3
+		 ((uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.LambdaPi.Syntax.Abs.First (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3))
 	) `HappyStk` happyRest
 
 happyReduce_21 = happyReduce 4 16 happyReduction_21
 happyReduction_21 (_ `HappyStk`
 	(HappyAbsSyn15  happy_var_3) `HappyStk`
 	_ `HappyStk`
-	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
 	 = HappyAbsSyn15
-		 (Language.LambdaPi.Syntax.Abs.Second happy_var_3
+		 ((uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.LambdaPi.Syntax.Abs.Second (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3))
 	) `HappyStk` happyRest
 
 happyReduce_22 = happySpecReduce_1  16 happyReduction_22
-happyReduction_22 _
+happyReduction_22 (HappyTerminal happy_var_1)
 	 =  HappyAbsSyn15
-		 (Language.LambdaPi.Syntax.Abs.Universe
+		 ((uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.LambdaPi.Syntax.Abs.Universe (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
 	)
+happyReduction_22 _  = notHappyAtAll 
 
 happyReduce_23 = happySpecReduce_1  16 happyReduction_23
 happyReduction_23 (HappyAbsSyn15  happy_var_1)
 	 =  HappyAbsSyn15
-		 (happy_var_1
+		 ((fst happy_var_1, (snd happy_var_1))
 	)
 happyReduction_23 _  = notHappyAtAll 
 
@@ -721,34 +722,35 @@ happyReduce_24 = happySpecReduce_2  17 happyReduction_24
 happyReduction_24 (HappyAbsSyn15  happy_var_2)
 	(HappyAbsSyn15  happy_var_1)
 	 =  HappyAbsSyn15
-		 (Language.LambdaPi.Syntax.Abs.App happy_var_1 happy_var_2
+		 ((fst happy_var_1, Language.LambdaPi.Syntax.Abs.App (fst happy_var_1) (snd happy_var_1) (snd happy_var_2))
 	)
 happyReduction_24 _ _  = notHappyAtAll 
 
 happyReduce_25 = happySpecReduce_1  17 happyReduction_25
 happyReduction_25 (HappyAbsSyn15  happy_var_1)
 	 =  HappyAbsSyn15
-		 (happy_var_1
+		 ((fst happy_var_1, (snd happy_var_1))
 	)
 happyReduction_25 _  = notHappyAtAll 
 
 happyReduce_26 = happySpecReduce_1  18 happyReduction_26
 happyReduction_26 (HappyAbsSyn15  happy_var_1)
 	 =  HappyAbsSyn18
-		 (Language.LambdaPi.Syntax.Abs.AScopedTerm happy_var_1
+		 ((fst happy_var_1, Language.LambdaPi.Syntax.Abs.AScopedTerm (fst happy_var_1) (snd happy_var_1))
 	)
 happyReduction_26 _  = notHappyAtAll 
 
 happyReduce_27 = happySpecReduce_1  19 happyReduction_27
-happyReduction_27 _
+happyReduction_27 (HappyTerminal happy_var_1)
 	 =  HappyAbsSyn19
-		 (Language.LambdaPi.Syntax.Abs.PatternWildcard
+		 ((uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.LambdaPi.Syntax.Abs.PatternWildcard (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
 	)
+happyReduction_27 _  = notHappyAtAll 
 
 happyReduce_28 = happySpecReduce_1  19 happyReduction_28
 happyReduction_28 (HappyAbsSyn11  happy_var_1)
 	 =  HappyAbsSyn19
-		 (Language.LambdaPi.Syntax.Abs.PatternVar happy_var_1
+		 ((fst happy_var_1, Language.LambdaPi.Syntax.Abs.PatternVar (fst happy_var_1) (snd happy_var_1))
 	)
 happyReduction_28 _  = notHappyAtAll 
 
@@ -757,10 +759,10 @@ happyReduction_29 (_ `HappyStk`
 	(HappyAbsSyn19  happy_var_4) `HappyStk`
 	_ `HappyStk`
 	(HappyAbsSyn19  happy_var_2) `HappyStk`
-	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
 	 = HappyAbsSyn19
-		 (Language.LambdaPi.Syntax.Abs.PatternPair happy_var_2 happy_var_4
+		 ((uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.LambdaPi.Syntax.Abs.PatternPair (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
 	) `HappyStk` happyRest
 
 happyNewToken action sts stk [] =
@@ -785,7 +787,7 @@ happyNewToken action sts stk (tk:tks) =
 	PT _ (TS _ 14) -> cont 33;
 	PT _ (TS _ 15) -> cont 34;
 	PT _ (TS _ 16) -> cont 35;
-	PT _ (T_VarIdent happy_dollar_dollar) -> cont 36;
+	PT _ (T_VarIdent _) -> cont 36;
 	_ -> happyError' ((tk:tks), [])
 	}
 
@@ -801,28 +803,28 @@ happyReturn1 :: () => a -> b -> Err a
 happyReturn1 = \a tks -> (return) a
 happyError' :: () => ([(Token)], [Prelude.String]) -> Err a
 happyError' = (\(tokens, _) -> happyError tokens)
-pProgram tks = happySomeParser where
+pProgram_internal tks = happySomeParser where
  happySomeParser = happyThen (happyParse action_0 tks) (\x -> case x of {HappyAbsSyn12 z -> happyReturn z; _other -> notHappyAtAll })
 
-pCommand tks = happySomeParser where
+pCommand_internal tks = happySomeParser where
  happySomeParser = happyThen (happyParse action_1 tks) (\x -> case x of {HappyAbsSyn13 z -> happyReturn z; _other -> notHappyAtAll })
 
-pListCommand tks = happySomeParser where
+pListCommand_internal tks = happySomeParser where
  happySomeParser = happyThen (happyParse action_2 tks) (\x -> case x of {HappyAbsSyn14 z -> happyReturn z; _other -> notHappyAtAll })
 
-pTerm2 tks = happySomeParser where
+pTerm2_internal tks = happySomeParser where
  happySomeParser = happyThen (happyParse action_3 tks) (\x -> case x of {HappyAbsSyn15 z -> happyReturn z; _other -> notHappyAtAll })
 
-pTerm tks = happySomeParser where
+pTerm_internal tks = happySomeParser where
  happySomeParser = happyThen (happyParse action_4 tks) (\x -> case x of {HappyAbsSyn15 z -> happyReturn z; _other -> notHappyAtAll })
 
-pTerm1 tks = happySomeParser where
+pTerm1_internal tks = happySomeParser where
  happySomeParser = happyThen (happyParse action_5 tks) (\x -> case x of {HappyAbsSyn15 z -> happyReturn z; _other -> notHappyAtAll })
 
-pScopedTerm tks = happySomeParser where
+pScopedTerm_internal tks = happySomeParser where
  happySomeParser = happyThen (happyParse action_6 tks) (\x -> case x of {HappyAbsSyn18 z -> happyReturn z; _other -> notHappyAtAll })
 
-pPattern tks = happySomeParser where
+pPattern_internal tks = happySomeParser where
  happySomeParser = happyThen (happyParse action_7 tks) (\x -> case x of {HappyAbsSyn19 z -> happyReturn z; _other -> notHappyAtAll })
 
 happySeq = happyDontSeq
@@ -840,6 +842,32 @@ happyError ts = Left $
 
 myLexer :: String -> [Token]
 myLexer = tokens
+
+-- Entrypoints
+
+pProgram :: [Token] -> Err Language.LambdaPi.Syntax.Abs.Program
+pProgram = fmap snd . pProgram_internal
+
+pCommand :: [Token] -> Err Language.LambdaPi.Syntax.Abs.Command
+pCommand = fmap snd . pCommand_internal
+
+pListCommand :: [Token] -> Err [Language.LambdaPi.Syntax.Abs.Command]
+pListCommand = fmap snd . pListCommand_internal
+
+pTerm2 :: [Token] -> Err Language.LambdaPi.Syntax.Abs.Term
+pTerm2 = fmap snd . pTerm2_internal
+
+pTerm :: [Token] -> Err Language.LambdaPi.Syntax.Abs.Term
+pTerm = fmap snd . pTerm_internal
+
+pTerm1 :: [Token] -> Err Language.LambdaPi.Syntax.Abs.Term
+pTerm1 = fmap snd . pTerm1_internal
+
+pScopedTerm :: [Token] -> Err Language.LambdaPi.Syntax.Abs.ScopedTerm
+pScopedTerm = fmap snd . pScopedTerm_internal
+
+pPattern :: [Token] -> Err Language.LambdaPi.Syntax.Abs.Pattern
+pPattern = fmap snd . pPattern_internal
 {-# LINE 1 "templates/GenericTemplate.hs" #-}
 -- $Id: GenericTemplate.hs,v 1.26 2005/01/14 14:47:22 simonmar Exp $
 

--- a/haskell/lambda-pi/src/Language/LambdaPi/Syntax/Par.y
+++ b/haskell/lambda-pi/src/Language/LambdaPi/Syntax/Par.y
@@ -25,82 +25,85 @@ import Language.LambdaPi.Syntax.Lex
 
 }
 
-%name pProgram Program
-%name pCommand Command
-%name pListCommand ListCommand
-%name pTerm2 Term2
-%name pTerm Term
-%name pTerm1 Term1
-%name pScopedTerm ScopedTerm
-%name pPattern Pattern
+%name pProgram_internal Program
+%name pCommand_internal Command
+%name pListCommand_internal ListCommand
+%name pTerm2_internal Term2
+%name pTerm_internal Term
+%name pTerm1_internal Term1
+%name pScopedTerm_internal ScopedTerm
+%name pPattern_internal Pattern
 -- no lexer declaration
 %monad { Err } { (>>=) } { return }
 %tokentype {Token}
 %token
-  '('        { PT _ (TS _ 1)        }
-  ')'        { PT _ (TS _ 2)        }
-  ','        { PT _ (TS _ 3)        }
-  '.'        { PT _ (TS _ 4)        }
-  ':'        { PT _ (TS _ 5)        }
-  ';'        { PT _ (TS _ 6)        }
-  '_'        { PT _ (TS _ 7)        }
-  'check'    { PT _ (TS _ 8)        }
-  'compute'  { PT _ (TS _ 9)        }
-  '×'        { PT _ (TS _ 10)       }
-  'Π'        { PT _ (TS _ 11)       }
-  'λ'        { PT _ (TS _ 12)       }
-  'π₁'       { PT _ (TS _ 13)       }
-  'π₂'       { PT _ (TS _ 14)       }
-  '→'        { PT _ (TS _ 15)       }
-  '𝕌'        { PT _ (TS _ 16)       }
-  L_VarIdent { PT _ (T_VarIdent $$) }
+  '('        { PT _ (TS _ 1)       }
+  ')'        { PT _ (TS _ 2)       }
+  ','        { PT _ (TS _ 3)       }
+  '.'        { PT _ (TS _ 4)       }
+  ':'        { PT _ (TS _ 5)       }
+  ';'        { PT _ (TS _ 6)       }
+  '_'        { PT _ (TS _ 7)       }
+  'check'    { PT _ (TS _ 8)       }
+  'compute'  { PT _ (TS _ 9)       }
+  '×'        { PT _ (TS _ 10)      }
+  'Π'        { PT _ (TS _ 11)      }
+  'λ'        { PT _ (TS _ 12)      }
+  'π₁'       { PT _ (TS _ 13)      }
+  'π₂'       { PT _ (TS _ 14)      }
+  '→'        { PT _ (TS _ 15)      }
+  '𝕌'        { PT _ (TS _ 16)      }
+  L_VarIdent { PT _ (T_VarIdent _) }
 
 %%
 
-VarIdent :: { Language.LambdaPi.Syntax.Abs.VarIdent }
-VarIdent  : L_VarIdent { Language.LambdaPi.Syntax.Abs.VarIdent $1 }
+VarIdent :: { (Language.LambdaPi.Syntax.Abs.BNFC'Position, Language.LambdaPi.Syntax.Abs.VarIdent) }
+VarIdent  : L_VarIdent { (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1), Language.LambdaPi.Syntax.Abs.VarIdent (tokenText $1)) }
 
-Program :: { Language.LambdaPi.Syntax.Abs.Program }
-Program : ListCommand { Language.LambdaPi.Syntax.Abs.AProgram $1 }
+Program :: { (Language.LambdaPi.Syntax.Abs.BNFC'Position, Language.LambdaPi.Syntax.Abs.Program) }
+Program
+  : ListCommand { (fst $1, Language.LambdaPi.Syntax.Abs.AProgram (fst $1) (snd $1)) }
 
-Command :: { Language.LambdaPi.Syntax.Abs.Command }
+Command :: { (Language.LambdaPi.Syntax.Abs.BNFC'Position, Language.LambdaPi.Syntax.Abs.Command) }
 Command
-  : 'check' Term ':' Term { Language.LambdaPi.Syntax.Abs.CommandCheck $2 $4 }
-  | 'compute' Term ':' Term { Language.LambdaPi.Syntax.Abs.CommandCompute $2 $4 }
+  : 'check' Term ':' Term { (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1), Language.LambdaPi.Syntax.Abs.CommandCheck (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1)) (snd $2) (snd $4)) }
+  | 'compute' Term ':' Term { (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1), Language.LambdaPi.Syntax.Abs.CommandCompute (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1)) (snd $2) (snd $4)) }
 
-ListCommand :: { [Language.LambdaPi.Syntax.Abs.Command] }
+ListCommand :: { (Language.LambdaPi.Syntax.Abs.BNFC'Position, [Language.LambdaPi.Syntax.Abs.Command]) }
 ListCommand
-  : {- empty -} { [] } | Command ';' ListCommand { (:) $1 $3 }
+  : {- empty -} { (Language.LambdaPi.Syntax.Abs.BNFC'NoPosition, []) }
+  | Command ';' ListCommand { (fst $1, (:) (snd $1) (snd $3)) }
 
-Term2 :: { Language.LambdaPi.Syntax.Abs.Term }
+Term2 :: { (Language.LambdaPi.Syntax.Abs.BNFC'Position, Language.LambdaPi.Syntax.Abs.Term) }
 Term2
-  : VarIdent { Language.LambdaPi.Syntax.Abs.Var $1 }
-  | '(' Term ')' { $2 }
+  : VarIdent { (fst $1, Language.LambdaPi.Syntax.Abs.Var (fst $1) (snd $1)) }
+  | '(' Term ')' { (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1), (snd $2)) }
 
-Term :: { Language.LambdaPi.Syntax.Abs.Term }
+Term :: { (Language.LambdaPi.Syntax.Abs.BNFC'Position, Language.LambdaPi.Syntax.Abs.Term) }
 Term
-  : 'Π' '(' Pattern ':' Term ')' '→' ScopedTerm { Language.LambdaPi.Syntax.Abs.Pi $3 $5 $8 }
-  | 'λ' Pattern '.' ScopedTerm { Language.LambdaPi.Syntax.Abs.Lam $2 $4 }
-  | Term1 '×' Term1 { Language.LambdaPi.Syntax.Abs.Product $1 $3 }
-  | '(' Term ',' Term ')' { Language.LambdaPi.Syntax.Abs.Pair $2 $4 }
-  | 'π₁' '(' Term ')' { Language.LambdaPi.Syntax.Abs.First $3 }
-  | 'π₂' '(' Term ')' { Language.LambdaPi.Syntax.Abs.Second $3 }
-  | '𝕌' { Language.LambdaPi.Syntax.Abs.Universe }
-  | Term1 { $1 }
+  : 'Π' '(' Pattern ':' Term ')' '→' ScopedTerm { (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1), Language.LambdaPi.Syntax.Abs.Pi (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1)) (snd $3) (snd $5) (snd $8)) }
+  | 'λ' Pattern '.' ScopedTerm { (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1), Language.LambdaPi.Syntax.Abs.Lam (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1)) (snd $2) (snd $4)) }
+  | Term1 '×' Term1 { (fst $1, Language.LambdaPi.Syntax.Abs.Product (fst $1) (snd $1) (snd $3)) }
+  | '(' Term ',' Term ')' { (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1), Language.LambdaPi.Syntax.Abs.Pair (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1)) (snd $2) (snd $4)) }
+  | 'π₁' '(' Term ')' { (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1), Language.LambdaPi.Syntax.Abs.First (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1)) (snd $3)) }
+  | 'π₂' '(' Term ')' { (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1), Language.LambdaPi.Syntax.Abs.Second (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1)) (snd $3)) }
+  | '𝕌' { (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1), Language.LambdaPi.Syntax.Abs.Universe (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1))) }
+  | Term1 { (fst $1, (snd $1)) }
 
-Term1 :: { Language.LambdaPi.Syntax.Abs.Term }
+Term1 :: { (Language.LambdaPi.Syntax.Abs.BNFC'Position, Language.LambdaPi.Syntax.Abs.Term) }
 Term1
-  : Term1 Term2 { Language.LambdaPi.Syntax.Abs.App $1 $2 }
-  | Term2 { $1 }
+  : Term1 Term2 { (fst $1, Language.LambdaPi.Syntax.Abs.App (fst $1) (snd $1) (snd $2)) }
+  | Term2 { (fst $1, (snd $1)) }
 
-ScopedTerm :: { Language.LambdaPi.Syntax.Abs.ScopedTerm }
-ScopedTerm : Term { Language.LambdaPi.Syntax.Abs.AScopedTerm $1 }
+ScopedTerm :: { (Language.LambdaPi.Syntax.Abs.BNFC'Position, Language.LambdaPi.Syntax.Abs.ScopedTerm) }
+ScopedTerm
+  : Term { (fst $1, Language.LambdaPi.Syntax.Abs.AScopedTerm (fst $1) (snd $1)) }
 
-Pattern :: { Language.LambdaPi.Syntax.Abs.Pattern }
+Pattern :: { (Language.LambdaPi.Syntax.Abs.BNFC'Position, Language.LambdaPi.Syntax.Abs.Pattern) }
 Pattern
-  : '_' { Language.LambdaPi.Syntax.Abs.PatternWildcard }
-  | VarIdent { Language.LambdaPi.Syntax.Abs.PatternVar $1 }
-  | '(' Pattern ',' Pattern ')' { Language.LambdaPi.Syntax.Abs.PatternPair $2 $4 }
+  : '_' { (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1), Language.LambdaPi.Syntax.Abs.PatternWildcard (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1))) }
+  | VarIdent { (fst $1, Language.LambdaPi.Syntax.Abs.PatternVar (fst $1) (snd $1)) }
+  | '(' Pattern ',' Pattern ')' { (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1), Language.LambdaPi.Syntax.Abs.PatternPair (uncurry Language.LambdaPi.Syntax.Abs.BNFC'Position (tokenLineCol $1)) (snd $2) (snd $4)) }
 
 {
 
@@ -117,5 +120,30 @@ happyError ts = Left $
 myLexer :: String -> [Token]
 myLexer = tokens
 
+-- Entrypoints
+
+pProgram :: [Token] -> Err Language.LambdaPi.Syntax.Abs.Program
+pProgram = fmap snd . pProgram_internal
+
+pCommand :: [Token] -> Err Language.LambdaPi.Syntax.Abs.Command
+pCommand = fmap snd . pCommand_internal
+
+pListCommand :: [Token] -> Err [Language.LambdaPi.Syntax.Abs.Command]
+pListCommand = fmap snd . pListCommand_internal
+
+pTerm2 :: [Token] -> Err Language.LambdaPi.Syntax.Abs.Term
+pTerm2 = fmap snd . pTerm2_internal
+
+pTerm :: [Token] -> Err Language.LambdaPi.Syntax.Abs.Term
+pTerm = fmap snd . pTerm_internal
+
+pTerm1 :: [Token] -> Err Language.LambdaPi.Syntax.Abs.Term
+pTerm1 = fmap snd . pTerm1_internal
+
+pScopedTerm :: [Token] -> Err Language.LambdaPi.Syntax.Abs.ScopedTerm
+pScopedTerm = fmap snd . pScopedTerm_internal
+
+pPattern :: [Token] -> Err Language.LambdaPi.Syntax.Abs.Pattern
+pPattern = fmap snd . pPattern_internal
 }
 

--- a/haskell/lambda-pi/src/Language/LambdaPi/Syntax/Print.hs
+++ b/haskell/lambda-pi/src/Language/LambdaPi/Syntax/Print.hs
@@ -139,37 +139,37 @@ instance Print Double where
 
 instance Print Language.LambdaPi.Syntax.Abs.VarIdent where
   prt _ (Language.LambdaPi.Syntax.Abs.VarIdent i) = doc $ showString i
-instance Print Language.LambdaPi.Syntax.Abs.Program where
+instance Print (Language.LambdaPi.Syntax.Abs.Program' a) where
   prt i = \case
-    Language.LambdaPi.Syntax.Abs.AProgram commands -> prPrec i 0 (concatD [prt 0 commands])
+    Language.LambdaPi.Syntax.Abs.AProgram _ commands -> prPrec i 0 (concatD [prt 0 commands])
 
-instance Print Language.LambdaPi.Syntax.Abs.Command where
+instance Print (Language.LambdaPi.Syntax.Abs.Command' a) where
   prt i = \case
-    Language.LambdaPi.Syntax.Abs.CommandCheck term1 term2 -> prPrec i 0 (concatD [doc (showString "check"), prt 0 term1, doc (showString ":"), prt 0 term2])
-    Language.LambdaPi.Syntax.Abs.CommandCompute term1 term2 -> prPrec i 0 (concatD [doc (showString "compute"), prt 0 term1, doc (showString ":"), prt 0 term2])
+    Language.LambdaPi.Syntax.Abs.CommandCheck _ term1 term2 -> prPrec i 0 (concatD [doc (showString "check"), prt 0 term1, doc (showString ":"), prt 0 term2])
+    Language.LambdaPi.Syntax.Abs.CommandCompute _ term1 term2 -> prPrec i 0 (concatD [doc (showString "compute"), prt 0 term1, doc (showString ":"), prt 0 term2])
 
-instance Print [Language.LambdaPi.Syntax.Abs.Command] where
+instance Print [Language.LambdaPi.Syntax.Abs.Command' a] where
   prt _ [] = concatD []
   prt _ (x:xs) = concatD [prt 0 x, doc (showString ";"), prt 0 xs]
 
-instance Print Language.LambdaPi.Syntax.Abs.Term where
+instance Print (Language.LambdaPi.Syntax.Abs.Term' a) where
   prt i = \case
-    Language.LambdaPi.Syntax.Abs.Var varident -> prPrec i 2 (concatD [prt 0 varident])
-    Language.LambdaPi.Syntax.Abs.Pi pattern_ term scopedterm -> prPrec i 0 (concatD [doc (showString "\928"), doc (showString "("), prt 0 pattern_, doc (showString ":"), prt 0 term, doc (showString ")"), doc (showString "\8594"), prt 0 scopedterm])
-    Language.LambdaPi.Syntax.Abs.Lam pattern_ scopedterm -> prPrec i 0 (concatD [doc (showString "\955"), prt 0 pattern_, doc (showString "."), prt 0 scopedterm])
-    Language.LambdaPi.Syntax.Abs.App term1 term2 -> prPrec i 1 (concatD [prt 1 term1, prt 2 term2])
-    Language.LambdaPi.Syntax.Abs.Product term1 term2 -> prPrec i 0 (concatD [prt 1 term1, doc (showString "\215"), prt 1 term2])
-    Language.LambdaPi.Syntax.Abs.Pair term1 term2 -> prPrec i 0 (concatD [doc (showString "("), prt 0 term1, doc (showString ","), prt 0 term2, doc (showString ")")])
-    Language.LambdaPi.Syntax.Abs.First term -> prPrec i 0 (concatD [doc (showString "\960\8321"), doc (showString "("), prt 0 term, doc (showString ")")])
-    Language.LambdaPi.Syntax.Abs.Second term -> prPrec i 0 (concatD [doc (showString "\960\8322"), doc (showString "("), prt 0 term, doc (showString ")")])
-    Language.LambdaPi.Syntax.Abs.Universe -> prPrec i 0 (concatD [doc (showString "\120140")])
+    Language.LambdaPi.Syntax.Abs.Var _ varident -> prPrec i 2 (concatD [prt 0 varident])
+    Language.LambdaPi.Syntax.Abs.Pi _ pattern_ term scopedterm -> prPrec i 0 (concatD [doc (showString "\928"), doc (showString "("), prt 0 pattern_, doc (showString ":"), prt 0 term, doc (showString ")"), doc (showString "\8594"), prt 0 scopedterm])
+    Language.LambdaPi.Syntax.Abs.Lam _ pattern_ scopedterm -> prPrec i 0 (concatD [doc (showString "\955"), prt 0 pattern_, doc (showString "."), prt 0 scopedterm])
+    Language.LambdaPi.Syntax.Abs.App _ term1 term2 -> prPrec i 1 (concatD [prt 1 term1, prt 2 term2])
+    Language.LambdaPi.Syntax.Abs.Product _ term1 term2 -> prPrec i 0 (concatD [prt 1 term1, doc (showString "\215"), prt 1 term2])
+    Language.LambdaPi.Syntax.Abs.Pair _ term1 term2 -> prPrec i 0 (concatD [doc (showString "("), prt 0 term1, doc (showString ","), prt 0 term2, doc (showString ")")])
+    Language.LambdaPi.Syntax.Abs.First _ term -> prPrec i 0 (concatD [doc (showString "\960\8321"), doc (showString "("), prt 0 term, doc (showString ")")])
+    Language.LambdaPi.Syntax.Abs.Second _ term -> prPrec i 0 (concatD [doc (showString "\960\8322"), doc (showString "("), prt 0 term, doc (showString ")")])
+    Language.LambdaPi.Syntax.Abs.Universe _ -> prPrec i 0 (concatD [doc (showString "\120140")])
 
-instance Print Language.LambdaPi.Syntax.Abs.ScopedTerm where
+instance Print (Language.LambdaPi.Syntax.Abs.ScopedTerm' a) where
   prt i = \case
-    Language.LambdaPi.Syntax.Abs.AScopedTerm term -> prPrec i 0 (concatD [prt 0 term])
+    Language.LambdaPi.Syntax.Abs.AScopedTerm _ term -> prPrec i 0 (concatD [prt 0 term])
 
-instance Print Language.LambdaPi.Syntax.Abs.Pattern where
+instance Print (Language.LambdaPi.Syntax.Abs.Pattern' a) where
   prt i = \case
-    Language.LambdaPi.Syntax.Abs.PatternWildcard -> prPrec i 0 (concatD [doc (showString "_")])
-    Language.LambdaPi.Syntax.Abs.PatternVar varident -> prPrec i 0 (concatD [prt 0 varident])
-    Language.LambdaPi.Syntax.Abs.PatternPair pattern_1 pattern_2 -> prPrec i 0 (concatD [doc (showString "("), prt 0 pattern_1, doc (showString ","), prt 0 pattern_2, doc (showString ")")])
+    Language.LambdaPi.Syntax.Abs.PatternWildcard _ -> prPrec i 0 (concatD [doc (showString "_")])
+    Language.LambdaPi.Syntax.Abs.PatternVar _ varident -> prPrec i 0 (concatD [prt 0 varident])
+    Language.LambdaPi.Syntax.Abs.PatternPair _ pattern_1 pattern_2 -> prPrec i 0 (concatD [doc (showString "("), prt 0 pattern_1, doc (showString ","), prt 0 pattern_2, doc (showString ")")])

--- a/haskell/lambda-pi/src/Language/LambdaPi/Syntax/Skel.hs
+++ b/haskell/lambda-pi/src/Language/LambdaPi/Syntax/Skel.hs
@@ -19,33 +19,33 @@ transVarIdent :: Language.LambdaPi.Syntax.Abs.VarIdent -> Result
 transVarIdent x = case x of
   Language.LambdaPi.Syntax.Abs.VarIdent string -> failure x
 
-transProgram :: Language.LambdaPi.Syntax.Abs.Program -> Result
+transProgram :: Show a => Language.LambdaPi.Syntax.Abs.Program' a -> Result
 transProgram x = case x of
-  Language.LambdaPi.Syntax.Abs.AProgram commands -> failure x
+  Language.LambdaPi.Syntax.Abs.AProgram _ commands -> failure x
 
-transCommand :: Language.LambdaPi.Syntax.Abs.Command -> Result
+transCommand :: Show a => Language.LambdaPi.Syntax.Abs.Command' a -> Result
 transCommand x = case x of
-  Language.LambdaPi.Syntax.Abs.CommandCheck term1 term2 -> failure x
-  Language.LambdaPi.Syntax.Abs.CommandCompute term1 term2 -> failure x
+  Language.LambdaPi.Syntax.Abs.CommandCheck _ term1 term2 -> failure x
+  Language.LambdaPi.Syntax.Abs.CommandCompute _ term1 term2 -> failure x
 
-transTerm :: Language.LambdaPi.Syntax.Abs.Term -> Result
+transTerm :: Show a => Language.LambdaPi.Syntax.Abs.Term' a -> Result
 transTerm x = case x of
-  Language.LambdaPi.Syntax.Abs.Var varident -> failure x
-  Language.LambdaPi.Syntax.Abs.Pi pattern_ term scopedterm -> failure x
-  Language.LambdaPi.Syntax.Abs.Lam pattern_ scopedterm -> failure x
-  Language.LambdaPi.Syntax.Abs.App term1 term2 -> failure x
-  Language.LambdaPi.Syntax.Abs.Product term1 term2 -> failure x
-  Language.LambdaPi.Syntax.Abs.Pair term1 term2 -> failure x
-  Language.LambdaPi.Syntax.Abs.First term -> failure x
-  Language.LambdaPi.Syntax.Abs.Second term -> failure x
-  Language.LambdaPi.Syntax.Abs.Universe -> failure x
+  Language.LambdaPi.Syntax.Abs.Var _ varident -> failure x
+  Language.LambdaPi.Syntax.Abs.Pi _ pattern_ term scopedterm -> failure x
+  Language.LambdaPi.Syntax.Abs.Lam _ pattern_ scopedterm -> failure x
+  Language.LambdaPi.Syntax.Abs.App _ term1 term2 -> failure x
+  Language.LambdaPi.Syntax.Abs.Product _ term1 term2 -> failure x
+  Language.LambdaPi.Syntax.Abs.Pair _ term1 term2 -> failure x
+  Language.LambdaPi.Syntax.Abs.First _ term -> failure x
+  Language.LambdaPi.Syntax.Abs.Second _ term -> failure x
+  Language.LambdaPi.Syntax.Abs.Universe _ -> failure x
 
-transScopedTerm :: Language.LambdaPi.Syntax.Abs.ScopedTerm -> Result
+transScopedTerm :: Show a => Language.LambdaPi.Syntax.Abs.ScopedTerm' a -> Result
 transScopedTerm x = case x of
-  Language.LambdaPi.Syntax.Abs.AScopedTerm term -> failure x
+  Language.LambdaPi.Syntax.Abs.AScopedTerm _ term -> failure x
 
-transPattern :: Language.LambdaPi.Syntax.Abs.Pattern -> Result
+transPattern :: Show a => Language.LambdaPi.Syntax.Abs.Pattern' a -> Result
 transPattern x = case x of
-  Language.LambdaPi.Syntax.Abs.PatternWildcard -> failure x
-  Language.LambdaPi.Syntax.Abs.PatternVar varident -> failure x
-  Language.LambdaPi.Syntax.Abs.PatternPair pattern_1 pattern_2 -> failure x
+  Language.LambdaPi.Syntax.Abs.PatternWildcard _ -> failure x
+  Language.LambdaPi.Syntax.Abs.PatternVar _ varident -> failure x
+  Language.LambdaPi.Syntax.Abs.PatternPair _ pattern_1 pattern_2 -> failure x


### PR DESCRIPTION
This PR extends Template Haskell support to include term, scope, and pattern types that are parametrized by some type arguments. However, the following is NOT supported:

1. The type of variables is supposed to be independent of the type of patterns. This is required specifically for `mkToFoil`, and more specifically, when constructing `toFoilPattern` function. Indeed, it is difficult to automatically infer how type parameters of pattern type constructor depend on the type parameters of variable identifier type constructor. Practically speaking, when using with BNFC with `--functor` (to add location info), use token type (e.g. `Ident`) for variable identifiers. To restore location for variables, use the location of the corresponding expression.
2. Type parameters are assumed to be plain types/kinds, dependencies between parameter types are not supported (e.g. `data T k (a :: k)` is not supported).

To demonstrate the use case, we modify `lambda-pi` example to rely on `--functor` option in BNFC (which adds location info, but also parametrizes all types of non-terminals).