### PR TITLE
Add Generic instance for SinkableK

### DIFF
--- a/haskell/free-foil/free-foil.cabal
+++ b/haskell/free-foil/free-foil.cabal
@@ -31,6 +31,7 @@ library
       Control.Monad.Foil
       Control.Monad.Foil.Example
       Control.Monad.Foil.Internal
+      Control.Monad.Foil.Internal.ValidNameBinders
       Control.Monad.Foil.Relative
       Control.Monad.Foil.TH
       Control.Monad.Foil.TH.MkFoilData

--- a/haskell/free-foil/src/Control/Monad/Foil.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil.hs
@@ -35,6 +35,7 @@ module Control.Monad.Foil (
   unsinkName,
   unsinkNamePattern,
   -- * Safe (co)sinking and renaming
+  SinkableK(..),
   Sinkable(..),
   CoSinkable(..),
   sink,

--- a/haskell/free-foil/src/Control/Monad/Foil.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil.hs
@@ -38,7 +38,7 @@ module Control.Monad.Foil (
   SinkableK(..),
   Sinkable(..),
   CoSinkable(..),
-  UnsafeHasNameBinders(..),
+  HasNameBinders(getNameBinders),
   sink,
   extendRenaming,
   extendNameBinderRenaming,

--- a/haskell/free-foil/src/Control/Monad/Foil.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil.hs
@@ -38,6 +38,7 @@ module Control.Monad.Foil (
   SinkableK(..),
   Sinkable(..),
   CoSinkable(..),
+  UnsafeHasNameBinders(..),
   sink,
   extendRenaming,
   extendNameBinderRenaming,

--- a/haskell/free-foil/src/Control/Monad/Foil/Internal.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/Internal.hs
@@ -1086,10 +1086,11 @@ instance GSinkableK (Field (Var a)) where
   gsinkabilityProofK irename (Field x) cont =
     cont irename (Field (unsafeCoerce x)) -- FIXME: unsafeCoerce?
 
-instance SinkableK f => GSinkableK (Field (Kon f :@: Var0)) where
-  gsinkabilityProofK irename@(RCons _ RNil) (Field x) cont =
-    sinkabilityProofK irename x $ \rename' x' ->
-      cont rename' (Field x')
+instance (SinkableK f, ExtractRenamingK i) => GSinkableK (Field (Kon f :@: Var i)) where
+  gsinkabilityProofK irename (Field x) cont =
+    sinkabilityProofK (RCons (extractRenamingK @_ @i irename) RNil) x $ \case
+      RCons rename' RNil -> \x' ->
+        cont (putBackRenamingK @_ @i rename' irename) (Field (unsafeCoerce x')) -- unsafeCoerce?
 
 instance SinkableK (f a) => GSinkableK (Field (Kon f :@: Kon a :@: Var0)) where
   gsinkabilityProofK irename@(RCons _ RNil) (Field x) cont =
@@ -1306,6 +1307,10 @@ instance GHasNameBinders (Field (Kon a)) where
 instance GHasNameBinders (Field (Var x)) where
   ggetNameBindersRaw (Field _x) = []
   greallyUnsafeSetNameBindersRaw (Field x) names = (Field (unsafeCoerce x), names)  -- FIXME: unsafeCoerce?
+
+instance GHasNameBinders (Field (Kon f :@: Var i)) where
+  ggetNameBindersRaw (Field _x) = []
+  greallyUnsafeSetNameBindersRaw (Field x) names = (Field (unsafeCoerce x), names) -- FIXME: unsafeCoerce?
 
 instance HasNameBinders f => GHasNameBinders (Field (Kon f :@: Var i :@: Var j)) where
   ggetNameBindersRaw (Field x) = getNameBindersRaw x

--- a/haskell/free-foil/src/Control/Monad/Foil/Internal.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/Internal.hs
@@ -576,6 +576,16 @@ instance UnifiablePattern U2 where
 class CoSinkable pattern => UnifiablePattern pattern where
   -- | Unify two patterns and decide which binders need to be renamed.
   unifyPatterns :: Distinct n => pattern n l -> pattern n r -> UnifyNameBinders pattern n l r
+  default unifyPatterns
+    :: (CoSinkable pattern, Distinct n)
+    => pattern n l -> pattern n r -> UnifyNameBinders pattern n l r
+  unifyPatterns l r = coerce (unifyPatterns (nameBinderListOf l) (nameBinderListOf r))
+
+instance UnifiablePattern NameBinderList where
+  unifyPatterns NameBinderListEmpty NameBinderListEmpty = SameNameBinders emptyNameBinders
+  unifyPatterns (NameBinderListCons x xs) (NameBinderListCons y ys) =
+    case (assertDistinct x, assertDistinct y) of
+      (Distinct, Distinct) -> unifyNameBinders x y `andThenUnifyPatterns` (xs, ys)
 
 -- | Unification of values in patterns.
 -- By default, 'Eq' instance is used, but it may be useful to ignore

--- a/haskell/free-foil/src/Control/Monad/Foil/Internal/ValidNameBinders.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/Internal/ValidNameBinders.hs
@@ -176,3 +176,8 @@ type family GInnerScopeOfRepK msg icon ifield pattern f o n l where
       ('Text "Unsupported structure in a binder/pattern"
       :$$: 'Text "  " :<>: 'ShowType f
       :$$: ShowLocalizeError msg icon 0 pattern n l)
+
+type PutBackLoT :: TyVar d s -> s -> LoT k -> LoT k
+type family PutBackLoT i c bs where
+  PutBackLoT VZ c (b :&&: bs) = c :&&: bs
+  PutBackLoT (VS x) c (b :&&: bs) = b :&&: PutBackLoT x c bs

--- a/haskell/free-foil/src/Control/Monad/Foil/Internal/ValidNameBinders.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/Internal/ValidNameBinders.hs
@@ -62,8 +62,6 @@ type ShowSaturatedPatternType pattern oo n l ll =
 
 type GInnerScopeOfAtom :: ErrorMessage -> Nat -> Nat -> (s -> s -> Type) -> Atom d Type -> Atom d s -> Atom d s -> Atom d s -> Atom d s
 type family GInnerScopeOfAtom msg icon ifield pattern atom oo n ll where
-  GInnerScopeOfAtom msg icon ifield pattern (Var x) oo n ll = n
-  GInnerScopeOfAtom msg icon ifield pattern (Kon a) oo n ll = n
   GInnerScopeOfAtom msg icon ifield pattern (Kon f :@: n :@: l) oo n ll = l
   GInnerScopeOfAtom msg icon ifield pattern (Kon f :@: o :@: i) oo n ll =
     TypeError
@@ -77,11 +75,7 @@ type family GInnerScopeOfAtom msg icon ifield pattern atom oo n ll where
       :$$: 'Text "  " :<>: ShowKindedScope oo n ll
       :$$: ShowLocalizeError msg icon ifield pattern oo ll
       )
