### PR TITLE
CI: test PRs on Linux only, prune caches, dry-run releases

### DIFF
--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -1,0 +1,37 @@
+name: Cleanup caches
+
+# A stack build caches its dependencies per platform, and the cache key includes
+# a hash of every package.yaml and *.cabal file. So a branch that bumps a version
+# or edits a dependency writes fresh dependency caches (a few hundred MB each),
+# which live on after the branch is merged and compete with `main`'s caches for
+# the repository's 10 GB budget. GitHub evicts least-recently-used, and `main`'s
+# caches are exactly the ones every new pull request wants to restore from.
+#
+# So when a pull request closes, delete the caches it created.
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cleanup:
+    name: Delete caches of the closed pull request
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🧹 Delete caches for refs/pull/${{ github.event.pull_request.number }}/merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          echo "Deleting caches for $BRANCH"
+          # A cache is scoped to the ref that created it, so listing by ref gives
+          # exactly this pull request's caches and nothing of main's.
+          gh cache list --repo "$REPO" --ref "$BRANCH" --limit 100 --json id,key,sizeInBytes \
+            --jq '.[] | "\(.id) \(.sizeInBytes) \(.key)"' | while read -r id size key; do
+              echo "  deleting $key ($((size / 1024 / 1024)) MB)"
+              gh cache delete "$id" --repo "$REPO" || true
+            done

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -18,8 +18,13 @@ jobs:
     name: Run tests
     runs-on: ${{ matrix.os }}
     strategy:
+      # Pull requests are tested on Linux only; `main` and tags are tested on
+      # all three platforms. A release is cut from `main`, so the cross-platform
+      # signal is still there when it matters, while an ordinary PR no longer
+      # pays for the (slowest) Windows job or writes ~1 GB of platform caches
+      # that then evict `main`'s caches from the repository's 10 GB budget.
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["ubuntu-latest", "windows-latest", "macos-latest"]') }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ on:
   release:
     types: [published]
 
+  # A dry run: builds the source and documentation tarballs exactly as a real
+  # release would, and stops before uploading anything. Without this, the steps
+  # below are exercised for the first time on release day.
+  workflow_dispatch:
+
 permissions:
   contents: write
 
@@ -32,6 +37,13 @@ jobs:
           ghc-version: "9.8.2"
           cabal-version: "latest"
 
+      - name: 💾 Cache cabal store (for haddocks)
+        uses: actions/cache@v4
+        with:
+          path: ~/.cabal/store
+          key: cabal-store-${{ runner.os }}-ghc9.8.2-${{ hashFiles('haskell/free-foil/free-foil.cabal') }}
+          restore-keys: cabal-store-${{ runner.os }}-ghc9.8.2-
+
       - name: 📚 Generate documentation tarball (free-foil)
         run: |
           cabal update
@@ -40,7 +52,17 @@ jobs:
           mv dist-docs/*-docs.tar.gz docs/
         working-directory: haskell/free-foil
 
+      - name: 📦 Upload tarballs as workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: hackage-tarballs
+          path: |
+            packages/*.tar.gz
+            haskell/free-foil/docs/*-docs.tar.gz
+
+      # Only a published release uploads to Hackage; a manual run is a dry run.
       - name: 🚀 Upload on Hackage
+        if: github.event_name == 'release'
         uses: haskell-actions/hackage-publish@v1
         with:
           hackageToken: ${{ secrets.HACKAGE_AUTH_TOKEN }}


### PR DESCRIPTION
Three workflow changes, prompted by a look at what CI actually caches.

- **The matrix.** All three platforms still run on `main` and on tags; a pull request now runs Linux only. A release is cut from `main`, so the cross-platform signal is kept where it decides something, and an ordinary PR no longer pays for the Windows job.
- **Cache churn.** `stack-action` keys its dependency cache on a hash of every `package.yaml` and `*.cabal`, so any version bump mints fresh caches — 374 MB on Linux, 382 MB on macOS, 691 MB on Windows. They outlive the branch and compete with `main`'s for the 10 GB budget, where eviction is least-recently-used. The 0.3.0 PRs took us to 4 GB in a day, and #36 is still holding 382 MB. A new workflow deletes a PR's caches when it closes.
- **Dry runs.** `release.yml` only fired on `release: published`, so the `cabal haddock` step from #36 would have run for the first time on release day. It now also takes `workflow_dispatch`, with the upload guarded on the event, so a manual run builds both tarballs and stops. They are kept as artifacts.