### PR TITLE
Add Control.Monad.Free.Foil.Annotated

### DIFF
--- a/haskell/free-foil/free-foil.cabal
+++ b/haskell/free-foil/free-foil.cabal
@@ -40,6 +40,7 @@ library
       Control.Monad.Foil.TH.MkToFoil
       Control.Monad.Foil.TH.Util
       Control.Monad.Free.Foil
+      Control.Monad.Free.Foil.Annotated
       Control.Monad.Free.Foil.Example
       Control.Monad.Free.Foil.TH
       Control.Monad.Free.Foil.TH.Convert
@@ -93,6 +94,7 @@ test-suite spec
   other-modules:
       Control.Monad.Foil.NameMapSpec
       Control.Monad.Foil.UnifyNameBindersSpec
+      Control.Monad.Free.Foil.AnnotatedSpec
       Control.Monad.Free.Foil.TH.MkFreeFoilSpec
       Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Config
       Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Syntax

--- a/haskell/free-foil/src/Control/Monad/Free/Foil/Annotated.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil/Annotated.hs
@@ -1,0 +1,162 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DeriveTraversable     #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms       #-}
+{-# LANGUAGE PolyKinds             #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+-- | Annotating every node of a free foil term.
+--
+-- A node can be annotated with anything: a source position, a type, a memoised
+-- normal form. 'AnnSig' turns a signature into an annotated one, and
+-- 'AnnAST' is the annotated syntax it generates.
+--
+-- The annotation is a /functor of the term/, and that is what lets it depend on
+-- the node's scope. In @'AST' binder sig n@ the signature's term parameter /is/
+-- the AST at the node's own scope, so an annotation built from it holds terms in
+-- that scope — which is what a type annotation in a dependent language needs.
+-- An annotation that ignores the term (a source position, say) is @'Const' a@.
+--
+-- Whether two annotations must agree for their nodes to match is a property of
+-- @ann@, not of 'AnnSig'. Two examples, and they are the two you will want:
+--
+-- An annotation that ignores the term (a source position) and /is/ compared:
+--
+-- > instance Eq a => ZipMatchK (Const (a :: Type)) where
+-- >   zipMatchWithK _ (Const l) (Const r)
+-- >     | l == r    = Just (Const l)
+-- >     | otherwise = Nothing
+--
+-- An annotation that holds terms (a type, with a memoised normal form) and is
+-- /ignored/, so that two terms differing only in their types are α-equivalent:
+--
+-- > data TypeInfo term = TypeInfo { infoType :: term, infoWHNF :: Maybe term }
+-- >
+-- > instance ZipMatchK TypeInfo where
+-- >   zipMatchWithK (f :^: M0) (TypeInfo t1 w1) (TypeInfo t2 w2) =
+-- >     TypeInfo <$> f t1 t2 <*> pure (do { a <- w1; b <- w2; f a b })
+--
+-- __Do not reach for the generic instance here.__ It compares the annotation's
+-- /shape/, so a node carrying a memoised normal form would fail to match the same
+-- node without one. An annotation-blind instance is one that always succeeds,
+-- pairing the terms it can and dropping the rest — as above. (Nor is
+-- 'zipMatchViaChooseLeft' available: an annotation holding terms must /construct/ a
+-- value at the result index, and cannot simply pick a side.)
+--
+-- __Note the asymmetry__ in the instances below: 'Bifunctor' and 'Bitraversable'
+-- traverse the annotation, but 'Bifoldable' does /not/. This is deliberate — see
+-- 'AnnSig'.
+module Control.Monad.Free.Foil.Annotated (
+  AnnSig(..),
+  AnnAST,
+  AnnScopedAST,
+  pattern AnnNode,
+  annotationOf,
+  freeVarsOfAnnotated,
+) where
+
+import           Data.Bifoldable
+import           Data.Bifunctor
+import           Data.Bitraversable
+import           Data.Kind             (Type)
+import           Data.Maybe            (mapMaybe)
+import           Data.ZipMatchK
+import           Generics.Kind         (GenericK (..), Field, Var0, Var1, (:$:),
+                                        Atom ((:@:)), (:*:))
+import qualified GHC.Generics          as GHC
+
+import qualified Control.Monad.Foil    as Foil
+import           Control.Monad.Free.Foil
+
+-- | A signature, with every node annotated by an @ann@ built from the node's term.
+--
+-- The annotation is applied to the /term/ parameter, so in an
+-- @'AST' binder ('AnnSig' ann sig) n@ it holds terms in the node's own scope.
+--
+-- 'Bifoldable' deliberately __skips the annotation__. That is what makes
+-- α-equivalence annotation-blind: 'Control.Monad.Free.Foil.alphaEquiv' consumes a
+-- zipped node with 'bifoldMap', so a type annotation is never compared, and two
+-- terms that differ only in their annotations are α-equivalent. The price is that
+-- 'Control.Monad.Free.Foil.freeVarsOf', which is also 'Bifoldable', does not see
+-- variables occurring inside annotations. Use 'freeVarsOfAnnotated' when those
+-- matter.
+data AnnSig (ann :: Type -> Type) (sig :: Type -> Type -> Type) scope term
+  = AnnSig (ann term) (sig scope term)
+  deriving (GHC.Generic)
+
+deriving instance (Functor ann, Functor (sig scope))
+  => Functor (AnnSig ann sig scope)
+deriving instance (Foldable ann, Foldable (sig scope))
+  => Foldable (AnnSig ann sig scope)
+deriving instance (Traversable ann, Traversable (sig scope))
+  => Traversable (AnnSig ann sig scope)
+
+instance (Functor ann, Bifunctor sig) => Bifunctor (AnnSig ann sig) where
+  bimap f g (AnnSig ann sig) = AnnSig (fmap g ann) (bimap f g sig)
+
+-- | __The annotation is not folded.__ See 'AnnSig'.
+instance Bifoldable sig => Bifoldable (AnnSig ann sig) where
+  bifoldMap f g (AnnSig _ann sig) = bifoldMap f g sig
+
+instance (Traversable ann, Bitraversable sig) => Bitraversable (AnnSig ann sig) where
+  bitraverse f g (AnnSig ann sig) = AnnSig <$> traverse g ann <*> bitraverse f g sig
+
+instance GenericK (AnnSig ann sig) where
+  type RepK (AnnSig ann sig) =
+    Field (ann :$: Var1) :*: Field ((sig :$: Var0) :@: Var1)
+
+instance (ZipMatchK ann, ZipMatchK sig)
+  => ZipMatchK (AnnSig (ann :: Type -> Type) (sig :: Type -> Type -> Type))
+
+-- | An annotated scope-safe term.
+type AnnAST binder ann sig = AST binder (AnnSig ann sig)
+
+-- | An annotated scope-safe term under a binder.
+type AnnScopedAST binder ann sig = ScopedAST binder (AnnSig ann sig)
+
+-- | An annotated node.
+pattern AnnNode
+  :: ann (AnnAST binder ann sig n)
+  -> sig (AnnScopedAST binder ann sig n) (AnnAST binder ann sig n)
+  -> AnnAST binder ann sig n
+pattern AnnNode ann sig = Node (AnnSig ann sig)
+
+{-# COMPLETE Var, AnnNode #-}
+
+-- | The annotation of a term, unless it is a variable (which is not a node, so it
+-- carries none).
+annotationOf :: AnnAST binder ann sig n -> Maybe (ann (AnnAST binder ann sig n))
+annotationOf = \case
+  Var _         -> Nothing
+  AnnNode ann _ -> Just ann
+
+-- | The free variables of an annotated term, __including__ those occurring inside
+-- annotations.
+--
+-- 'Control.Monad.Free.Foil.freeVarsOf' misses the latter, since 'Bifoldable' skips
+-- the annotation (see 'AnnSig').
+freeVarsOfAnnotated
+  :: (Foil.Distinct n, Foil.CoSinkable binder, Bifoldable sig, Foldable ann)
+  => AnnAST binder ann sig n -> [Foil.Name n]
+freeVarsOfAnnotated = \case
+  Var name -> [name]
+  AnnNode ann sig ->
+    foldMap freeVarsOfAnnotated ann
+      <> bifoldMap freeVarsOfAnnotatedScoped freeVarsOfAnnotated sig
+
+-- | The free variables of an annotated scoped term, including those inside
+-- annotations.
+freeVarsOfAnnotatedScoped
+  :: (Foil.Distinct n, Foil.CoSinkable binder, Bifoldable sig, Foldable ann)
+  => AnnScopedAST binder ann sig n -> [Foil.Name n]
+freeVarsOfAnnotatedScoped (ScopedAST binder body) =
+  case Foil.assertDistinct binder of
+    Foil.Distinct ->
+      mapMaybe (Foil.unsinkNamePattern binder) (freeVarsOfAnnotated body)

--- a/haskell/free-foil/test/Control/Monad/Free/Foil/AnnotatedSpec.hs
+++ b/haskell/free-foil/test/Control/Monad/Free/Foil/AnnotatedSpec.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DeriveTraversable     #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms       #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | Annotated syntax: one 'AnnSig' serving two annotations with opposite matching
+-- behaviour, and the 'Bifoldable' asymmetry that α-equivalence relies on.
+module Control.Monad.Free.Foil.AnnotatedSpec (spec) where
+
+import           Data.Bifunctor.TH
+import           Data.Functor.Const                (Const (..))
+import           Data.Kind                         (Type)
+import           Data.ZipMatchK
+import           Generics.Kind.TH                  (deriveGenericK)
+import qualified GHC.Generics                      as GHC
+import           Test.Hspec
+
+import qualified Control.Monad.Foil                as Foil
+import           Control.Monad.Free.Foil
+import           Control.Monad.Free.Foil.Annotated
+
+-- | A minimal λ-calculus signature.
+data LamSig scope term = AppSig term term | LamSig scope
+  deriving (GHC.Generic, Functor, Foldable, Traversable)
+
+deriveBifunctor ''LamSig
+deriveBifoldable ''LamSig
+deriveBitraversable ''LamSig
+deriveGenericK ''LamSig
+instance ZipMatchK LamSig
+
+instance ZipMatchK Int where zipMatchWithK = zipMatchViaEq
+
+-- | An annotation that ignores the term — a source position, say — and __is
+-- compared__ when matching.
+instance Eq a => ZipMatchK (Const (a :: Type)) where
+  zipMatchWithK _ (Const l) (Const r)
+    | l == r    = Just (Const l)
+    | otherwise = Nothing
+
+type Positioned = AnnAST Foil.NameBinder (Const Int) LamSig
+
+-- | An annotation that holds a term at the node's own scope — a type, say.
+--
+-- It is optional, and it has to be: an annotation holding a term needs a term to
+-- hold, so a closed annotated term could not be built at all without either a
+-- 'Maybe' or a knot.
+newtype TypeOf term = TypeOf (Maybe term)
+  deriving (GHC.Generic, Functor, Foldable, Traversable)
+
+deriveGenericK ''TypeOf
+
+-- | Matching __ignores__ the annotation: it always succeeds, pairing the terms it
+-- can and dropping what it cannot.
+--
+-- The /generic/ instance would not do: it compares the annotation's shape, so a
+-- node with a memoised type would fail to match the same node without one.
+instance ZipMatchK TypeOf where
+  zipMatchWithK (f :^: M0) (TypeOf l) (TypeOf r) =
+    Just (TypeOf (do { a <- l; b <- r; f a b }))
+
+type Typed = AnnAST Foil.NameBinder TypeOf LamSig
+
+-- | @\\x. x x@, annotated at every node with a source position.
+positioned :: Int -> Positioned Foil.VoidS
+positioned k = Foil.withFresh Foil.emptyScope $ \binder ->
+  case Foil.assertDistinct binder of
+    Foil.Distinct ->
+      let x = Var (Foil.nameOf binder)
+       in AnnNode (Const k)
+            (LamSig (ScopedAST binder (AnnNode (Const k) (AppSig x x))))
+
+-- | @\\x. x@, carrying the given type annotation at its root.
+typed :: Maybe (Typed Foil.VoidS) -> Typed Foil.VoidS
+typed ty = Foil.withFresh Foil.emptyScope $ \binder ->
+  case Foil.assertDistinct binder of
+    Foil.Distinct ->
+      AnnNode (TypeOf ty) (LamSig (ScopedAST binder (Var (Foil.nameOf binder))))
+
+-- | @\\x. x x@, with no type annotations, to have a structurally different term.
+selfApp :: Typed Foil.VoidS
+selfApp = Foil.withFresh Foil.emptyScope $ \binder ->
+  case Foil.assertDistinct binder of
+    Foil.Distinct ->
+      let x = Var (Foil.nameOf binder)
+       in AnnNode (TypeOf Nothing)
+            (LamSig (ScopedAST binder (AnnNode (TypeOf Nothing) (AppSig x x))))
+
+spec :: Spec
+spec = do
+  describe "an annotation that ignores the term (Const)" $ do
+    it "matches when the annotations agree" $
+      alphaEquiv Foil.emptyScope (positioned 1) (positioned 1) `shouldBe` True
+
+    it "does not match when they differ" $
+      alphaEquiv Foil.emptyScope (positioned 1) (positioned 2) `shouldBe` False
+
+  describe "an annotation that holds a term (a type)" $ do
+    it "is ignored when matching: terms differing only in their types are alpha-equivalent" $
+      -- The property a dependent typechecker needs. It works because Bifoldable
+      -- skips the annotation, so alphaEquiv never walks into it.
+      alphaEquiv Foil.emptyScope (typed Nothing) (typed (Just (typed Nothing)))
+        `shouldBe` True
+
+    it "still distinguishes terms that differ in the term itself" $
+      alphaEquiv Foil.emptyScope (typed Nothing) selfApp `shouldBe` False
+
+  describe "freeVarsOfAnnotated" $
+    it "sees a variable that freeVarsOf misses, because it occurs in an annotation" $
+      Foil.withFresh Foil.emptyScope $ \outer ->
+        case Foil.assertDistinct outer of
+          Foil.Distinct ->
+            let x = Var (Foil.nameOf outer)                      -- free at this scope
+                scope = Foil.extendScope outer Foil.emptyScope
+             in Foil.withFresh scope $ \inner ->
+                  case Foil.assertDistinct inner of
+                    Foil.Distinct ->
+                      -- \y. y, annotated with a type that mentions x
+                      let node = AnnNode (TypeOf (Just x))
+                                   (LamSig (ScopedAST inner (Var (Foil.nameOf inner))))
+                       in do
+                            freeVarsOf node `shouldBe` []
+                            length (freeVarsOfAnnotated node) `shouldBe` 1


### PR DESCRIPTION
`AnnSig` annotates every node of a free foil term. Three projects built on free-foil have written their own version, and no two of them agree, so I add one type that covers all of them:

```haskell
data AnnSig (ann :: Type -> Type) (sig :: Type -> Type -> Type) scope term
  = AnnSig (ann term) (sig scope term)
```

The annotation is a functor of the term, which is how it gets to depend on the scope of the node. A source position ignores the term. A type annotation holds terms at the node's own scope, since that is what the term parameter is:

```haskell
type Positioned = AnnAST NameBinder (Const Loc)   LamSig
type Typed      = AnnAST NameBinder TypeOf        LamSig  -- newtype TypeOf term = TypeOf (Maybe term)
```

Whether two annotations must agree for their nodes to match is up to `ann`, not to `AnnSig`. Positions are compared, types are ignored:

```haskell
alphaEquiv emptyScope (positioned 1) (positioned 1)          -- True
alphaEquiv emptyScope (positioned 1) (positioned 2)          -- False
alphaEquiv emptyScope (typed Nothing) (typed (Just intType)) -- True
```

The third one works because `Bifoldable` skips the annotation, while `Bifunctor` and `Bitraversable` traverse it. The asymmetry is deliberate: `alphaEquiv` consumes a zipped node with `bifoldMap`, so it never walks into a type. But `freeVarsOf` is `Bifoldable` too, and so it misses this `x`:

```haskell
freeVarsOf          node  -- []   the body binds its own variable
freeVarsOfAnnotated node  -- [x]  the annotation mentions a free one
```

The haddocks give the `ZipMatchK` instances for both kinds of annotation, and warn that the generic instance will not do for a type: it compares the shape of the annotation, so a node with a memoized normal form fails to match the same node without one.