### PR TITLE
Foil: pin down unifyNameBinders' renaming direction

### DIFF
--- a/haskell/free-foil/free-foil.cabal
+++ b/haskell/free-foil/free-foil.cabal
@@ -91,6 +91,7 @@ test-suite spec
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Control.Monad.Foil.UnifyNameBindersSpec
       Control.Monad.Free.Foil.TH.MkFreeFoilSpec
       Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Config
       Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Syntax

--- a/haskell/free-foil/src/Control/Monad/Foil/Internal.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/Internal.hs
@@ -408,6 +408,20 @@ data UnifyNameBinders (pattern :: S -> S -> Type) n l r where
 
 -- | Unify binders either by asserting that they are the same,
 -- or by providing a /safe/ renaming function to convert one binder to another.
+--
+-- When the binders differ, the one with the /larger/ name is renamed towards the
+-- one with the smaller name. The direction is deliberate, but it is not what makes
+-- the renaming safe, and it is worth being explicit about that, since the choice
+-- looks arbitrary and has been "fixed" downstream before.
+--
+-- The renaming returned here is not applied by substituting names blindly: callers
+-- push it through a term with 'Control.Monad.Foil.Relative.liftRM', which refreshes
+-- a binder whenever it would capture. So the target name may perfectly well be used
+-- by a binder /inside/ the term being renamed — a term built in a small scope keeps
+-- its small binder names when 'sink' places it in a larger one, so binder names do
+-- not always grow with depth — and the result is still correct. See
+-- @Control.Monad.Foil.UnifyNameBindersSpec@ for the term that exercises exactly
+-- this.
 unifyNameBinders
   :: forall i l r pattern. Distinct i
   => NameBinder i l -- ^ Left pattern.

--- a/haskell/free-foil/test/Control/Monad/Foil/UnifyNameBindersSpec.hs
+++ b/haskell/free-foil/test/Control/Monad/Foil/UnifyNameBindersSpec.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | 'Foil.unifyNameBinders' renames the binder with the /larger/ name towards the
+-- one with the smaller name. This module pins that down, because the choice looks
+-- arbitrary and is not: it is safe, but only because the renaming it asks for is
+-- applied by a capture-avoiding substitution.
+--
+-- A fresh name is @max scope + 1@, so binder names normally grow as one goes
+-- deeper into a term. They do not have to: 'Foil.sink' is a coercion, so a term
+-- built in a small scope keeps its (small) binder names when it is placed inside
+-- a larger one. A term whose /outer/ binder is named after its /inner/ one is
+-- therefore reachable, and it is the term that makes the direction of the
+-- renaming observable.
+module Control.Monad.Foil.UnifyNameBindersSpec (spec) where
+
+import           Data.Maybe                                       (fromJust)
+import           Test.Hspec
+
+import qualified Control.Monad.Foil                               as Foil
+import           Control.Monad.Free.Foil
+
+import           Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Syntax
+
+-- | @\\x. x@, with the binder named @max scope + 1@.
+identityIn :: Foil.Distinct n => Foil.Scope n -> FFTerm n
+identityIn scope = Foil.withFresh scope $ \binder ->
+  case Foil.assertDistinct binder of
+    Foil.Distinct -> FFFun (FFPatternVar binder) (Var (Foil.nameOf binder))
+
+-- | @\\x. \\y. y@, built outside-in: the outer binder is named 0, the inner 1.
+nestedNormal :: FFTerm Foil.VoidS
+nestedNormal = Foil.withFresh Foil.emptyScope $ \outer ->
+  case Foil.assertDistinct outer of
+    Foil.Distinct ->
+      FFFun (FFPatternVar outer) (identityIn (Foil.extendScope outer Foil.emptyScope))
+
+-- | The same term, @\\x. \\y. y@, built inside-out: the outer binder is named 1
+-- and the inner one 0, so the names run backwards.
+nestedInverted :: FFTerm Foil.VoidS
+nestedInverted = fromJust $
+  Foil.withFresh Foil.emptyScope $ \(binder0 :: Foil.NameBinder Foil.VoidS n1) ->
+    case Foil.assertDistinct binder0 of
+      Foil.Distinct ->
+        let scope1 = Foil.extendScope binder0 Foil.emptyScope
+            inner  = Foil.sink (identityIn Foil.emptyScope) :: FFTerm n1  -- binder named 0
+         in Foil.withFresh scope1 $ \outer ->                             -- named 1
+              case Foil.assertDistinct outer of
+                Foil.Distinct ->
+                  unsinkAST Foil.emptyScope
+                    (FFFun (FFPatternVar outer) (Foil.sink inner))
+
+spec :: Spec
+spec = describe "unifyNameBinders (via alphaEquiv)" $ do
+  it "identifies two spellings of the same term whose binder names run opposite ways" $
+    -- Unifying the two outer binders renames the right one (1) down to the left
+    -- one (0) -- onto a name a binder /inside that very body/ already uses. The
+    -- renaming is applied with 'liftRM', which refreshes on a clash, so it does
+    -- not capture. Renaming towards the smaller name is therefore safe, and this
+    -- is the example that says so.
+    alphaEquiv Foil.emptyScope nestedNormal nestedInverted `shouldBe` True
+
+  it "is symmetric on that pair" $
+    alphaEquiv Foil.emptyScope nestedInverted nestedNormal `shouldBe` True
+
+  it "still tells genuinely different terms apart" $
+    alphaEquiv Foil.emptyScope nestedNormal (identityIn Foil.emptyScope) `shouldBe` False

