### PR TITLE
mkFreeFoil: fix constructors with several scoped children

### DIFF
--- a/haskell/free-foil/free-foil.cabal
+++ b/haskell/free-foil/free-foil.cabal
@@ -91,6 +91,9 @@ test-suite spec
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Control.Monad.Free.Foil.TH.MkFreeFoilSpec
+      Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Config
+      Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Syntax
       Paths_free_foil
   hs-source-dirs:
       test
@@ -102,7 +105,10 @@ test-suite spec
     , containers >=0.6 && <0.9
     , deepseq >=1.4 && <1.6
     , free-foil
+    , hspec
+    , hspec-discover
     , kind-generics >=0.5.0 && <0.6
+    , kind-generics-th
     , template-haskell >=2.21.0.0 && <2.24
     , text >=1.2.3.1 && <2.2
   default-language: Haskell2010

--- a/haskell/free-foil/package.yaml
+++ b/haskell/free-foil/package.yaml
@@ -54,6 +54,9 @@ tests:
       - -with-rtsopts=-N
     dependencies:
       - free-foil
+      - hspec
+      - hspec-discover
+      - kind-generics-th
 
   doctests:
     source-dirs:

--- a/haskell/free-foil/src/Control/Monad/Free/Foil/TH/MkFreeFoil.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil/TH/MkFreeFoil.hs
@@ -21,7 +21,8 @@ import           Control.Monad.Foil.TH.Util
 import qualified Control.Monad.Free.Foil    as Foil
 import           Data.Bifunctor
 import           Data.List                  (find, unzip4, (\\), nub)
-import           Data.Maybe                 (catMaybes, mapMaybe)
+import           Data.Maybe                 (catMaybes, listToMaybe, mapMaybe,
+                                             maybeToList)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import qualified GHC.Generics               as GHC
@@ -333,6 +334,23 @@ toFreeFoilBindingCon config rawRetType theOuterScope = go
       ForallC params ctx con -> ForallC params ctx <$> go con
       RecGadtC conNames argTypes retType -> go (GadtC conNames (map removeName argTypes) retType)
 
+-- | Is this raw field a binding (pattern) field?
+--
+-- Such a field has no counterpart in the free foil node: the binder it stands for
+-- lives inside the 'Foil.ScopedAST' of each scoped child.
+isBindingField :: FreeFoilConfig -> Type -> Bool
+isBindingField FreeFoilConfig{..} = \case
+  PeelConT typeName _ | Just _ <- lookupBindingName typeName freeFoilTermConfigs -> True
+  _ -> False
+
+-- | Is this raw field a scoped-term field?
+--
+-- Such a field becomes a 'Foil.ScopedAST', which carries a binder of its own.
+isScopeField :: FreeFoilConfig -> Type -> Bool
+isScopeField FreeFoilConfig{..} = \case
+  PeelConT typeName _ | Just _ <- lookupScopeName typeName freeFoilTermConfigs -> True
+  _ -> False
+
 termConToPat :: Name -> FreeFoilConfig -> FreeFoilTermConfig -> Con -> Q [([Name], Pat, Pat, [Exp])]
 termConToPat rawTypeName config@FreeFoilConfig{..} FreeFoilTermConfig{..} = go
   where
@@ -384,8 +402,40 @@ termConToPat rawTypeName config@FreeFoilConfig{..} FreeFoilTermConfig{..} = go
       GadtC conNames rawArgTypes _rawRetType -> concat <$> do
         forM conNames $ \conName -> do
           let newConName = toSignatureName config conName