-  GInnerScopeOfAtom msg icon ifield pattern atom oo n ll =
-    TypeError
-      ('Text "Unexpected atom in a Foil binder/pattern"
-      :$$: 'Text "  " :<>: 'ShowType atom
-      :$$: ShowLocalizeError msg icon ifield pattern oo ll)
+  GInnerScopeOfAtom msg icon ifield pattern atom oo n ll = n
 
 type SameInnerScope :: ErrorMessage -> Nat -> (s -> s -> Type) -> Atom k s -> Atom k s -> Atom k s
 type family SameInnerScope msg icon pattern n l where

--- a/haskell/free-foil/src/Control/Monad/Foil/Internal/ValidNameBinders.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/Internal/ValidNameBinders.hs
@@ -1,0 +1,178 @@
+{-# LANGUAGE StandaloneKindSignatures  #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeOperators  #-}
+{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeFamilies  #-}
+{-# LANGUAGE PolyKinds  #-}
+{-# LANGUAGE DataKinds  #-}
+module Control.Monad.Foil.Internal.ValidNameBinders where
+
+import Data.Kind (Type, Constraint)
+import GHC.TypeError
+import GHC.TypeLits
+import Generics.Kind
+import qualified GHC.Generics as GHC
+
+type SubstInRepK :: TyVar d k -> Atom d k -> (LoT d -> Type) -> LoT d -> Type
+type family SubstInRepK i atom f where
+  SubstInRepK i atom V1 = V1
+  SubstInRepK i atom U1 = U1
+  SubstInRepK i atom (M1 info c f) = M1 info c (SubstInRepK i atom f)
+  SubstInRepK i atom (Field field) = Field (SubstInAtom i atom field)
+  SubstInRepK i atom f =
+    TypeError
+      ('Text "cannot substitute variable"
+      :$$: 'Text "  " :<>: 'ShowType (Var i)
+      :$$: 'Text "with atom"
+      :$$: 'Text "  " :<>: 'ShowType atom
+      :$$: 'Text "in"
+      :$$: 'Text "  " :<>: 'ShowType f)
+
+type SubstInAtom :: TyVar d k -> Atom d k -> Atom d k1 -> Atom d k1
+type family SubstInAtom i atom f where
+  SubstInAtom i atom (Var i) = atom
+  SubstInAtom i atom (Var j) = Var j
+  SubstInAtom i atom (Kon a) = Kon a
+  SubstInAtom i atom (f :@: x) = SubstInAtom i atom f :@: SubstInAtom i atom x
+  -- SubstInAtom i atom atom' = atom'
+  SubstInAtom i atom atom' =
+    TypeError
+      ('Text "cannot substitute variable"
+      :$$: 'Text "  " :<>: 'ShowType (Var i)
+      :$$: 'Text "with atom"
+      :$$: 'Text "  " :<>: 'ShowType atom
+      :$$: 'Text "in an atom"
+      :$$: 'Text "  " :<>: 'ShowType atom')
+
+type ShowKindedScope oo n ll = ShowScope oo n ll :<>: 'Text " : S"
+
+type ShowScope :: Atom d s -> Atom d s -> Atom d s -> ErrorMessage
+type family ShowScope oo n ll where
+  ShowScope oo ll ll = 'Text "innerScope"
+  ShowScope oo oo ll = 'Text "outerScope"
+  ShowScope oo n  ll = ShowScopeN 1 n
+
+type ShowScopeN :: Natural -> Atom d s -> ErrorMessage
+type family ShowScopeN i n where
+  ShowScopeN i (Var VZ) = 'Text "scope" :<>: 'ShowType i
+  ShowScopeN i (Var (VS x)) = ShowScopeN (i + 1) (Var x)
+
+type ShowSaturatedPatternType pattern oo n l ll =
+  'ShowType pattern :<>: 'Text " " :<>: ShowScope oo n ll :<>: 'Text " " :<>: ShowScope oo l ll
+
+type GInnerScopeOfAtom :: ErrorMessage -> Nat -> Nat -> (s -> s -> Type) -> Atom d Type -> Atom d s -> Atom d s -> Atom d s -> Atom d s
+type family GInnerScopeOfAtom msg icon ifield pattern atom oo n ll where
+  GInnerScopeOfAtom msg icon ifield pattern (Kon a) oo n ll = n
+  GInnerScopeOfAtom msg icon ifield pattern (Kon f :@: n :@: l) oo n ll = l
+  GInnerScopeOfAtom msg icon ifield pattern (Kon f :@: o :@: i) oo n ll =
+    TypeError
+      ('Text "Unexpected Foil scope extension in the binder/pattern"
+      :$$: 'Text "  " :<>: ShowSaturatedPatternType f oo o i ll
+      :$$: 'Text "the binder/pattern tries to extend scope"
+      :$$: 'Text "  " :<>: ShowKindedScope oo o ll
+      :$$: 'Text "to scope"
+      :$$: 'Text "  " :<>: ShowKindedScope oo i ll
+      :$$: 'Text "but it is expected to extend the current (outer) scope"
+      :$$: 'Text "  " :<>: ShowKindedScope oo n ll
+      :$$: ShowLocalizeError msg icon ifield pattern oo ll
+      )
+  GInnerScopeOfAtom msg icon ifield pattern atom oo n ll =
+    TypeError
+      ('Text "the following atom does not seem to be a valid part of a pattern/binder"
+      :$$: 'Text "  " :<>: 'ShowType atom
+      :$$: ShowLocalizeError msg icon ifield pattern oo ll)
+
+type SameInnerScope :: ErrorMessage -> Nat -> (s -> s -> Type) -> Atom k s -> Atom k s -> Atom k s
+type family SameInnerScope msg icon pattern n l where
+  SameInnerScope msg icon pattern l l = l
+  SameInnerScope msg icon pattern n l =
+    TypeError
+      ('Text "Unexpected extended (inner) Foil scope in the data type"
+      :$$: 'Text "  " :<>: ShowSaturatedPatternType pattern n n l l
+      :$$: 'Text "expecting extended (inner) scope to be"
+      :$$: 'Text "  " :<>: ShowKindedScope n l l
+      :$$: 'Text "but the inferred extended (inner) scope is"
+      :$$: 'Text "  " :<>: ShowKindedScope n n l
+      :$$: ShowLocalizeError msg icon 0 pattern n l
+      )
+
+type GValidNameBinders :: (s -> s -> Type) -> (LoT (s -> s -> Type) -> Type) -> Constraint
+type family GValidNameBinders pattern f :: Constraint where
+  GValidNameBinders pattern (f :: LoT (s -> s -> Type) -> Type) =
+    (GInnerScopeOfRepK ('Text "") 0 0 pattern f Var0 Var0 Var1)
+    ~ (Var1 :: Atom (s -> s -> Type) s)
+
+type AtomSucc :: Atom d k1 -> Atom (k -> d) k1
+type family AtomSucc atom where
+  AtomSucc (Var i) = Var (VS i)
+
+type AtomUnSucc :: ErrorMessage -> Nat -> (s -> s -> Type) -> Atom d s -> Atom d s -> Atom (k -> d) k1 -> Atom d k1
+type family AtomUnSucc msg icon pattern oo ll atom where
+  AtomUnSucc msg icon pattern oo ll (Var (VS i)) = Var i
+  AtomUnSucc msg icon pattern oo ll (Var VZ) = TypeError
+    ('Text "Intermediate scope escapes existential quantification for data type"
+      :$$: ShowLocalizeError msg icon 0 pattern oo ll
+      )
+
+type family First x y where
+  First (Var x) (Var y) = Var x
+
+type family AndShowFieldNumber ifield msg where
+  AndShowFieldNumber 0 msg = msg
+  AndShowFieldNumber n msg =
+    'Text "when checking field number " :<>: 'ShowType n
+    :$$: msg
+
+type family AndShowConNumber icon msg where
+  AndShowConNumber 0 msg = msg
+  AndShowConNumber n msg =
+    'Text "when checking constructor number " :<>: 'ShowType n
+    :$$: msg
+
+type AndShowDataType pattern n l msg =
+  'Text "when tracking Foil scopes for the data type"
+  :$$: 'Text "  " :<>: ShowSaturatedPatternType pattern n n l l
+  :$$: msg
+
+type ShowLocalizeError msg icon ifield pattern o l =
+    AndShowFieldNumber ifield
+      (AndShowConNumber icon
+        (AndShowDataType pattern o l
+          msg))
+
+type family CountCons f where
+  CountCons (f :+: g) = CountCons f + CountCons g
+  CountCons (M1 GHC.C c f) = 1
+
+type family CountFields f where
+  CountFields (f :*: g) = CountFields f + CountFields g
+  CountFields (M1 GHC.S c f) = 1
+
+type GInnerScopeOfRepK :: ErrorMessage -> Nat -> Nat -> (s -> s -> Type) -> (LoT k -> Type) -> Atom k s -> Atom k s -> Atom k s -> Atom k s
+type family GInnerScopeOfRepK msg icon ifield pattern f o n l where
+  GInnerScopeOfRepK msg icon ifield pattern V1 o n l = l
+  GInnerScopeOfRepK msg icon ifield pattern U1 o n l = n
+  GInnerScopeOfRepK msg icon ifield pattern (M1 GHC.C c f) o n l =
+    GInnerScopeOfRepK msg icon 1 pattern f o n l
+  GInnerScopeOfRepK msg icon ifield pattern (M1 GHC.D c f) o n l =
+    GInnerScopeOfRepK msg 1 ifield pattern f o n l
+  GInnerScopeOfRepK msg icon ifield pattern (M1 i c f) o n l =
+    GInnerScopeOfRepK msg icon ifield pattern f o n l
+  GInnerScopeOfRepK msg icon ifield pattern (f :+: g) o n l = First
+    (SameInnerScope msg icon pattern (GInnerScopeOfRepK msg icon ifield pattern f o n l) l)
+    (SameInnerScope msg icon pattern (GInnerScopeOfRepK msg (icon + CountCons f) ifield pattern g o n l) l)
+  GInnerScopeOfRepK msg icon ifield pattern (f :*: g) o n l =
+    GInnerScopeOfRepK msg icon (ifield + CountFields f) pattern g o
+      (GInnerScopeOfRepK msg icon ifield pattern f o n l) l
+  GInnerScopeOfRepK msg icon ifield pattern (Var i :~~: Var j :=>: f) o n l =
+    GInnerScopeOfRepK msg icon ifield pattern (SubstInRepK i (Var j) f)
+      (SubstInAtom i (Var j) o) (SubstInAtom i (Var j) n) (SubstInAtom i (Var j) l)
+  GInnerScopeOfRepK msg icon ifield pattern (Exists k f) o n l =
+    AtomUnSucc msg icon pattern o l
+      (GInnerScopeOfRepK msg icon ifield pattern f (AtomSucc o) (AtomSucc n) (AtomSucc l))
+  GInnerScopeOfRepK msg icon ifield pattern (Field atom) o n l = GInnerScopeOfAtom msg icon ifield pattern atom o n l
+  GInnerScopeOfRepK msg icon ifield pattern f o n l =
+    TypeError
+      ('Text "Unsupported structure in a binder/pattern"
+      :$$: 'Text "  " :<>: 'ShowType f
+      :$$: ShowLocalizeError msg icon 0 pattern n l)

--- a/haskell/free-foil/src/Control/Monad/Foil/Internal/ValidNameBinders.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/Internal/ValidNameBinders.hs
@@ -62,6 +62,7 @@ type ShowSaturatedPatternType pattern oo n l ll =
 
 type GInnerScopeOfAtom :: ErrorMessage -> Nat -> Nat -> (s -> s -> Type) -> Atom d Type -> Atom d s -> Atom d s -> Atom d s -> Atom d s
 type family GInnerScopeOfAtom msg icon ifield pattern atom oo n ll where
+  GInnerScopeOfAtom msg icon ifield pattern (Var x) oo n ll = n
   GInnerScopeOfAtom msg icon ifield pattern (Kon a) oo n ll = n
   GInnerScopeOfAtom msg icon ifield pattern (Kon f :@: n :@: l) oo n ll = l
   GInnerScopeOfAtom msg icon ifield pattern (Kon f :@: o :@: i) oo n ll =
@@ -78,7 +79,7 @@ type family GInnerScopeOfAtom msg icon ifield pattern atom oo n ll where
       )
   GInnerScopeOfAtom msg icon ifield pattern atom oo n ll =
     TypeError
-      ('Text "the following atom does not seem to be a valid part of a pattern/binder"
+      ('Text "Unexpected atom in a Foil binder/pattern"
       :$$: 'Text "  " :<>: 'ShowType atom
       :$$: ShowLocalizeError msg icon ifield pattern oo ll)
 

--- a/haskell/free-foil/src/Control/Monad/Free/Foil.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil.hs
@@ -72,6 +72,9 @@ instance GenericK (AST binder sig) where
 instance (Bifunctor sig, Foil.CoSinkable binder) => Foil.Sinkable (ScopedAST binder sig)
 instance (Bifunctor sig, Foil.CoSinkable binder) => Foil.Sinkable (AST binder sig)
 
+instance (Bifunctor sig, Foil.CoSinkable binder) => Foil.SinkableK (ScopedAST binder sig)
+instance (Bifunctor sig, Foil.CoSinkable binder) => Foil.SinkableK (AST binder sig)
+
 instance Foil.InjectName (AST binder sig) where
   injectName = Var
 

--- a/haskell/free-foil/src/Control/Monad/Free/Foil.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil.hs
@@ -69,11 +69,11 @@ instance GenericK (AST binder sig) where
                 :$: (Kon ScopedAST :@: Kon binder :@: Kon sig :@: Var0)
                 :@: (Kon AST :@: Kon binder :@: Kon sig :@: Var0))
 
-instance (Bifunctor sig, Foil.CoSinkable binder) => Foil.Sinkable (ScopedAST binder sig)
-instance (Bifunctor sig, Foil.CoSinkable binder) => Foil.Sinkable (AST binder sig)
+instance (Bifunctor sig, Foil.CoSinkable binder, Foil.SinkableK binder) => Foil.Sinkable (ScopedAST binder sig)
+instance (Bifunctor sig, Foil.CoSinkable binder, Foil.SinkableK binder) => Foil.Sinkable (AST binder sig)
 
-instance (Bifunctor sig, Foil.CoSinkable binder) => Foil.SinkableK (ScopedAST binder sig)
-instance (Bifunctor sig, Foil.CoSinkable binder) => Foil.SinkableK (AST binder sig)
+instance (Bifunctor sig, Foil.CoSinkable binder, Foil.SinkableK binder) => Foil.SinkableK (ScopedAST binder sig)
+instance (Bifunctor sig, Foil.CoSinkable binder, Foil.SinkableK binder) => Foil.SinkableK (AST binder sig)
 
 instance Foil.InjectName (AST binder sig) where
   injectName = Var
@@ -82,7 +82,7 @@ instance Foil.InjectName (AST binder sig) where
 
 -- | Substitution for free (scoped monads).
 substitute
-  :: (Bifunctor sig, Foil.Distinct o, Foil.CoSinkable binder)
+  :: (Bifunctor sig, Foil.Distinct o, Foil.CoSinkable binder, Foil.SinkableK binder)
   => Foil.Scope o
   -> Foil.Substitution (AST binder sig) i o
   -> AST binder sig i
@@ -107,7 +107,7 @@ substitute scope subst = \case
 --
 -- In general, 'substitute' is more efficient since it does not always refresh binders.
 substituteRefreshed
-  :: (Bifunctor sig, Foil.Distinct o, Foil.CoSinkable binder)
+  :: (Bifunctor sig, Foil.Distinct o, Foil.CoSinkable binder, Foil.SinkableK binder)
   => Foil.Scope o
   -> Foil.Substitution (AST binder sig) i o
   -> AST binder sig i
@@ -124,7 +124,8 @@ substituteRefreshed scope subst = \case
         in ScopedAST binder' body'
 
 -- | @'AST' sig@ is a monad relative to 'Foil.Name'.
-instance (Bifunctor sig, Foil.CoSinkable binder) => Foil.RelMonad Foil.Name (AST binder sig) where
+instance (Bifunctor sig, Foil.CoSinkable binder, Foil.SinkableK binder)
+  => Foil.RelMonad Foil.Name (AST binder sig) where
   rreturn = Var
   rbind scope term subst =
     case term of
@@ -140,7 +141,7 @@ instance (Bifunctor sig, Foil.CoSinkable binder) => Foil.RelMonad Foil.Name (AST
 
 -- | Substitution for a single generalized pattern.
 substitutePattern
-  :: (Bifunctor sig, Foil.Distinct o, Foil.CoSinkable binder', Foil.CoSinkable binder)
+  :: (Bifunctor sig, Foil.Distinct o, Foil.CoSinkable binder', Foil.CoSinkable binder, Foil.SinkableK binder)
   => Foil.Scope o                           -- ^ Resulting scope.
   -> Foil.Substitution (AST binder sig) n o -- ^ Environment mapping names in scope @n@.
   -> binder' n i                            -- ^ Binders that extend scope @n@ to scope @i@.
@@ -156,7 +157,7 @@ substitutePattern scope env binders args body =
 
 -- | Refresh (force) all binders in a term, minimizing the used indices.
 refreshAST
-  :: (Bifunctor sig, Foil.Distinct n, Foil.CoSinkable binder)
+  :: (Bifunctor sig, Foil.Distinct n, Foil.CoSinkable binder, Foil.SinkableK binder)
   => Foil.Scope n
   -> AST binder sig n
   -> AST binder sig n
@@ -165,7 +166,7 @@ refreshAST scope = \case
   Node t -> Node (bimap (refreshScopedAST scope) (refreshAST scope) t)
 
 -- | Similar to `refreshAST`, but for scoped terms.
-refreshScopedAST :: (Bifunctor sig, Foil.Distinct n, Foil.CoSinkable binder)
+refreshScopedAST :: (Bifunctor sig, Foil.Distinct n, Foil.CoSinkable binder, Foil.SinkableK binder)
   => Foil.Scope n
   -> ScopedAST binder sig n
   -> ScopedAST binder sig n
@@ -181,7 +182,7 @@ refreshScopedAST scope (ScopedAST binder body) =
 -- Compared to 'alphaEquiv', this function may perform some unnecessary
 -- changes of bound variables when the binders are the same on both sides.
 alphaEquivRefreshed
-  :: (Bitraversable sig, ZipMatchK sig, Foil.Distinct n, Foil.UnifiablePattern binder)
+  :: (Bitraversable sig, ZipMatchK sig, Foil.Distinct n, Foil.UnifiablePattern binder, Foil.SinkableK binder)
   => Foil.Scope n
   -> AST binder sig n
   -> AST binder sig n
@@ -194,7 +195,7 @@ alphaEquivRefreshed scope t1 t2 = refreshAST scope t1 `unsafeEqAST` refreshAST s
 -- Compared to 'alphaEquivRefreshed', this function might skip unnecessary
 -- changes of bound variables when both binders in two matching scoped terms coincide.
 alphaEquiv
-  :: (Bitraversable sig, ZipMatchK sig, Foil.Distinct n, Foil.UnifiablePattern binder)
+  :: (Bitraversable sig, ZipMatchK sig, Foil.Distinct n, Foil.UnifiablePattern binder, Foil.SinkableK binder)
   => Foil.Scope n
   -> AST binder sig n
   -> AST binder sig n
@@ -208,7 +209,7 @@ alphaEquiv _ _ _ = False
 
 -- | Same as 'alphaEquiv' but for scoped terms.
 alphaEquivScoped
-  :: (Bitraversable sig, ZipMatchK sig, Foil.Distinct n, Foil.UnifiablePattern binder)
+  :: (Bitraversable sig, ZipMatchK sig, Foil.Distinct n, Foil.UnifiablePattern binder, Foil.SinkableK binder)
   => Foil.Scope n
   -> ScopedAST binder sig n
   -> ScopedAST binder sig n

--- a/haskell/free-foil/src/Control/Monad/Free/Foil.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil.hs
@@ -69,11 +69,7 @@ instance GenericK (AST binder sig) where
                 :$: (Kon ScopedAST :@: Kon binder :@: Kon sig :@: Var0)
                 :@: (Kon AST :@: Kon binder :@: Kon sig :@: Var0))
 
-instance (Bifunctor sig, Foil.CoSinkable binder) => Foil.Sinkable (ScopedAST binder sig) where
-  sinkabilityProof rename (ScopedAST binder body) =
-    Foil.extendRenaming rename binder $ \rename' binder' ->
-      ScopedAST binder' (Foil.sinkabilityProof rename' body)
-
+instance (Bifunctor sig, Foil.CoSinkable binder) => Foil.Sinkable (ScopedAST binder sig)
 instance (Bifunctor sig, Foil.CoSinkable binder) => Foil.Sinkable (AST binder sig)
 
 instance Foil.InjectName (AST binder sig) where

--- a/haskell/lambda-pi/src/Language/LambdaPi/Impl/FreeFoilTH.hs
+++ b/haskell/lambda-pi/src/Language/LambdaPi/Impl/FreeFoilTH.hs
@@ -84,6 +84,9 @@ deriveCoSinkable ''Raw.VarIdent ''Raw.Pattern'
 mkToFoilPattern ''Raw.VarIdent ''Raw.Pattern'
 mkFromFoilPattern ''Raw.VarIdent ''Raw.Pattern'
 
+deriveGenericK ''FoilPattern'
+instance Foil.SinkableK (FoilPattern' a)
+
 -- | Ignoring location information when unifying patterns.
 instance Foil.UnifiableInPattern Raw.BNFC'Position where
   unifyInPattern _ _  = True

--- a/haskell/lambda-pi/src/Language/LambdaPi/Impl/FreeFoilTH.hs
+++ b/haskell/lambda-pi/src/Language/LambdaPi/Impl/FreeFoilTH.hs
@@ -20,11 +20,16 @@
 -- 3. Correct \(\alpha\)-equivalence checks (see 'alphaEquiv' and 'alphaEquivRefreshed') as well as \(\alpha\)-normalization (see 'refreshAST').
 -- 4. Conversion helpers (see 'convertToAST' and 'convertFromAST').
 --
+-- The following is provided via __generic__ representation via [kind-generics](https://hackage.haskell.org/package/kind-generics) (see "Generics.Kind"):
+-- 1. 'ZipMatch' instances for signatures (enabling general \(\alpha\)-equivalence).
+-- 2. 'Sinkable' instances for terms.
+-- 3. 'CoSinkable' instances for patterns.
+--
 -- The following is __generated__ using Template Haskell:
 --
--- 1. Convenient pattern synonyms.
--- 2. 'ZipMatch' instances (enabling general \(\alpha\)-equivalence).
--- 3. Conversion between scope-safe and raw term representation.
+-- 1. Signature bifunctor for terms.
+-- 2. Convenient pattern synonyms.
+-- 4. Conversion between scope-safe and raw term representation.
 --
 -- The following is implemented __manually__ in this module:
 --
@@ -80,12 +85,12 @@ mkConvertFromFreeFoil ''Raw.Term' ''Raw.VarIdent ''Raw.ScopedTerm' ''Raw.Pattern
 -- ** Scope-safe patterns
 
 mkFoilPattern ''Raw.VarIdent ''Raw.Pattern'
-deriveCoSinkable ''Raw.VarIdent ''Raw.Pattern'
-mkToFoilPattern ''Raw.VarIdent ''Raw.Pattern'
-mkFromFoilPattern ''Raw.VarIdent ''Raw.Pattern'
-
 deriveGenericK ''FoilPattern'
 instance Foil.SinkableK (FoilPattern' a)
+instance Foil.HasNameBinders (FoilPattern' a)
+instance Foil.CoSinkable (FoilPattern' a)
+mkToFoilPattern ''Raw.VarIdent ''Raw.Pattern'
+mkFromFoilPattern ''Raw.VarIdent ''Raw.Pattern'
 
 -- | Ignoring location information when unifying patterns.
 instance Foil.UnifiableInPattern Raw.BNFC'Position where

--- a/haskell/lambda-pi/src/Language/LambdaPi/Impl/FreeFoilTH.hs
+++ b/haskell/lambda-pi/src/Language/LambdaPi/Impl/FreeFoilTH.hs
@@ -92,10 +92,10 @@ instance Foil.CoSinkable (FoilPattern' a)
 mkToFoilPattern ''Raw.VarIdent ''Raw.Pattern'
 mkFromFoilPattern ''Raw.VarIdent ''Raw.Pattern'
 
+instance Foil.UnifiablePattern (FoilPattern' a)
 -- | Ignoring location information when unifying patterns.
 instance Foil.UnifiableInPattern Raw.BNFC'Position where
   unifyInPattern _ _  = True
-deriveUnifiablePattern ''Raw.VarIdent ''Raw.Pattern'
 
 -- | Deriving 'GHC.Generic' and 'GenericK' instances.
 deriving instance GHC.Generic (Term'Sig a scope term)

--- a/haskell/soas/src/Language/SOAS/Impl/Generated.hs
+++ b/haskell/soas/src/Language/SOAS/Impl/Generated.hs
@@ -63,13 +63,30 @@ instance Foil.Sinkable (OpTyping' a)
 instance Foil.SinkableK (Binders' a)
 instance Foil.SinkableK (TypeBinders' a)
 
--- FIXME: derive via GenericK
 instance Foil.HasNameBinders (Binders' a)
 instance Foil.CoSinkable (Binders' a)
 
--- FIXME: derive via GenericK
 instance Foil.HasNameBinders (TypeBinders' a)
 instance Foil.CoSinkable (TypeBinders' a)
+
+data Test a (n :: Foil.S) (l :: Foil.S) where
+  Good1 :: Foil.NameBinder n l -> Test a n l
+  Good2 :: Foil.NameBinder n n -> Test a n n
+  Good3 :: Test a n n
+  Good4 :: Foil.NameBinder n i -> Test a i l -> Test a n l
+  Good5 :: Foil.NameBinder n i' -> Test a i' i -> Test a i l -> Test a n l
+  -- Bad1 :: Test a n l                           -- not enough binders
+  -- Bad2 :: Foil.NameBinder n i -> Test a n l    -- intermediate scope escapes (not enough binders?)
+  -- Bad3 :: Int -> Int -> Int -> Foil.NameBinder i n -> Int -> Test a n l    -- unexpected scope extension
+  -- Bad4 :: Foil.NameBinder l n -> Test a n l    -- unexpected scope extension
+  -- Bad5 :: Foil.NameBinder n i -> Foil.NameBinder i l -> Foil.NameBinder l i -> Test a n l -- intermediate scope escapes (not enough binders?)
+  -- Bad6 :: Foil.NameBinder n l -> Foil.NameBinder n l -> Test a n l -- unexpected scope extension
+  -- Bad7 :: [Foil.NameBinder n l] -> Test a n l -- no GHasNameBinders (unreadable error message)
+deriveGenericK ''Test
+instance Foil.HasNameBinders (Test a)
+instance Foil.SinkableK (Test a)
+instance Foil.CoSinkable (Test a)
+
 
 mkFreeFoilConversions soasConfig
 

--- a/haskell/soas/src/Language/SOAS/Impl/Generated.hs
+++ b/haskell/soas/src/Language/SOAS/Impl/Generated.hs
@@ -69,25 +69,6 @@ instance Foil.CoSinkable (Binders' a)
 instance Foil.HasNameBinders (TypeBinders' a)
 instance Foil.CoSinkable (TypeBinders' a)
 
-data Test a (n :: Foil.S) (l :: Foil.S) where
-  Good1 :: Foil.NameBinder n l -> Test a n l
-  Good2 :: Foil.NameBinder n n -> Test a n n
-  Good3 :: Test a n n
-  Good4 :: Foil.NameBinder n i -> Test a i l -> Test a n l
-  Good5 :: Foil.NameBinder n i' -> Test a i' i -> Test a i l -> Test a n l
-  -- Bad1 :: Test a n l                           -- not enough binders
-  -- Bad2 :: Foil.NameBinder n i -> Test a n l    -- intermediate scope escapes (not enough binders?)
-  -- Bad3 :: Int -> Int -> Int -> Foil.NameBinder i n -> Int -> Test a n l    -- unexpected scope extension
-  -- Bad4 :: Foil.NameBinder l n -> Test a n l    -- unexpected scope extension
-  -- Bad5 :: Foil.NameBinder n i -> Foil.NameBinder i l -> Foil.NameBinder l i -> Test a n l -- intermediate scope escapes (not enough binders?)
-  -- Bad6 :: Foil.NameBinder n l -> Foil.NameBinder n l -> Test a n l -- unexpected scope extension
-  -- Bad7 :: [Foil.NameBinder n l] -> Test a n l -- no GHasNameBinders (unreadable error message)
-deriveGenericK ''Test
-instance Foil.HasNameBinders (Test a)
-instance Foil.SinkableK (Test a)
-instance Foil.CoSinkable (Test a)
-
-
 mkFreeFoilConversions soasConfig
 
 -- | Ignore 'Raw.BNFC'Position' when matching terms.

--- a/haskell/soas/src/Language/SOAS/Impl/Generated.hs
+++ b/haskell/soas/src/Language/SOAS/Impl/Generated.hs
@@ -56,6 +56,18 @@ deriveBifunctor ''OpArgTyping'Sig
 deriveBifunctor ''ScopedOpArgTyping'Sig
 deriveBifunctor ''Type'Sig
 
+deriveBifoldable ''OpArg'Sig
+deriveBifoldable ''Term'Sig
+deriveBifoldable ''OpArgTyping'Sig
+deriveBifoldable ''ScopedOpArgTyping'Sig
+deriveBifoldable ''Type'Sig
+
+deriveBitraversable ''OpArg'Sig
+deriveBitraversable ''Term'Sig
+deriveBitraversable ''OpArgTyping'Sig
+deriveBitraversable ''ScopedOpArgTyping'Sig
+deriveBitraversable ''Type'Sig
+
 instance Foil.Sinkable (Subst' a)
 instance Foil.Sinkable (Constraint' a)
 instance Foil.Sinkable (OpTyping' a)
@@ -81,6 +93,15 @@ instance ZipMatchK Raw.MetaVarIdent where zipMatchWithK = zipMatchViaEq
 instance ZipMatchK a => ZipMatchK (Term'Sig a)
 instance ZipMatchK a => ZipMatchK (OpArg'Sig a)
 instance ZipMatchK a => ZipMatchK (Type'Sig a)
+
+-- TODO: infer via GenericK
+instance Foil.UnifiablePattern (Binders' a) where
+  unifyPatterns (NoBinders _loc) (NoBinders _loc') = Foil.SameNameBinders Foil.emptyNameBinders
+  unifyPatterns (SomeBinders _loc x xs) (SomeBinders _loc' y ys) =
+    case (Foil.assertDistinct x, Foil.assertDistinct y) of
+      (Foil.Distinct, Foil.Distinct) ->
+        Foil.unifyNameBinders x y `Foil.andThenUnifyPatterns` (xs, ys)
+  unifyPatterns _ _ = Foil.NotUnifiable
 
 -- |
 -- >>> "?m[App(Lam(x.x), Lam(y.y))]" :: Term' Raw.BNFC'Position Foil.VoidS

--- a/haskell/soas/src/Language/SOAS/Impl/Generated.hs
+++ b/haskell/soas/src/Language/SOAS/Impl/Generated.hs
@@ -44,12 +44,19 @@ deriveGenericK ''OpArg'Sig
 deriveGenericK ''Term'Sig
 deriveGenericK ''OpArgTyping'Sig
 deriveGenericK ''Type'Sig
+deriveGenericK ''Subst'
+deriveGenericK ''Constraint'
+deriveGenericK ''OpTyping'
 
 deriveBifunctor ''OpArg'Sig
 deriveBifunctor ''Term'Sig
 deriveBifunctor ''OpArgTyping'Sig
 deriveBifunctor ''ScopedOpArgTyping'Sig
 deriveBifunctor ''Type'Sig
+
+instance Foil.Sinkable (Subst' a)
+instance Foil.Sinkable (Constraint' a)
+instance Foil.Sinkable (OpTyping' a)
 
 -- FIXME: derive via GenericK
 instance Foil.CoSinkable (Binders' a) where

--- a/haskell/soas/src/Language/SOAS/Impl/Generated.hs
+++ b/haskell/soas/src/Language/SOAS/Impl/Generated.hs
@@ -64,29 +64,12 @@ instance Foil.SinkableK (Binders' a)
 instance Foil.SinkableK (TypeBinders' a)
 
 -- FIXME: derive via GenericK
-instance Foil.CoSinkable (Binders' a) where
-  withPattern withBinder unit comp scope binders cont =
-    case binders of
-      NoBinders loc -> cont unit (NoBinders loc)
-      -- OneBinder loc binder ->
-      --   Foil.withPattern withBinder unit comp scope binder $ \f binder' ->
-      --     cont f (OneBinder loc binder')
-      SomeBinders loc binder moreBinders ->
-        Foil.withPattern withBinder unit comp scope binder $ \f binder' ->
-          let scope' = Foil.extendScopePattern binder' scope
-           in Foil.withPattern withBinder unit comp scope' moreBinders $ \g moreBinders' ->
-                cont (comp f g) (SomeBinders loc binder' moreBinders')
+instance Foil.UnsafeHasNameBinders (Binders' a)
+instance Foil.CoSinkable (Binders' a)
 
 -- FIXME: derive via GenericK
-instance Foil.CoSinkable (TypeBinders' a) where
-  withPattern withBinder unit comp scope binders cont =
-    case binders of
-      NoTypeBinders loc -> cont unit (NoTypeBinders loc)
-      SomeTypeBinders loc binder moreTypeBinders ->
-        Foil.withPattern withBinder unit comp scope binder $ \f binder' ->
-          let scope' = Foil.extendScopePattern binder' scope
-           in Foil.withPattern withBinder unit comp scope' moreTypeBinders $ \g moreTypeBinders' ->
-                cont (comp f g) (SomeTypeBinders loc binder' moreTypeBinders')
+instance Foil.UnsafeHasNameBinders (TypeBinders' a)
+instance Foil.CoSinkable (TypeBinders' a)
 
 mkFreeFoilConversions soasConfig
 

--- a/haskell/soas/src/Language/SOAS/Impl/Generated.hs
+++ b/haskell/soas/src/Language/SOAS/Impl/Generated.hs
@@ -47,6 +47,8 @@ deriveGenericK ''Type'Sig
 deriveGenericK ''Subst'
 deriveGenericK ''Constraint'
 deriveGenericK ''OpTyping'
+deriveGenericK ''Binders'
+deriveGenericK ''TypeBinders'
 
 deriveBifunctor ''OpArg'Sig
 deriveBifunctor ''Term'Sig
@@ -58,17 +60,11 @@ instance Foil.Sinkable (Subst' a)
 instance Foil.Sinkable (Constraint' a)
 instance Foil.Sinkable (OpTyping' a)
 
+instance Foil.SinkableK (Binders' a)
+instance Foil.SinkableK (TypeBinders' a)
+
 -- FIXME: derive via GenericK
 instance Foil.CoSinkable (Binders' a) where
-  coSinkabilityProof rename (NoBinders loc) cont = cont rename (NoBinders loc)
-  -- coSinkabilityProof rename (OneBinder loc binder) cont =
-  --   Foil.coSinkabilityProof rename binder $ \rename' binder' ->
-  --     cont rename' (OneBinder loc binder')
-  coSinkabilityProof rename (SomeBinders loc binder binders) cont =
-    Foil.coSinkabilityProof rename binder $ \rename' binder' ->
-      Foil.coSinkabilityProof rename' binders $ \rename'' binders' ->
-        cont rename'' (SomeBinders loc binder' binders')
-
   withPattern withBinder unit comp scope binders cont =
     case binders of
       NoBinders loc -> cont unit (NoBinders loc)
@@ -83,12 +79,6 @@ instance Foil.CoSinkable (Binders' a) where
 
 -- FIXME: derive via GenericK
 instance Foil.CoSinkable (TypeBinders' a) where
-  coSinkabilityProof rename (NoTypeBinders loc) cont = cont rename (NoTypeBinders loc)
-  coSinkabilityProof rename (SomeTypeBinders loc binder binders) cont =
-    Foil.coSinkabilityProof rename binder $ \rename' binder' ->
-      Foil.coSinkabilityProof rename' binders $ \rename'' binders' ->
-        cont rename'' (SomeTypeBinders loc binder' binders')
-
   withPattern withBinder unit comp scope binders cont =
     case binders of
       NoTypeBinders loc -> cont unit (NoTypeBinders loc)

--- a/haskell/soas/src/Language/SOAS/Impl/Generated.hs
+++ b/haskell/soas/src/Language/SOAS/Impl/Generated.hs
@@ -94,14 +94,7 @@ instance ZipMatchK a => ZipMatchK (Term'Sig a)
 instance ZipMatchK a => ZipMatchK (OpArg'Sig a)
 instance ZipMatchK a => ZipMatchK (Type'Sig a)
 
--- TODO: infer via GenericK
-instance Foil.UnifiablePattern (Binders' a) where
-  unifyPatterns (NoBinders _loc) (NoBinders _loc') = Foil.SameNameBinders Foil.emptyNameBinders
-  unifyPatterns (SomeBinders _loc x xs) (SomeBinders _loc' y ys) =
-    case (Foil.assertDistinct x, Foil.assertDistinct y) of
-      (Foil.Distinct, Foil.Distinct) ->
-        Foil.unifyNameBinders x y `Foil.andThenUnifyPatterns` (xs, ys)
-  unifyPatterns _ _ = Foil.NotUnifiable
+instance Foil.UnifiablePattern (Binders' a)
 
 -- |
 -- >>> "?m[App(Lam(x.x), Lam(y.y))]" :: Term' Raw.BNFC'Position Foil.VoidS

--- a/haskell/soas/src/Language/SOAS/Impl/Generated.hs
+++ b/haskell/soas/src/Language/SOAS/Impl/Generated.hs
@@ -64,11 +64,11 @@ instance Foil.SinkableK (Binders' a)
 instance Foil.SinkableK (TypeBinders' a)
 
 -- FIXME: derive via GenericK
-instance Foil.UnsafeHasNameBinders (Binders' a)
+instance Foil.HasNameBinders (Binders' a)
 instance Foil.CoSinkable (Binders' a)
 
 -- FIXME: derive via GenericK
-instance Foil.UnsafeHasNameBinders (TypeBinders' a)
+instance Foil.HasNameBinders (TypeBinders' a)
 instance Foil.CoSinkable (TypeBinders' a)
 
 mkFreeFoilConversions soasConfig


### PR DESCRIPTION
- [x] Generic implementations for
  - `Sinkable`
  - `CoSinkable`
  - `UnifiablePattern`
- [x] `SinkableK` generalizes both `Sinkable` and `CoSinkable` (except `withPattern`)
  - ℹ️ `f n1 n2 .. nK` is treated as a generalized binder with variables/terms in scopes `n1`, `n2`, ... `nK`
- [x] Kind-polymorphic generic instances for `SinkableK` (covering `sinkabilityProof` and `coSinkabilityProof`)
- [x] `HasNameBinders` generalizes access to nested `NameBinder`s, which makes generic `withPattern` possible!
  - ✅ UPDATE: we now have a separate check via `GValidNameBinders` that prevents misuse mentioned below and (sometimes) provides nice error messages. In particular, the following example shows good vs bad constructors in a user-defined pattern:
  ```haskell
  data Test a (n :: Foil.S) (l :: Foil.S) where
    Good1 :: Foil.NameBinder n l -> Test a n l
    Good2 :: Foil.NameBinder n n -> Test a n n
    Good3 :: Test a n n
    Good4 :: Foil.NameBinder n i -> Test a i l -> Test a n l
    Good5 :: forall b n i' i unused l a. b -> Foil.NameBinder n i' -> Test a i' i -> Test a i l -> Test a n l
    Good6 :: forall a n i l. Term' a n -> Test a n i -> Term' a i -> Test a i l -> Term' a l -> Test a n l
    -- deriving HasNameBinders for any of the constructors below will result in a type error
    Bad1 :: Test a n l                           -- not enough binders
    Bad2 :: Foil.NameBinder n i -> Test a n l    -- intermediate scope escapes (not enough binders?)
    Bad3 :: Int -> Int -> Int -> Foil.NameBinder i n -> Int -> Test a n l    -- unexpected scope extension
    Bad4 :: Foil.NameBinder l n -> Test a n l    -- unexpected scope extension
    Bad5 :: Foil.NameBinder n i -> Foil.NameBinder i l -> Foil.NameBinder l i -> Test a n l -- intermediate scope escapes (not enough binders?)
    Bad6 :: Foil.NameBinder n l -> Foil.NameBinder n l -> Test a n l -- unexpected scope extension
    Bad7 :: [Foil.NameBinder n l] -> Test a n l -- no GHasNameBinders (unreadable error message)
  ```
  - ~~Current implementation is "slightly" unsafe, but should be fine in practice 🤞~~
     https://github.com/fizruk/free-foil/blob/02a8d1bf72f19c8b0031624832971c5d7f7e0dbe/haskell/free-foil/src/Control/Monad/Foil/Internal.hs#L1215-L1234
- [x] Use generic instance in examples

Obsolete plan:
- [x] ~~Add an internal `GSinkable` class and use it for default `sinkabilityProof` implementation~~
- [x] ~~Make `GSinkable` work for GADTs~~
  - ~~⚠️ it works for some important examples, but is ad hoc is some places and will easily not work for your definition, in that case you will get a, likely horrific, type error, and will have to resort to manually implementing the instance~~