--- a/haskell/free-foil/test/Control/Monad/Free/Foil/TH/MkFreeFoilSpec/Syntax.hs
+++ b/haskell/free-foil/test/Control/Monad/Free/Foil/TH/MkFreeFoilSpec/Syntax.hs
@@ -11,8 +11,9 @@
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeFamilies      #-}
 -- Generated conversions carry a redundant @Ord@ constraint; 'soas' silences the
--- same warning in its generated module.
-{-# OPTIONS_GHC -Wno-missing-signatures -Wno-redundant-constraints #-}
+-- same warning in its generated module, as it does the orphan 'ZipMatchK'
+-- instance for the raw identifier type.
+{-# OPTIONS_GHC -Wno-missing-signatures -Wno-redundant-constraints -Wno-orphans #-}
 
 -- | The scope-safe syntax generated from
 -- "Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Config".
@@ -27,6 +28,7 @@ module Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Syntax where
 import qualified Control.Monad.Foil                              as Foil
 import           Control.Monad.Free.Foil.TH.MkFreeFoil
 import           Data.Bifunctor.TH
+import           Data.ZipMatchK
 import           Generics.Kind.TH                                (deriveGenericK)
 
 import           Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Config
@@ -42,5 +44,9 @@ instance Foil.UnifiablePattern FFPattern
 deriveBifunctor ''TermSig
 deriveBifoldable ''TermSig
 deriveBitraversable ''TermSig
+
+deriveGenericK ''TermSig
+instance ZipMatchK VarIdent where zipMatchWithK = zipMatchViaEq
+instance ZipMatchK TermSig
 
 mkFreeFoilConversions config


### PR DESCRIPTION
Raised by @AbsoluteNikola (Nikolay Rulev), who [forked the library](https://github.com/AbsoluteNikola/free-foil) to flip `i1 < i2` to `i1 > i2` ("extend to bigger scope"). The direction looks arbitrary, so here is why it is safe.

A fresh name is `max scope + 1`, so binder names usually grow with depth. But `sink` is a coercion, so a term built in a small scope keeps its small names inside a bigger one, and the same `\x. \y. y` can have its names running either way:

```
λ x0 . λ x1 . x1     -- built outside-in
λ x1 . λ x0 . x0     -- built inside-out (sink, then unsinkAST)
```

Unifying the two outer binders renames `x1` down to `x0` — onto a name the nested binder in that very body already uses. That looks like capture, and is not: the renaming is pushed through the term with `liftRM`, which refreshes a binder whenever it would capture. So `alphaEquiv` identifies the two (and still separates genuinely different terms). That is the new test, and the haddock now points at it.