-          (concat -> vars, concat -> pats, concat -> pats', concat -> exps) <- unzip4 <$>
-            mapM (fromArgType . snd) rawArgTypes
+          perField <- mapM (fromArgType . snd) rawArgTypes
+          let (concat -> vars, concat -> pats, _, _) = unzip4 perField
+              -- These expressions rebuild the /raw/ constructor, whose fields are
+              -- shaped differently from the free foil node's: the raw constructor
+              -- has a single binding (pattern) field and its scoped fields carry
+              -- no binder of their own, whereas in the free foil every scoped
+              -- child carries its own binder. So a scoped child contributes only
+              -- its body here, and the binding field is filled from the first
+              -- scoped child's binder -- the raw syntax can name only one binder,
+              -- and a constructor that binds several scopes binds the same name
+              -- in each of them.
+              firstScopeBinder = listToMaybe
+                [ binder
+                | (rawArgType, (binder : _, _, _, _)) <- zip (map snd rawArgTypes) perField
+                , isScopeField config rawArgType ]
+              rawFieldExp rawArgType (_, _, _, fieldExps)
+                | isBindingField config rawArgType = map VarE (maybeToList firstScopeBinder)
+                | isScopeField config rawArgType   = drop 1 fieldExps  -- the body; the binder is not a raw field
+                | otherwise                        = fieldExps
+              exps = concat (zipWith rawFieldExp (map snd rawArgTypes) perField)
+              -- Only the first scoped child's binder makes it back into the raw
+              -- syntax (see above), so matching the others' binders would bind a
+              -- variable we never use.
+              sigPats = goSigPats True (zip (map snd rawArgTypes) perField)
+              goSigPats _ [] = []
+              goSigPats isFirstScope ((rawArgType, (_, _, fieldPats, _)) : rest)
+                | isScopeField config rawArgType =
+                    (if isFirstScope then fieldPats else map ignoreBinder fieldPats)
+                      ++ goSigPats False rest
+                | otherwise = fieldPats ++ goSigPats isFirstScope rest
+              ignoreBinder = \case
+                TupP [_binder, body] -> TupP [WildP, body]
+                p                    -> p
+              pats' = sigPats
           return $
             if rawTypeName == rawTermName
               then [ (vars, ConP 'Foil.Node [] [ConP newConName [] pats], ConP newConName [] pats', exps) ]
@@ -521,6 +571,52 @@ termConToPatQuantified config@FreeFoilConfig{..} = go
       ForallC _params _ctx con -> go con
       RecGadtC conNames argTypes retType -> go (GadtC conNames (map removeName argTypes) retType)
 
+-- | Argument types of a pattern synonym for a single raw constructor.
+--
+-- This has to agree with 'termConToPat', which decides what the synonym's
+-- /arguments/ are, and the two used to disagree:
+--
+-- * a raw binding (pattern) field contributes __no__ argument, since a binder
+--   in the free foil lives inside the 'Foil.ScopedAST' it binds, not beside it;
+-- * a raw scoped-term field contributes __two__ arguments, a binder and a body;
+-- * every other field contributes one argument, as before.
+--
+-- Crucially, each scoped-term field gets a __fresh__ inner scope: a constructor
+-- with several scoped children (a recursive @let@, say) binds a separate name in
+-- each of them, so sharing one scope variable between them is wrong. A
+-- constructor with at most one scoped child keeps the inner scope named @i@,
+-- so the generated code for such constructors is unchanged.
+patternSynonymArgTypes :: FreeFoilConfig -> Type -> Type -> [Type] -> [Type]
+patternSynonymArgTypes config@FreeFoilConfig{..} outerScope innerScope rawArgTypes =
+    go (1 :: Int) rawArgTypes
+  where
+    -- Only when there are several scoped children do we need to number the
+    -- scopes; with one child, @i@ keeps the generated code as it was.
+    scopeCount = length (filter (isScopeField config) rawArgTypes)
+    innerScopeFor k
+      | scopeCount <= 1 = innerScope
+      | otherwise       = VarT (mkName ("i" ++ show k))
+
+    go _ [] = []
+    go k (rawArgType : rest) = case rawArgType of
+      PeelConT typeName _params
+        -- The binder is an argument of the ScopedAST, not of the node.
+        | Just _ <- lookupBindingName typeName freeFoilTermConfigs -> go k rest
+        -- A scoped child: its own binder, then its body, in its own scope.
+        | Just FreeFoilTermConfig{..} <- lookupScopeName typeName freeFoilTermConfigs ->
+            let inner = innerScopeFor k
+                rawBindingType = PeelConT rawBindingName (typeParamsOf rawArgType)
+             in toFreeFoilType SortTerm config outerScope inner rawBindingType
+                  : toFreeFoilType SortTerm config outerScope inner rawArgType
+                  : go (k + 1) rest
+      _ -> toFreeFoilType SortTerm config outerScope innerScope rawArgType : go k rest
+
+    -- A scoped type and its binding type are parametrised alike (both carry the
+    -- annotation type, if any), so the binder type reuses the scope's parameters.
+    typeParamsOf = \case
+      PeelConT _ params -> params
+      _                 -> []
+
 mkPatternSynonym :: Name -> FreeFoilConfig -> FreeFoilTermConfig -> Type -> Con -> Q [(Name, [Dec])]
 mkPatternSynonym rawTypeName config termConfig@FreeFoilTermConfig{..} rawRetType = go
   where
@@ -529,16 +625,18 @@ mkPatternSynonym rawTypeName config termConfig@FreeFoilTermConfig{..} rawRetType
       GadtC conNames rawArgTypes _rawRetType -> concat <$> do
         forM (conNames \\ [rawVarConName]) $ \conName -> do
           let patName = toConName config conName
-              rawConType = foldr (\x y -> AppT (AppT ArrowT x) y) rawRetType (map snd rawArgTypes)
               outerScope = VarT (mkName "o")
               innerScope
                 | rawTypeName `elem` rawSubScopeNames = outerScope
                 | otherwise = VarT (mkName "i")
+              synType = foldr (\x y -> AppT (AppT ArrowT x) y)
+                (toFreeFoilType SortTerm config outerScope innerScope rawRetType)
+                (patternSynonymArgTypes config outerScope innerScope (map snd rawArgTypes))
           [(vars, pat, _, _)] <- termConToPat rawTypeName config termConfig (GadtC [conName] rawArgTypes rawRetType)    -- FIXME: unsafe matching!
           addModFinalizer $ putDoc (DeclDoc patName)
             ("/Generated/ with '" ++ show 'mkFreeFoil ++ "'. Pattern synonym for an '" ++ show ''Foil.AST ++ "' node of type '" ++ show conName ++ "'.")
           return [(patName,
-            [ PatSynSigD patName (toFreeFoilType SortTerm config outerScope innerScope rawConType)
+            [ PatSynSigD patName synType
             , PatSynD patName (PrefixPatSyn vars) ImplBidir pat
             ])]
 
@@ -1187,6 +1285,19 @@ bindingConToClause rawType config FreeFoilTermConfig{..} = go
 sigConToClause :: Sort -> Type -> FreeFoilConfig -> FreeFoilTermConfig -> Con -> Q [Clause]
 sigConToClause sort rawRetType config@FreeFoilConfig{..} FreeFoilTermConfig{..} = go
   where
+    -- Matching a raw constructor, we must bind exactly one variable per raw
+    -- field. The binding (pattern) field binds @theBinder@, and each scoped
+    -- field binds only a body -- and then every scoped child of the free foil
+    -- node is given /the same/ @theBinder@, since the raw syntax names one
+    -- binder and a constructor binding several scopes binds it in each of them.
+    fromRawArgType :: Bool -> Name -> Name -> Type -> Q ([Pat], [Exp])
+    fromRawArgType isVarCon theIdent theBinder rawArgType
+      | isBindingField config rawArgType = return ([VarP theBinder], [])
+      | isScopeField config rawArgType = do
+          body <- newName "body"
+          return ([VarP body], [TupE [Just (VarE theBinder), Just (VarE body)]])
+      | otherwise = fromArgType isVarCon theIdent rawArgType
+
     fromArgType :: Bool -> Name -> Type -> Q ([Pat], [Exp])
     fromArgType isVarCon theIdent = \case
       PeelConT typeName _params
@@ -1227,11 +1338,12 @@ sigConToClause sort rawRetType config@FreeFoilConfig{..} FreeFoilTermConfig{..} 
     go = \case
       GadtC conNames rawArgTypes _rawRetType -> concat <$> do
         theIdent <- newName "_theRawIdent"
+        theBinder <- newName "binder"
         forM conNames $ \conName -> do
           let newConName = toSignatureName config conName
               isVarCon = conName == rawVarConName
           (concat -> pats, concat -> exps) <- unzip <$>
-            mapM (fromArgType isVarCon theIdent . snd) rawArgTypes
+            mapM (fromRawArgType isVarCon theIdent theBinder . snd) rawArgTypes
           case sort of
             SortTerm
               | isVarCon -> return

--- a/haskell/free-foil/test/Control/Monad/Free/Foil/TH/MkFreeFoilSpec.hs
+++ b/haskell/free-foil/test/Control/Monad/Free/Foil/TH/MkFreeFoilSpec.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE DataKinds       #-}
+{-# LANGUAGE PatternSynonyms #-}
+
+-- | Regression tests for 'mkFreeFoil' and 'mkFreeFoilConversions' on raw
+-- constructors whose shape does not line up with the free foil node they become.
+--
+-- That "Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Syntax" compiles at all is half
+-- the test: the generated pattern synonyms and conversions used to be ill-typed
+-- for @Let@ and @LetRec@. These examples are the other half — they check that a
+-- raw binder still binds what it used to.
+module Control.Monad.Free.Foil.TH.MkFreeFoilSpec (spec) where
+
+import qualified Control.Monad.Foil                               as Foil
+import qualified Data.Map                                         as Map
+import           Test.Hspec
+
+import           Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Config
+import           Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Syntax
+
+-- | Convert a closed raw term into the scope-safe representation and back.
+--
+-- Binders come back renamed (that is what 'intToVarIdent' is for), so the
+-- examples below check how names /relate/, not what they are called.
+roundtrip :: Term -> Term
+roundtrip = fromTerm . toTerm Foil.emptyScope Map.empty
+
+x, y :: VarIdent
+x = VarIdent "x"
+y = VarIdent "y"
+
+-- | A closed term, to use where a term must not mention the surrounding binder.
+identity :: Term
+identity = Fun (PatternVar y) (ScopedTerm (Var y))
+
+spec :: Spec
+spec = do
+  describe "a pattern adjacent to its scope (Fun)" $
+    it "round-trips, and the body still refers to the binder" $
+      case roundtrip (Fun (PatternVar x) (ScopedTerm (Var x))) of
+        Fun (PatternVar binder) (ScopedTerm (Var v)) -> v `shouldBe` binder
+        other -> expectationFailure ("unexpected shape: " <> show other)
+
+  describe "a pattern separated from its scope (Let)" $ do
+    it "puts the binder in the binding position, not the bound term's" $
+      -- The generated conversions used to hand the raw constructor its arguments
+      -- in the free foil node's order rather than the raw one, which put the
+      -- bound term where the pattern belongs.
+      case roundtrip (Let (PatternVar x) identity (ScopedTerm (Var x))) of
+        Let (PatternVar binder) bound (ScopedTerm (Var v)) -> do
+          v `shouldBe` binder                 -- the body refers to the binder
+          bound `shouldSatisfy` isFun         -- the bound term is still a term
+        other -> expectationFailure ("unexpected shape: " <> show other)
+
+  describe "one pattern binding two scopes (LetRec)" $ do
+    it "binds the same name in both scopes" $
+      -- Each scoped child of a free foil node carries its own binder, so the two
+      -- scopes get two distinct foil names. The raw syntax has only one pattern,
+      -- so converting back must give both scopes the same name again.
+      case roundtrip (LetRec (PatternVar x) (ScopedTerm (Var x)) (ScopedTerm (Var x))) of
+        LetRec (PatternVar binder) (ScopedTerm (Var v1)) (ScopedTerm (Var v2)) -> do
+          v1 `shouldBe` binder
+          v2 `shouldBe` binder
+        other -> expectationFailure ("unexpected shape: " <> show other)
+
+    it "keeps the two scopes apart" $
+      case roundtrip (LetRec (PatternVar x) (ScopedTerm identity) (ScopedTerm (Var x))) of
+        LetRec (PatternVar binder) (ScopedTerm first) (ScopedTerm (Var v)) -> do
+          first `shouldSatisfy` isFun   -- the first scope does not mention the binder
+          v `shouldBe` binder           -- the second one does
+        other -> expectationFailure ("unexpected shape: " <> show other)
+  where
+    isFun Fun{} = True
+    isFun _     = False

--- a/haskell/free-foil/test/Control/Monad/Free/Foil/TH/MkFreeFoilSpec/Config.hs
+++ b/haskell/free-foil/test/Control/Monad/Free/Foil/TH/MkFreeFoilSpec/Config.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | A raw syntax in the shape BNFC produces, used to test 'mkFreeFoil'.
+--
+-- The interesting constructors are the ones whose /raw/ shape does not line up
+-- with the free foil node they become:
+--
+-- * @Let@ has a pattern, a term, and one scoped term (so the pattern is not
+--   adjacent to the scope it binds);
+-- * @LetRec@ has a pattern and __two__ scoped terms (so one raw binder binds
+--   two separate scopes).
+--
+-- Both used to generate ill-typed code. See the spec.
+--
+-- The config lives in its own module because Template Haskell may not splice a
+-- value defined in the same module.
+module Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Config where
+
+import           Control.Monad.Free.Foil.TH.MkFreeFoil
+
+newtype VarIdent = VarIdent String
+  deriving (Eq, Ord, Show)
+
+newtype Pattern = PatternVar VarIdent
+  deriving (Eq, Show)
+
+newtype ScopedTerm = ScopedTerm Term
+  deriving (Eq, Show)
+
+data Term
+  = Var VarIdent
+  | App Term Term
+  | Fun Pattern ScopedTerm                -- ^ pattern, then its scope (this always worked)
+  | Let Pattern Term ScopedTerm           -- ^ a term between the pattern and its scope
+  | LetRec Pattern ScopedTerm ScopedTerm  -- ^ one pattern binding two scopes
+  deriving (Eq, Show)
+
+rawVar :: VarIdent -> Term
+rawVar = Var
+
+intToVarIdent :: Int -> VarIdent
+intToVarIdent i = VarIdent ("x" <> show i)
+
+rawScopedTerm :: Term -> ScopedTerm
+rawScopedTerm = ScopedTerm
+
+rawScopeToTerm :: ScopedTerm -> Term
+rawScopeToTerm (ScopedTerm t) = t
+
+config :: FreeFoilConfig
+config = FreeFoilConfig
+  { rawQuantifiedNames = []
+  , freeFoilTermConfigs =
+      [ FreeFoilTermConfig
+          { rawIdentName = ''VarIdent
+          , rawTermName = ''Term
+          , rawBindingName = ''Pattern
+          , rawScopeName = ''ScopedTerm
+          , rawVarConName = 'Var
+          , rawSubTermNames = []
+          , rawSubScopeNames = []
+          , intToRawIdentName = 'intToVarIdent
+          , rawVarIdentToTermName = 'rawVar
+          , rawTermToScopeName = 'rawScopedTerm
+          , rawScopeToTermName = 'rawScopeToTerm
+          } ]
+  , freeFoilNameModifier = ("FF" ++)
+  , freeFoilScopeNameModifier = ("FFScoped" ++)
+  , freeFoilConNameModifier = ("FF" ++)
+  , freeFoilConvertFromName = ("from" ++)
+  , freeFoilConvertToName = ("to" ++)
+  , signatureNameModifier = (++ "Sig")
+  }

--- a/haskell/free-foil/test/Control/Monad/Free/Foil/TH/MkFreeFoilSpec/Syntax.hs
+++ b/haskell/free-foil/test/Control/Monad/Free/Foil/TH/MkFreeFoilSpec/Syntax.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE KindSignatures    #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE PatternSynonyms   #-}
+{-# LANGUAGE RankNTypes        #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeFamilies      #-}
+-- Generated conversions carry a redundant @Ord@ constraint; 'soas' silences the
+-- same warning in its generated module.
+{-# OPTIONS_GHC -Wno-missing-signatures -Wno-redundant-constraints #-}
+
+-- | The scope-safe syntax generated from
+-- "Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Config".
+--
+-- That this module /compiles at all/ is the regression test: before the fix,
+-- 'mkFreeFoil' and 'mkFreeFoilConversions' generated ill-typed code for @Let@
+-- and @LetRec@ (a pattern synonym whose signature disagreed with its arguments,
+-- and conversions that gave the raw constructor the wrong number of arguments in
+-- the wrong order).
+module Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Syntax where
+
+import qualified Control.Monad.Foil                              as Foil
+import           Control.Monad.Free.Foil.TH.MkFreeFoil
+import           Data.Bifunctor.TH
+import           Generics.Kind.TH                                (deriveGenericK)
+
+import           Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Config
+
+mkFreeFoil config
+
+deriveGenericK ''FFPattern
+instance Foil.SinkableK FFPattern
+instance Foil.HasNameBinders FFPattern
+instance Foil.CoSinkable FFPattern
+instance Foil.UnifiablePattern FFPattern
+
+deriveBifunctor ''TermSig
+deriveBifoldable ''TermSig
+deriveBitraversable ''TermSig
+
+mkFreeFoilConversions config

--- a/haskell/free-foil/test/Spec.hs
+++ b/haskell/free-foil/test/Spec.hs
@@ -1,2 +1,1 @@
-main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
Reported and diagnosed by @AbsoluteNikola in [free-foil-refinement-types](https://github.com/AbsoluteNikola/free-foil-refinement-types), where `mkFreeFoil` had to be abandoned: the generated code was pasted in by hand and patched (`-- FIXED HERE`) because it did not typecheck. This fixes the generator, so that it produces what was hand-written there.

Two raw shapes were affected:

```
Let    ::= Pattern Term ScopedTerm        -- a term between the pattern and its scope
LetRec ::= Pattern ScopedTerm ScopedTerm  -- one pattern binding two scopes
```

The synonym's arguments and its type signature came from two traversals that disagreed: the pattern drops the raw binding field (a binder lives inside the `ScopedAST` it binds) and emits a binder and body per scoped child, while the signature kept the field and shared one inner scope across children. So the arguments were typed in the wrong order, and a constructor with two scoped children had more arguments than its signature had arrows:

```haskell
-- before (neither of these typechecks)
pattern Let    :: Pattern o i -> Term o -> Term i -> Term o
pattern Let       x binder body = Node (LetSig x (ScopedAST binder body))
pattern LetRec :: Pattern o i -> Term i -> Term i -> Term o
pattern LetRec    binder1 body1 binder2 body2 = ...   -- four arguments, three arrows

-- after
pattern Let    :: Term o -> Pattern o i -> Term i -> Term o
pattern LetRec :: Pattern o i1 -> Term i1 -> Pattern o i2 -> Term i2 -> Term o
```

`mkFreeFoilConversions` had the mirror problem, and now rebuilds the raw constructor in raw field order — one binder into every scoped child going in, read back from the first coming out:

```haskell
fromTermSig (LetSig    x (binder, body))          = Let    binder x body
toTermSig   (Let    binder x body)                = Right (LetSig x (binder, body))
toTermSig   (LetRec binder body1 body2)           = Right (LetRecSig (binder, body1) (binder, body2))
fromTermSig (LetRecSig (binder, body1) (_, body2)) = LetRec binder body1 body2
```

Constructors with at most one scoped child generate exactly what they did before, which is all of `lambda-pi` and `soas` — hence unnoticed here.

Also adds free-foil's first tests.