### PR TITLE
ValidNameBinders: substitute under sums and products

### DIFF
--- a/haskell/free-foil/src/Control/Monad/Foil/Internal/ValidNameBinders.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/Internal/ValidNameBinders.hs
@@ -19,6 +19,8 @@ type family SubstInRepK i atom f where
   SubstInRepK i atom U1 = U1
   SubstInRepK i atom (M1 info c f) = M1 info c (SubstInRepK i atom f)
   SubstInRepK i atom (Field field) = Field (SubstInAtom i atom field)
+  SubstInRepK i atom (f :+: g) = SubstInRepK i atom f :+: SubstInRepK i atom g
+  SubstInRepK i atom (f :*: g) = SubstInRepK i atom f :*: SubstInRepK i atom g
   SubstInRepK i atom f =
     TypeError
       ('Text "cannot substitute variable"


### PR DESCRIPTION
`SubstInRepK` runs when `GInnerScopeOfRepK` meets an equality constraint in a GADT constructor of a user-defined pattern, and substitutes through the rest of that constructor's representation. It handled only `M1` and `Field`, so a constructor that *equates its scopes* and carries *more than one field* fell into the catch-all and was rejected with a spurious "cannot substitute variable" type error, although the pattern is perfectly valid.

This is enough to trigger it:

```haskell
data P (n :: Foil.S) (l :: Foil.S) where
  PNil  :: Int -> Bool -> P n n          -- equality constraint + a product of fields
  PCons :: Foil.NameBinder n l -> P n l

deriveGenericK ''P
instance Foil.SinkableK P
instance Foil.HasNameBinders P
```

Before this change that is rejected with `cannot substitute variable … in Field (Kon Int) :*: Field (Kon Bool)`. Now it compiles. Constructors with a single field are unaffected, which is why the patterns in `lambda-pi` and `soas` never hit this.