### PR TITLE
Generate Free Foil with Template Haskell

### DIFF
--- a/haskell/free-foil/free-foil.cabal
+++ b/haskell/free-foil/free-foil.cabal
@@ -44,6 +44,7 @@ library
       Control.Monad.Free.Foil.TH.Convert
       Control.Monad.Free.Foil.TH.PatternSynonyms
       Control.Monad.Free.Foil.TH.Signature
+      Control.Monad.Free.Foil.TH.ZipMatch
   other-modules:
       Paths_free_foil
   hs-source-dirs:

--- a/haskell/free-foil/free-foil.cabal
+++ b/haskell/free-foil/free-foil.cabal
@@ -41,6 +41,7 @@ library
       Control.Monad.Free.Foil
       Control.Monad.Free.Foil.Example
       Control.Monad.Free.Foil.TH
+      Control.Monad.Free.Foil.TH.PatternSynonyms
       Control.Monad.Free.Foil.TH.Signature
   other-modules:
       Paths_free_foil

--- a/haskell/free-foil/free-foil.cabal
+++ b/haskell/free-foil/free-foil.cabal
@@ -41,6 +41,7 @@ library
       Control.Monad.Free.Foil
       Control.Monad.Free.Foil.Example
       Control.Monad.Free.Foil.TH
+      Control.Monad.Free.Foil.TH.Convert
       Control.Monad.Free.Foil.TH.PatternSynonyms
       Control.Monad.Free.Foil.TH.Signature
   other-modules:

--- a/haskell/free-foil/free-foil.cabal
+++ b/haskell/free-foil/free-foil.cabal
@@ -40,6 +40,8 @@ library
       Control.Monad.Foil.TH.Util
       Control.Monad.Free.Foil
       Control.Monad.Free.Foil.Example
+      Control.Monad.Free.Foil.TH
+      Control.Monad.Free.Foil.TH.Signature
   other-modules:
       Paths_free_foil
   hs-source-dirs:

--- a/haskell/free-foil/src/Control/Monad/Foil/TH/Util.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/TH/Util.hs
@@ -24,3 +24,6 @@ tvarName :: TyVarBndr a -> Name
 tvarName = \case
   PlainTV name _ -> name
   KindedTV name _ _ -> name
+
+removeName :: VarBangType -> BangType
+removeName (_name, bang_, type_) = (bang_, type_)

--- a/haskell/free-foil/src/Control/Monad/Free/Foil.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil.hs
@@ -22,9 +22,11 @@ import           Control.DeepSeq
 import qualified Control.Monad.Foil.Internal as Foil
 import qualified Control.Monad.Foil.Relative as Foil
 import           Data.Bifoldable
-import           Data.Bifunctor.Sum
 import           Data.Bifunctor
+import           Data.Bifunctor.Sum
 import           Data.Coerce                 (coerce)
+import           Data.Map                    (Map)
+import qualified Data.Map                    as Map
 import           Data.Monoid                 (All (..))
 import           GHC.Generics                (Generic)
 
