### PR TITLE
Release v0.2.0

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,0 +1,3 @@
+:set -XOverloadedStrings
+:set -XDataKinds
+import qualified Language.SOAS.Impl as SOAS

--- a/haskell/free-foil/ChangeLog.md
+++ b/haskell/free-foil/ChangeLog.md
@@ -1,5 +1,11 @@
 # CHANGELOG for `free-foil`
 
+# 0.2.0 — 2024-10-27
+
+- Generate [`COMPLETE` pragma](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/pragmas.html#complete-pragmas) in `mkPatternSynonyms` (see [#26](https://github.com/fizruk/free-foil/pull/26))
+- Polykind `ZipMatchK` class with default generic implementation via [`kind-generics`](https://hackage.haskell.org/package/kind-generics) (see [#27](https://github.com/fizruk/free-foil/pull/27))
+- New experimental TH generation for Free Foil with support for rich syntax in `Control.Monad.Free.Foil.TH.MkFreeFoil` (see [#28](https://github.com/fizruk/free-foil/pull/28))
+
 # 0.1.0 — 2024-08-18
 
 - Generalize functions for binders, support general patterns (see [#16](https://github.com/fizruk/free-foil/pull/16))

--- a/haskell/free-foil/free-foil.cabal
+++ b/haskell/free-foil/free-foil.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           free-foil
-version:        0.1.0
+version:        0.2.0
 synopsis:       Efficient Type-Safe Capture-Avoiding Substitution for Free (Scoped Monads)
 description:    Please see the README on GitHub at <https://github.com/fizruk/free-foil#readme>
 category:       Parsing

--- a/haskell/free-foil/package.yaml
+++ b/haskell/free-foil/package.yaml
@@ -1,5 +1,5 @@
 name: free-foil
-version: 0.1.0
+version: 0.2.0
 github: "fizruk/free-foil"
 license: BSD3
 author: "Nikolai Kudasov"

--- a/haskell/lambda-pi/lambda-pi.cabal
+++ b/haskell/lambda-pi/lambda-pi.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.24
 -- see: https://github.com/sol/hpack
 
 name:           lambda-pi
-version:        0.1.0
+version:        0.2.0
 synopsis:       λΠ-calculus implemented in a few different ways.
 description:    Please see the README on GitHub at <https://github.com/fizruk/free-foil#readme>
 category:       Language
@@ -60,7 +60,7 @@ library
     , bifunctors
     , containers
     , deepseq
-    , free-foil >=0.1.0
+    , free-foil >=0.2.0
     , kind-generics-th
     , template-haskell
     , text >=1.2.3.1
@@ -84,7 +84,7 @@ executable lambda-pi
     , bifunctors
     , containers
     , deepseq
-    , free-foil >=0.1.0
+    , free-foil >=0.2.0
     , kind-generics-th
     , lambda-pi
     , template-haskell
@@ -110,7 +110,7 @@ test-suite doctests
     , containers
     , deepseq
     , doctest-parallel
-    , free-foil >=0.1.0
+    , free-foil >=0.2.0
     , kind-generics-th
     , lambda-pi
     , template-haskell
@@ -139,7 +139,7 @@ test-suite spec
     , bifunctors
     , containers
     , deepseq
-    , free-foil >=0.1.0
+    , free-foil >=0.2.0
     , hspec
     , hspec-discover
     , kind-generics-th

--- a/haskell/lambda-pi/package.yaml
+++ b/haskell/lambda-pi/package.yaml
@@ -1,5 +1,5 @@
 name: lambda-pi
-version: 0.1.0
+version: 0.2.0
 github: "fizruk/free-foil"
 license: BSD3
 author: "Nikolai Kudasov"
@@ -39,7 +39,7 @@ dependencies:
   bifunctors:
   template-haskell:
   deepseq:
-  free-foil: ">= 0.1.0"
+  free-foil: ">= 0.2.0"
   kind-generics-th:
 
 ghc-options:

--- a/haskell/soas/package.yaml
+++ b/haskell/soas/package.yaml
@@ -1,5 +1,5 @@
 name: soas
-version: 0.1.0
+version: 0.2.0
 github: "fizruk/free-foil"
 license: BSD3
 author: "Nikolai Kudasov"
@@ -39,7 +39,7 @@ dependencies:
   bifunctors:
   template-haskell:
   deepseq:
-  free-foil: ">= 0.1.0"
+  free-foil: ">= 0.2.0"
   kind-generics-th:
 
 ghc-options:

--- a/haskell/soas/soas.cabal
+++ b/haskell/soas/soas.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.24
 -- see: https://github.com/sol/hpack
 
 name:           soas
-version:        0.1.0
+version:        0.2.0
 synopsis:       Second-Order Abstract Syntax implemented via Free Foil (a version of SOAS).
 description:    Please see the README on GitHub at <https://github.com/fizruk/free-foil#readme>
 category:       Language
@@ -58,7 +58,7 @@ library
     , bifunctors
     , containers
     , deepseq
-    , free-foil >=0.1.0
+    , free-foil >=0.2.0
     , kind-generics-th
     , template-haskell
     , text >=1.2.3.1
@@ -82,7 +82,7 @@ executable soas
     , bifunctors
     , containers
     , deepseq
-    , free-foil >=0.1.0
+    , free-foil >=0.2.0
     , kind-generics-th
     , soas
     , template-haskell
@@ -108,7 +108,7 @@ test-suite doctests
     , containers
     , deepseq
     , doctest-parallel
-    , free-foil >=0.1.0
+    , free-foil >=0.2.0
     , kind-generics-th
     , soas
     , template-haskell
@@ -135,7 +135,7 @@ test-suite spec
     , bifunctors
     , containers
     , deepseq
-    , free-foil >=0.1.0
+    , free-foil >=0.2.0
     , hspec
     , hspec-discover
     , kind-generics-th

--- a/haskell/soas/src/Language/SOAS/Impl.hs
+++ b/haskell/soas/src/Language/SOAS/Impl.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -Wno-orphans -Wno-redundant-constraints -ddump-splices #-}
+{-# OPTIONS_GHC -Wno-orphans -Wno-redundant-constraints #-}
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleContexts         #-}
 {-# LANGUAGE ScopedTypeVariables         #-}
@@ -16,6 +16,7 @@
 -- | Functions over Second-Order Abstract Syntax (SOAS)
 -- represented using scope-safe Haskell types (via Free Foil).
 module Language.SOAS.Impl where
+
 
 import Data.List (find)
 import Data.Bifunctor
@@ -68,6 +69,7 @@ applySubsts scope substs term =
     MetaVar _loc m args | Just (Subst _ _ binders body) <- lookupSubst m substs ->
       substitutePattern scope Foil.voidSubst binders args body
     Var{} -> term
+    -- NOTE: generic recursive processing!
     Node node -> Node (bimap goScoped (applySubsts scope substs) node)
   where
     goScoped (ScopedAST binders body) =


### PR DESCRIPTION
- Generate [`COMPLETE` pragma](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/pragmas.html#complete-pragmas) in `mkPatternSynonyms` (see [#26](https://github.com/fizruk/free-foil/pull/26))
- Polykind `ZipMatchK` class with default generic implementation via [`kind-generics`](https://hackage.haskell.org/package/kind-generics) (see [#27](https://github.com/fizruk/free-foil/pull/27))
- New experimental TH generation for Free Foil with support for rich syntax in `Control.Monad.Free.Foil.TH.MkFreeFoil` (see [#28](https://github.com/fizruk/free-foil/pull/28))