@@ -245,4 +247,45 @@ class ZipMatch sig where
 instance (ZipMatch f, ZipMatch g) => ZipMatch (Sum f g) where
   zipMatch (L2 f) (L2 f') = L2 <$> zipMatch f f'
   zipMatch (R2 g) (R2 g') = R2 <$> zipMatch g g'
-  zipMatch _ _ = Nothing
+  zipMatch _ _            = Nothing
+
+-- * Converting to and from free foil
+
+-- ** Convert to free foil
+
+convertToAST
+  :: (Foil.Distinct n, Bifunctor sig, Ord rawIdent)
+  => (rawTerm -> Either rawIdent (sig (rawPattern, rawScopedTerm) rawTerm))
+  -> (rawPattern -> Maybe rawIdent)
+  -> (rawScopedTerm -> rawTerm)
+  -> Foil.Scope n
+  -> Map rawIdent (Foil.Name n) -> rawTerm -> AST sig n
+convertToAST toSig getPatternBinder getScopedTerm scope names t =
+  case toSig t of
+    Left x ->
+      case Map.lookup x names of
+        Nothing   -> error "undefined variable"
+        Just name -> Var name
+    Right node -> Node $
+      bimap
+        (convertToScopedAST toSig getPatternBinder getScopedTerm scope names)
+        (convertToAST toSig getPatternBinder getScopedTerm scope names)
+        node
+
+convertToScopedAST
+  :: (Foil.Distinct n, Bifunctor sig, Ord rawIdent)
+  => (rawTerm -> Either rawIdent (sig (rawPattern, rawScopedTerm) rawTerm))
+  -> (rawPattern -> Maybe rawIdent)
+  -> (rawScopedTerm -> rawTerm)
+  -> Foil.Scope n
+  -> Map rawIdent (Foil.Name n)
+  -> (rawPattern, rawScopedTerm)
+  -> ScopedAST sig n
+convertToScopedAST toSig getPatternBinder getScopedTerm scope names (pat, scopedTerm) =
+  Foil.withFresh scope $ \binder ->
+    let scope' = Foil.extendScope binder scope
+        names' =
+          case getPatternBinder pat of
+            Nothing -> Foil.sink <$> names
+            Just x  -> Map.insert x (Foil.nameOf binder) (Foil.sink <$> names)
+     in ScopedAST binder (convertToAST toSig getPatternBinder getScopedTerm scope' names' (getScopedTerm scopedTerm))

--- a/haskell/free-foil/src/Control/Monad/Free/Foil/TH.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil/TH.hs
@@ -1,0 +1,5 @@
+module Control.Monad.Free.Foil.TH (
+  module Control.Monad.Free.Foil.TH.Signature,
+) where
+
+import Control.Monad.Free.Foil.TH.Signature

--- a/haskell/free-foil/src/Control/Monad/Free/Foil/TH.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil/TH.hs
@@ -2,8 +2,10 @@ module Control.Monad.Free.Foil.TH (
   module Control.Monad.Free.Foil.TH.Signature,
   module Control.Monad.Free.Foil.TH.PatternSynonyms,
   module Control.Monad.Free.Foil.TH.Convert,
+  module Control.Monad.Free.Foil.TH.ZipMatch,
 ) where
 
 import Control.Monad.Free.Foil.TH.Signature
 import Control.Monad.Free.Foil.TH.PatternSynonyms
 import Control.Monad.Free.Foil.TH.Convert
+import Control.Monad.Free.Foil.TH.ZipMatch

--- a/haskell/free-foil/src/Control/Monad/Free/Foil/TH.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil/TH.hs
@@ -1,5 +1,7 @@
 module Control.Monad.Free.Foil.TH (
   module Control.Monad.Free.Foil.TH.Signature,
+  module Control.Monad.Free.Foil.TH.PatternSynonyms,
 ) where
 
 import Control.Monad.Free.Foil.TH.Signature
+import Control.Monad.Free.Foil.TH.PatternSynonyms

--- a/haskell/free-foil/src/Control/Monad/Free/Foil/TH.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil/TH.hs
@@ -1,7 +1,9 @@
 module Control.Monad.Free.Foil.TH (
   module Control.Monad.Free.Foil.TH.Signature,
   module Control.Monad.Free.Foil.TH.PatternSynonyms,
+  module Control.Monad.Free.Foil.TH.Convert,
 ) where
 
 import Control.Monad.Free.Foil.TH.Signature
 import Control.Monad.Free.Foil.TH.PatternSynonyms
+import Control.Monad.Free.Foil.TH.Convert

--- a/haskell/free-foil/src/Control/Monad/Free/Foil/TH/Convert.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil/TH/Convert.hs
@@ -1,0 +1,191 @@
+{-# LANGUAGE LambdaCase      #-}
+{-# OPTIONS_GHC -fno-warn-type-defaults      #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Control.Monad.Free.Foil.TH.Convert where
+
+import           Language.Haskell.TH
+import           Language.Haskell.TH.Syntax
+
+import           Control.Monad.Foil.TH.Util
+
+mkConvertToFreeFoil
+  :: Name -- ^ Type name for raw terms.
+  -> Name -- ^ Type name for raw variable identifiers.
+  -> Name -- ^ Type name for raw scoped terms.
+  -> Name -- ^ Type name for raw patterns.
+  -> Q [Dec]
+mkConvertToFreeFoil termT nameT scopeT patternT = concat <$> sequence
+  [ mkConvertToSig termT nameT scopeT patternT
+  , mkGetPatternBinder nameT patternT
+  , mkGetScopedTerm termT scopeT
+  ]
+
+mkConvertToSig
+  :: Name -- ^ Type name for raw terms.
+  -> Name -- ^ Type name for raw variable identifiers.
+  -> Name -- ^ Type name for raw scoped terms.
+  -> Name -- ^ Type name for raw patterns.
+  -> Q [Dec]
+mkConvertToSig termT nameT scopeT patternT = do
+  TyConI (DataD _ctx _name termTVars _kind termCons _deriv) <- reify termT
+  TyConI (NewtypeD _ctx _name nameTVars _kind _nameCons _deriv) <- reify nameT
+
+  convertTermToSigClauses <- concat <$> mapM toClause termCons
+
+  let params = map (VarT . tvarName) termTVars
+      termType = return $ PeelConT termT params
+      nameType = return $ PeelConT nameT (map (VarT . tvarName) nameTVars)
+      scopeType = return $ PeelConT scopeT params
+      patternType = return $ PeelConT patternT params
+      signatureType = return $ PeelConT signatureT params
+  convertTermToSigClausesType <-
+    [t| $termType -> Either $nameType ($signatureType ($patternType, $scopeType) $termType) |]
+
+  addModFinalizer $ putDoc (DeclDoc convertTermToSigT)
+    ("/Generated/ with '" ++ show 'mkConvertToFreeFoil ++ "'. Perform one step of converting '" ++ show termT ++ "', peeling off one node of type '" ++ show signatureT ++ "'.")
+  return
+    [ SigD convertTermToSigT convertTermToSigClausesType
+    , FunD convertTermToSigT convertTermToSigClauses
+    ]
+  where
+    signatureT = mkName (nameBase termT ++ "Sig")
+    convertTermToSigT = mkName ("convertTo" ++ nameBase signatureT)
+
+    toClause :: Con -> Q [Clause]
+    toClause = \case
+      NormalC conName types | any isVarP pats
+        -> return [Clause [ConP conName [] pats] (NormalB (AppE (ConE 'Left) (VarE x))) []]
+        where
+          x = mkName "x"
+          isVarP VarP{} = True
+          isVarP _ = False
+          pats =
+            [ case type_ of
+                PeelConT typeName _ | typeName == nameT -> VarP x
+                _ -> WildP
+            | (_bang, type_) <- types ]
+      NormalC conName types -> mkClause conName conName' types
+        where
+          conName' = mkName (nameBase conName ++ "Sig")
+      RecC conName types -> toClause (NormalC conName (map removeName types))
+      InfixC l conName r -> mkClause conName conName' [l, r]
+        where
+          conName' = mkName (nameBase conName ++ "---")
+      ForallC _ _ con -> toClause con
+      GadtC conNames types _retType -> concat <$> mapM (\conName -> toClause (NormalC conName types)) conNames
+      RecGadtC conNames types retType -> toClause (GadtC conNames (map removeName types) retType)
+
+    mkClause conName conName' types = return
+      [ Clause [ConP conName [] pats] (NormalB (AppE (ConE 'Right) (foldl AppE (ConE conName') (concat args)))) [] ]
+      where
+        p = mkName "p"
+        (pats, args) = unzip
+          [ case type_ of
+              PeelConT typeName _
+                | typeName == patternT -> (VarP p, [])
+                | typeName == scopeT -> (VarP x, [TupE [Just (VarE p), Just (VarE x)]])
+              _ -> (VarP x, [VarE x])
+          | (i, (_bang, type_)) <- zip [0..] types
+          , let x = mkName ("x" ++ show i)
+          ]
+
+mkGetPatternBinder
+  :: Name -- ^ Type name for raw variable identifiers.
+  -> Name -- ^ Type name for raw patterns.
+  -> Q [Dec]
+mkGetPatternBinder nameT patternT = do
+  TyConI (NewtypeD _ctx _name nameTVars _kind _nameCons _deriv) <- reify nameT
+  TyConI (DataD _ctx _name patternTVars _kind patternCons _deriv) <- reify patternT
+
+  getPatternBinderClauses <- concat <$> mapM toClause patternCons
+
+  let nameType = return $ PeelConT nameT (map (VarT . tvarName) nameTVars)
+      patternType = return $ PeelConT patternT (map (VarT . tvarName) patternTVars)
+  getPatternBinderClausesType <-
+    [t| $patternType -> Maybe $nameType |]
+
+  addModFinalizer $ putDoc (DeclDoc getPatternBinderT)
+    ("/Generated/ with '" ++ show 'mkGetPatternBinder ++ "'. Extract at most one binder from a pattern or __crash__.")
+  return
+    [ SigD getPatternBinderT getPatternBinderClausesType
+    , FunD getPatternBinderT getPatternBinderClauses
+    ]
+  where
+    getPatternBinderT = mkName ("get" ++ nameBase patternT ++ "Binder")
+
+    toClause :: Con -> Q [Clause]
+    toClause = \case
+      NormalC conName types -> mkClause conName types
+      RecC conName types -> toClause (NormalC conName (map removeName types))
+      InfixC l conName r -> toClause (NormalC conName [l, r])
+      ForallC _ _ con -> toClause con
+      GadtC conNames types _retType -> concat <$> mapM (\conName -> mkClause conName types) conNames
+      RecGadtC conNames types retType -> toClause (GadtC conNames (map removeName types) retType)
+
+    mkClause :: Name -> [BangType] -> Q [Clause]
+    mkClause conName types = do
+      body <- case concat vars of
+        [] -> [e| Nothing |]
+        [Just y] -> [e| Just $y |]
+        _ -> [e| error "complex patterns are not supported" |]
+      return [ Clause [ConP conName [] pats] (NormalB body) [] ]
+      where
+        x = mkName "x"
+        (pats, vars) = unzip
+          [ case type_ of
+              PeelConT typeName _
+                | typeName == nameT -> (VarP x, [Just (return (VarE x))])
+                | typeName == patternT -> (WildP, [Nothing])
+              _ -> (WildP, [])
+          | (_bang, type_) <- types
+          ]
+
+mkGetScopedTerm
+  :: Name -- ^ Type name for raw terms.
+  -> Name -- ^ Type name for raw scoped terms.
+  -> Q [Dec]
+mkGetScopedTerm termT scopeT = do
+  TyConI (DataD _ctx _name termTVars _kind _termCons _deriv) <- reify termT
+  TyConI (DataD _ctx _name _scopeTVars _kind scopeCons _deriv) <- reify scopeT
+
+  getScopedTermClauses <- concat <$> mapM toClause scopeCons
+
+  let params = map (VarT . tvarName) termTVars
+      termType = return $ PeelConT termT params
+      scopeType = return $ PeelConT scopeT params
+  getScopedTermClausesType <-
+    [t| $scopeType -> $termType |]
+
+  addModFinalizer $ putDoc (DeclDoc getScopedTermT)
+    ("/Generated/ with '" ++ show 'mkGetScopedTerm ++ "'. Extract scoped term or __crash__.")
+  return
+    [ SigD getScopedTermT getScopedTermClausesType
+    , FunD getScopedTermT getScopedTermClauses
+    ]
+  where
+    getScopedTermT = mkName ("get" ++ nameBase termT ++ "From" ++ nameBase scopeT)
+
+    toClause :: Con -> Q [Clause]
+    toClause = \case
+      NormalC conName types -> mkClause conName types
+      RecC conName types -> toClause (NormalC conName (map removeName types))
+      InfixC l conName r -> toClause (NormalC conName [l, r])
+      ForallC _ _ con -> toClause con
+      GadtC conNames types _retType -> concat <$> mapM (\conName -> mkClause conName types) conNames
+      RecGadtC conNames types retType -> toClause (GadtC conNames (map removeName types) retType)
+
+    mkClause :: Name -> [BangType] -> Q [Clause]
+    mkClause conName types = do
+      body <- case concat vars of
+        [y] -> [e| $y |]
+        _ -> [e| error "complex patterns are not supported" |]
+      return [ Clause [ConP conName [] pats] (NormalB body) [] ]
+      where
+        x = mkName "x"
+        (pats, vars) = unzip
+          [ case type_ of
+              PeelConT typeName _
+                | typeName == termT -> (VarP x, [return (VarE x)])
+              _ -> (WildP, [])
+          | (_bang, type_) <- types
+          ]

--- a/haskell/free-foil/src/Control/Monad/Free/Foil/TH/PatternSynonyms.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil/TH/PatternSynonyms.hs
@@ -81,8 +81,6 @@ mkPatternSynonym signatureType scope term = \case
     mkPatternName conName = mkName (dropEnd (length "Sig") (nameBase conName))
     dropEnd k = reverse . drop k . reverse
 
-    removeName (_name, bang_, type_) = (bang_, type_)
-
     collapse = \case
       Left (x, y) -> [x, y]
       Right x -> [x]

--- a/haskell/free-foil/src/Control/Monad/Free/Foil/TH/PatternSynonyms.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil/TH/PatternSynonyms.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE LambdaCase      #-}
+{-# OPTIONS_GHC -fno-warn-type-defaults      #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ViewPatterns    #-}
+module Control.Monad.Free.Foil.TH.PatternSynonyms where
+
+import qualified Control.Monad.Foil         as Foil
+import           Control.Monad.Foil.TH.Util
+import           Control.Monad.Free.Foil
+import           Language.Haskell.TH
+
+-- | Generate helpful pattern synonyms given a signature bifunctor.
+mkPatternSynonyms
+  :: Name -- ^ Type name for the signature bifunctor.
+  -> Q [Dec]
+mkPatternSynonyms signatureT = do
+  TyConI (DataD _ctx _name signatureTVars _kind signatureCons _deriv) <- reify signatureT
+
+  case reverse signatureTVars of
+    (tvarName -> term) : (tvarName -> scope) : (reverse -> params) -> do
+      concat <$> mapM (mkPatternSynonym (PeelConT signatureT (map (VarT . tvarName) params)) scope term) signatureCons
+    _ -> fail "cannot generate pattern synonyms"
+
+mkPatternSynonym :: Type -> Name -> Name -> Con -> Q [Dec]
+mkPatternSynonym signatureType scope term = \case
+  NormalC conName types -> mkPatternSynonym signatureType scope term
+    (GadtC [conName] types (AppT (AppT signatureType (VarT scope)) (VarT term)))
+
+  RecC conName types -> mkPatternSynonym signatureType scope term (NormalC conName (map removeName types))
+
+  InfixC l conName r -> mkPatternSynonym signatureType scope term (NormalC conName [l, r])
+
+  ForallC params ctx con -> do
+    [ PatSynSigD patName patType, patD ] <- mkPatternSynonym signatureType scope term con
+    return
+      [ PatSynSigD patName (ForallT params ctx patType)
+      , patD
+      ]
+
+  GadtC conNames types _retType -> do
+    let argsWithTypes = zipWith toPatternArgType [0..] types
+        argsWithTypes' = foldMap collapse argsWithTypes
+        pats   = map toArg argsWithTypes
+        args  = map fst argsWithTypes'
+        types' = map snd argsWithTypes'
+    return $ concat
+      [ [ PatSynSigD patternName (foldr (AppT . AppT ArrowT) termType types')
+        , PatSynD  patternName (PrefixPatSyn args) ImplBidir (ConP 'Node [] [ConP conName [] pats])
+        ]
+      | conName <- conNames
+      , let patternName = mkPatternName conName
+      ]
+
+  RecGadtC conNames types retType -> mkPatternSynonym signatureType scope term (GadtC conNames (map removeName types) retType)
+
+  where
+    n = mkName "n"
+    termType = PeelConT ''AST [signatureType, VarT n]
+    toArg = \case
+      Left ((b, _), (x, _)) -> ConP 'ScopedAST [] [VarP b, VarP x]
+      Right (x, _) -> VarP x
+
+    toPatternArgType i (_bang, VarT typeName)
+      | typeName == scope =
+          Left
+            ( (mkName ("b" ++ show i), PeelConT ''Foil.NameBinder [VarT n, VarT l])
+            , (mkName ("x" ++ show i), PeelConT ''AST [signatureType, VarT l]))
+      | typeName == term =
+          Right (mkName ("x" ++ show i), PeelConT ''AST [signatureType, VarT n])
+      where
+        l = mkName ("l" ++ show i)
+    toPatternArgType i (_bang, type_)
+      = Right (mkName ("z" ++ show i), type_)
+
+    mkPatternName conName = mkName (dropEnd (length "Sig") (nameBase conName))
+    dropEnd k = reverse . drop k . reverse
+
+    removeName (_name, bang_, type_) = (bang_, type_)
+
+    collapse = \case
+      Left (x, y) -> [x, y]
+      Right x -> [x]

--- a/haskell/free-foil/src/Control/Monad/Free/Foil/TH/PatternSynonyms.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil/TH/PatternSynonyms.hs
@@ -5,10 +5,12 @@
 {-# LANGUAGE ViewPatterns    #-}
 module Control.Monad.Free.Foil.TH.PatternSynonyms where
 
+import Control.Monad (forM_)
 import qualified Control.Monad.Foil         as Foil
 import           Control.Monad.Foil.TH.Util
 import           Control.Monad.Free.Foil
 import           Language.Haskell.TH
+import           Language.Haskell.TH.Syntax
 
 -- | Generate helpful pattern synonyms given a signature bifunctor.
 mkPatternSynonyms
@@ -44,6 +46,9 @@ mkPatternSynonym signatureType scope term = \case
         pats   = map toArg argsWithTypes
         args  = map fst argsWithTypes'
         types' = map snd argsWithTypes'
+    forM_ conNames $ \conName ->
+      addModFinalizer $ putDoc (DeclDoc (mkPatternName conName))
+        ("/Generated/ with '" ++ show 'mkPatternSynonyms ++ "'. Pattern synonym for an '" ++ show ''AST ++ "' node of type '" ++ show conName ++ "'.")
     return $ concat
       [ [ PatSynSigD patternName (foldr (AppT . AppT ArrowT) termType types')
         , PatSynD  patternName (PrefixPatSyn args) ImplBidir (ConP 'Node [] [ConP conName [] pats])

--- a/haskell/free-foil/src/Control/Monad/Free/Foil/TH/Signature.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil/TH/Signature.hs
@@ -1,13 +1,13 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Control.Monad.Free.Foil.TH.Signature where
 
 import           Language.Haskell.TH
 import           Language.Haskell.TH.Syntax
 
-import Control.Monad (forM_)
-import Control.Monad.Foil.TH.Util
-import Data.Maybe (catMaybes)
+import           Control.Monad              (forM_)
+import           Control.Monad.Foil.TH.Util
+import           Data.Maybe                 (catMaybes)
 
 -- | Generate a signature for the free foil (or free scoped monads)
 -- based on a naïve recursive abstract syntax representation,
@@ -29,7 +29,8 @@ mkSignature termT nameT scopeT patternT = do
   addModFinalizer $ putDoc (DeclDoc signatureT)
     ("/Generated/ with '" ++ show 'mkSignature ++ "'. A signature bifunctor, specifying the nodes of a syntax tree corresponding to '" ++ show termT ++ "'.")
   return
-    [ DataD [] signatureT (termTVars ++ [PlainTV scope BndrReq, PlainTV term BndrReq]) Nothing signatureCons []
+    [ DataD [] signatureT (termTVars ++ [PlainTV scope BndrReq, PlainTV term BndrReq]) Nothing signatureCons
+      [DerivClause Nothing [ConT ''Functor, ConT ''Foldable, ConT ''Traversable]]
     ]
   where
     signatureT = mkName (nameBase termT ++ "Sig")

--- a/haskell/free-foil/src/Control/Monad/Free/Foil/TH/Signature.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil/TH/Signature.hs
@@ -48,13 +48,13 @@ mkSignature termT nameT scopeT patternT = do
         where
           conName' = mkName (nameBase conName ++ "---")
       ForallC params ctx con -> fmap (ForallC params ctx) <$> toSignatureCons scope term con
-      GadtC params argTypes retType -> Just <$> (GadtC params <$> (catMaybes <$> mapM toSignatureParam argTypes) <*> retType')
+      GadtC conNames argTypes retType -> Just <$> (GadtC conNames <$> (catMaybes <$> mapM toSignatureParam argTypes) <*> retType')
         where
           retType' = case retType of
             PeelConT typeName typeParams
               | typeName == termT -> return (PeelConT signatureT (typeParams ++ [VarT scope, VarT term]))
             _ -> fail "unexpected return type in a GADT constructor"
-      RecGadtC params argTypes retType -> Just <$> (RecGadtC params <$> (catMaybes <$> mapM toSignatureParam' argTypes) <*> retType')
+      RecGadtC conNames argTypes retType -> Just <$> (RecGadtC conNames <$> (catMaybes <$> mapM toSignatureParam' argTypes) <*> retType')
         where
           retType' = case retType of
             PeelConT typeName typeParams

--- a/haskell/free-foil/src/Control/Monad/Free/Foil/TH/Signature.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil/TH/Signature.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Control.Monad.Free.Foil.TH.Signature where
+
+import           Language.Haskell.TH
+
+import Control.Monad.Foil.TH.Util
+import Data.Maybe (catMaybes)
+
+-- | Generate a signature for the free foil (or free scoped monads)
+-- based on a naïve recursive abstract syntax representation,
+-- with clearly separated types for terms, variable identifiers, scoped terms,
+-- and patterns (binders).
+mkSignature
+  :: Name -- ^ Type name for raw terms.
+  -> Name -- ^ Type name for raw variable identifiers.
+  -> Name -- ^ Type name for raw scoped terms.
+  -> Name -- ^ Type name for raw patterns.
+  -> Q [Dec]
+mkSignature termT nameT scopeT patternT = do
+  scope <- newName "scope"
+  term <- newName "term"
+  TyConI (DataD _ctx _name termTVars _kind termCons _deriv) <- reify termT
+
+  signatureCons <- catMaybes <$> mapM (toSignatureCons scope term) termCons
+
+  return
+    [ DataD [] signatureT (termTVars ++ [PlainTV scope BndrReq, PlainTV term BndrReq]) Nothing signatureCons []
+    ]
+  where
+    signatureT = mkName (nameBase termT ++ "Sig")
+
+    toSignatureCons :: Name -> Name -> Con -> Q (Maybe Con)
+    toSignatureCons scope term con' = case con' of
+      -- treat constructors with a single variable field as variable constructor and ignore
+      NormalC _conName types | or [ typeName == nameT | (_bang, PeelConT typeName _typeParams) <- types ]
+        -> pure Nothing
+      RecC _conName types | or [ typeName == nameT | (_name, _bang, PeelConT typeName _typeParams) <- types ]
+        -> pure Nothing
+
+      NormalC conName params -> Just . NormalC conName' . catMaybes <$> mapM toSignatureParam params
+        where
+          conName' = mkName (nameBase conName ++ "Sig")
+      RecC conName params -> Just . RecC conName' . catMaybes <$> mapM toSignatureParam' params
+        where
+          conName' = mkName (nameBase conName ++ "Sig")
+      InfixC l conName r -> Just <$> (flip InfixC conName' <$> toInfixParam l <*> toInfixParam r)
+        where
+          conName' = mkName (nameBase conName ++ "---")
+      ForallC params ctx con -> fmap (ForallC params ctx) <$> toSignatureCons scope term con
+      GadtC params argTypes retType -> Just <$> (GadtC params <$> (catMaybes <$> mapM toSignatureParam argTypes) <*> retType')
+        where
+          retType' = case retType of
+            PeelConT typeName typeParams
+              | typeName == termT -> return (PeelConT signatureT (typeParams ++ [VarT scope, VarT term]))
+            _ -> fail "unexpected return type in a GADT constructor"
+      RecGadtC params argTypes retType -> Just <$> (RecGadtC params <$> (catMaybes <$> mapM toSignatureParam' argTypes) <*> retType')
+        where
+          retType' = case retType of
+            PeelConT typeName typeParams
+              | typeName == termT -> return (PeelConT signatureT (typeParams ++ [VarT scope, VarT term]))
+            _ -> fail "unexpected return type in a GADT constructor"
+
+      where
+        toInfixParam (bang_, type_) = toSignatureParam (bang_, type_) >>= \case
+          Nothing -> pure (bang_, VarT ''())
+          Just bt -> pure bt
+
+        toSignatureParam' (name, bang_, type_) = fmap k <$> toSignatureParam (bang_, type_)
+          where
+            k (x, y) = (name, x, y)
+
+        toSignatureParam (bang_, PeelConT typeName _typeParams)
+          | typeName == nameT = fail ("variable with other stuff in constructor: " ++ show con')
+          | typeName == patternT = pure Nothing -- skip binders, they will be inserted automatically with each scoped term
+          | typeName == scopeT = pure (Just (bang_, VarT scope))
+          | typeName == termT = pure (Just (bang_, VarT term))
+        toSignatureParam bt = pure (Just bt)  -- everything else remains as is

--- a/haskell/free-foil/src/Control/Monad/Free/Foil/TH/ZipMatch.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil/TH/ZipMatch.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE LambdaCase      #-}
+{-# OPTIONS_GHC -fno-warn-type-defaults      #-}
+{-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Control.Monad.Free.Foil.TH.ZipMatch where
+
+import           Language.Haskell.TH
+
+import           Control.Monad.Foil.TH.Util
+import           Control.Monad.Free.Foil
+
+-- | Generate helpful pattern synonyms given a signature bifunctor.
+deriveZipMatch
+  :: Name -- ^ Type name for the signature bifunctor.
+  -> Q [Dec]
+deriveZipMatch signatureT = do
+  TyConI (DataD _ctx _name signatureTVars _kind signatureCons _deriv) <- reify signatureT
+
+  case reverse signatureTVars of
+    (tvarName -> term) : (tvarName -> scope) : (reverse -> params) -> do
+      let signatureType = PeelConT signatureT (map (VarT . tvarName) params)
+      clauses <- concat <$> mapM (toClause scope term) signatureCons
+      let defaultClause = Clause [WildP, WildP] (NormalB (ConE 'Nothing)) []
+      let instType = AppT (ConT ''ZipMatch) signatureType
+
+      return
+        [ InstanceD Nothing [] instType
+          [ FunD 'zipMatch (clauses ++ [defaultClause]) ]
+        ]
+    _ -> fail "cannot generate pattern synonyms"
+
+  where
+    toClause :: Name -> Name -> Con -> Q [Clause]
+    toClause scope term = go
+      where
+        go = \case
+          NormalC conName types -> mkClause conName types
+          RecC conName types -> go (NormalC conName (map removeName types))
+          InfixC l conName r -> go (NormalC conName [l, r])
+          ForallC _ _ con -> go con
+          GadtC conNames types _retType -> concat <$> mapM (\conName -> mkClause conName types) conNames
+          RecGadtC conNames types retType -> go (GadtC conNames (map removeName types) retType)
+
+        mkClause :: Name -> [BangType] -> Q [Clause]
+        mkClause conName types = return
+          [Clause [ConP conName [] lpats, ConP conName [] rpats]
+            (NormalB (AppE (ConE 'Just) (foldl AppE (ConE conName) args))) []]
+          where
+            (lpats, rpats, args) = unzip3
+              [ case type_ of
+                  VarT typeName
+                    | typeName `elem` [scope, term] -> (VarP l, VarP r, TupE [Just (VarE l), Just (VarE r)])
+                  _ -> (VarP l, WildP, VarE l)
+              | (i, (_bang, type_)) <- zip [0..] types
+              , let l = mkName ("l" ++ show i)
+              , let r = mkName ("r" ++ show i)
+              ]

--- a/haskell/lambda-pi/lambda-pi.cabal
+++ b/haskell/lambda-pi/lambda-pi.cabal
@@ -38,6 +38,7 @@ library
       Language.LambdaPi.Impl.Foil
       Language.LambdaPi.Impl.FoilTH
       Language.LambdaPi.Impl.FreeFoil
+      Language.LambdaPi.Impl.FreeFoilTH
       Language.LambdaPi.Syntax.Abs
       Language.LambdaPi.Syntax.Layout
       Language.LambdaPi.Syntax.Lex

--- a/haskell/lambda-pi/src/Language/LambdaPi/Impl/FreeFoilTH.hs
+++ b/haskell/lambda-pi/src/Language/LambdaPi/Impl/FreeFoilTH.hs
@@ -30,6 +30,7 @@ import qualified Language.LambdaPi.Syntax.Print as Raw
 
 -- ** Signature
 mkSignature ''Raw.Term' ''Raw.VarIdent ''Raw.ScopedTerm' ''Raw.Pattern'
+deriveZipMatch ''Term'Sig
 deriveBifunctor ''Term'Sig
 deriveBifoldable ''Term'Sig
 deriveBitraversable ''Term'Sig
@@ -85,17 +86,6 @@ instance IsString (AST (Term'Sig Raw.BNFC'Position) Foil.VoidS) where
 -- | Pretty-print scope-safe terms via raw representation.
 instance Show (AST (Term'Sig a) Foil.VoidS) where
   show = Raw.printTree . fromTerm'
-
-instance ZipMatch (Term'Sig a) where
-  zipMatch (AppSig loc l r) (AppSig _loc l' r') = Just (AppSig loc (l, l') (r, r'))
-  zipMatch (PairSig loc l r) (PairSig _loc l' r') = Just (PairSig loc (l, l') (r, r'))
-  zipMatch (ProductSig loc l r) (ProductSig _loc l' r') = Just (ProductSig loc (l, l') (r, r'))
-  zipMatch (LamSig loc s) (LamSig _loc s') = Just (LamSig loc (s, s'))
-  zipMatch (FirstSig loc t) (FirstSig _loc t') = Just (FirstSig loc (t, t'))
-  zipMatch (SecondSig loc t) (SecondSig _loc t') = Just (SecondSig loc (t, t'))
-  zipMatch (UniverseSig loc) (UniverseSig _loc) = Just (UniverseSig loc)
-  zipMatch (PiSig loc l r) (PiSig _loc l' r') = Just (PiSig loc (l, l') (r, r'))
-  zipMatch _ _ = Nothing
 
 -- ** Evaluation
 

--- a/haskell/lambda-pi/src/Language/LambdaPi/Impl/FreeFoilTH.hs
+++ b/haskell/lambda-pi/src/Language/LambdaPi/Impl/FreeFoilTH.hs
@@ -26,6 +26,7 @@ mkPatternSynonyms ''Term'Sig
 -- ** Conversion
 
 mkConvertToFreeFoil ''Raw.Term' ''Raw.VarIdent ''Raw.ScopedTerm' ''Raw.Pattern'
+mkConvertFromFreeFoil ''Raw.Term' ''Raw.VarIdent ''Raw.ScopedTerm' ''Raw.Pattern'
 
 -- * User-defined code
 
@@ -33,3 +34,17 @@ mkConvertToFreeFoil ''Raw.Term' ''Raw.VarIdent ''Raw.ScopedTerm' ''Raw.Pattern'
 -- This is a special case of 'convertToAST'.
 toTerm' :: Foil.Distinct n => Foil.Scope n -> Map Raw.VarIdent (Foil.Name n) -> Raw.Term' a -> AST (Term'Sig a) n
 toTerm' = convertToAST convertToTerm'Sig getPattern'Binder getTerm'FromScopedTerm'
+
+-- | Convert a scope-safe representation back into 'Raw.Term''.
+-- This is a special case of 'convertFromAST'.
+--
+-- 'Raw.VarIdent' names are generated based on the raw identifiers in the underlying foil representation.
+--
+-- This function does not recover location information for variables, patterns, or scoped terms.
+fromTerm' :: AST (Term'Sig a) n -> Raw.Term' a
+fromTerm' = convertFromAST
+  convertFromTerm'Sig
+  (Raw.Var (error "location missing"))
+  (Raw.PatternVar (error "location missing"))
+  (Raw.AScopedTerm (error "location missing"))
+  (\n -> Raw.VarIdent ("x" ++ show n))

--- a/haskell/lambda-pi/src/Language/LambdaPi/Impl/FreeFoilTH.hs
+++ b/haskell/lambda-pi/src/Language/LambdaPi/Impl/FreeFoilTH.hs
@@ -1,15 +1,35 @@
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE KindSignatures    #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE PatternSynonyms   #-}
+{-# LANGUAGE TemplateHaskell   #-}
 module Language.LambdaPi.Impl.FreeFoilTH where
 
+import qualified Control.Monad.Foil           as Foil
+import           Control.Monad.Free.Foil
 import           Control.Monad.Free.Foil.TH
-import qualified Language.LambdaPi.Syntax.Abs    as Raw
+import           Data.Bifunctor.TH
+import           Data.Map                     (Map)
+import qualified Language.LambdaPi.Syntax.Abs as Raw
 
 -- * Generated code
 
 -- ** Signature
 mkSignature ''Raw.Term' ''Raw.VarIdent ''Raw.ScopedTerm' ''Raw.Pattern'
+deriveBifunctor ''Term'Sig
+deriveBifoldable ''Term'Sig
+deriveBitraversable ''Term'Sig
 
 -- ** Pattern synonyms
 mkPatternSynonyms ''Term'Sig
+
+-- ** Conversion
+
+mkConvertToFreeFoil ''Raw.Term' ''Raw.VarIdent ''Raw.ScopedTerm' ''Raw.Pattern'
+
+-- * User-defined code
+
+-- | Convert 'Raw.Term'' into a scope-safe representation.
+-- This is a special case of 'convertToAST'.
+toTerm' :: Foil.Distinct n => Foil.Scope n -> Map Raw.VarIdent (Foil.Name n) -> Raw.Term' a -> AST (Term'Sig a) n
+toTerm' = convertToAST convertToTerm'Sig getPattern'Binder getTerm'FromScopedTerm'

--- a/haskell/lambda-pi/src/Language/LambdaPi/Impl/FreeFoilTH.hs
+++ b/haskell/lambda-pi/src/Language/LambdaPi/Impl/FreeFoilTH.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE KindSignatures #-}
+module Language.LambdaPi.Impl.FreeFoilTH where
+
+import           Control.Monad.Free.Foil.TH
+import qualified Language.LambdaPi.Syntax.Abs    as Raw
+
+-- * Generated code
+
+-- ** Signature
+mkSignature ''Raw.Term' ''Raw.VarIdent ''Raw.ScopedTerm' ''Raw.Pattern'

--- a/haskell/lambda-pi/src/Language/LambdaPi/Impl/FreeFoilTH.hs
+++ b/haskell/lambda-pi/src/Language/LambdaPi/Impl/FreeFoilTH.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE PatternSynonyms #-}
 module Language.LambdaPi.Impl.FreeFoilTH where
 
 import           Control.Monad.Free.Foil.TH
@@ -9,3 +10,6 @@ import qualified Language.LambdaPi.Syntax.Abs    as Raw
 
 -- ** Signature
 mkSignature ''Raw.Term' ''Raw.VarIdent ''Raw.ScopedTerm' ''Raw.Pattern'
+
+-- ** Pattern synonyms
+mkPatternSynonyms ''Term'Sig

--- a/haskell/lambda-pi/src/Language/LambdaPi/Impl/FreeFoilTH.hs
+++ b/haskell/lambda-pi/src/Language/LambdaPi/Impl/FreeFoilTH.hs
@@ -1,16 +1,28 @@
 {-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE KindSignatures    #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE PatternSynonyms   #-}
 {-# LANGUAGE TemplateHaskell   #-}
 module Language.LambdaPi.Impl.FreeFoilTH where
 
+import Data.String (IsString(..))
 import qualified Control.Monad.Foil           as Foil
 import           Control.Monad.Free.Foil
 import           Control.Monad.Free.Foil.TH
 import           Data.Bifunctor.TH
 import           Data.Map                     (Map)
+import qualified Data.Map as Map
 import qualified Language.LambdaPi.Syntax.Abs as Raw
+import qualified Language.LambdaPi.Syntax.Par as Raw
+import qualified Language.LambdaPi.Syntax.Lex as Raw
+import qualified Language.LambdaPi.Syntax.Print as Raw
+
+-- $setup
+-- >>> :set -XOverloadedStrings
+-- >>> :set -XDataKinds
+-- >>> import qualified Control.Monad.Foil as Foil
 
 -- * Generated code
 
@@ -23,17 +35,26 @@ deriveBitraversable ''Term'Sig
 -- ** Pattern synonyms
 mkPatternSynonyms ''Term'Sig
 
--- ** Conversion
+-- ** Conversion helpers
 
 mkConvertToFreeFoil ''Raw.Term' ''Raw.VarIdent ''Raw.ScopedTerm' ''Raw.Pattern'
 mkConvertFromFreeFoil ''Raw.Term' ''Raw.VarIdent ''Raw.ScopedTerm' ''Raw.Pattern'
 
 -- * User-defined code
 
--- | Convert 'Raw.Term'' into a scope-safe representation.
+type Term = AST (Term'Sig Raw.BNFC'Position)
+
+-- ** Conversion helpers
+
+-- | Convert 'Raw.Term'' into a scope-safe term.
 -- This is a special case of 'convertToAST'.
 toTerm' :: Foil.Distinct n => Foil.Scope n -> Map Raw.VarIdent (Foil.Name n) -> Raw.Term' a -> AST (Term'Sig a) n
 toTerm' = convertToAST convertToTerm'Sig getPattern'Binder getTerm'FromScopedTerm'
+
+-- | Convert 'Raw.Term'' into a closed scope-safe term.
+-- This is a special case of 'toTerm''.
+toTerm'Closed :: Raw.Term' a -> AST (Term'Sig a) Foil.VoidS
+toTerm'Closed = toTerm' Foil.emptyScope Map.empty
 
 -- | Convert a scope-safe representation back into 'Raw.Term''.
 -- This is a special case of 'convertFromAST'.
@@ -48,3 +69,16 @@ fromTerm' = convertFromAST
   (Raw.PatternVar (error "location missing"))
   (Raw.AScopedTerm (error "location missing"))
   (\n -> Raw.VarIdent ("x" ++ show n))
+
+-- | Parse scope-safe terms via raw representation.
+--
+-- >>> fromString "λx.λy.λx.x" :: Term Foil.VoidS
+-- λ x0 . λ x1 . λ x2 . x2
+instance IsString (AST (Term'Sig Raw.BNFC'Position) Foil.VoidS) where
+  fromString input = case Raw.pTerm (Raw.tokens input) of
+    Left err -> error ("could not parse λΠ-term: " <> input <> "\n  " <> err)
+    Right term -> toTerm'Closed term
+
+-- | Pretty-print scope-safe terms via raw representation.
+instance Show (AST (Term'Sig a) Foil.VoidS) where
+  show = Raw.printTree . fromTerm'


### PR DESCRIPTION
- [x] Generate signature (no complex patterns)
- [x] Generate pattern synonyms for free foil terms
- [x] Generate/derive conversion functions to free foil (no complex patterns)
- [x] Generate/derive conversion functions from free foil (no complex patterns)
- [x] Derive `ZipMatch` instance
- [x] Use free foil with TH to implement $\lambda\Pi$-calculus (without typechecking)