### PR TITLE
The cheap performance wins

### DIFF
--- a/haskell/free-foil/ChangeLog.md
+++ b/haskell/free-foil/ChangeLog.md
@@ -14,6 +14,14 @@ New:
 
 - A `zipmatchk` benchmark for `free-foil`, comparing the generic and the derived instance on `alphaEquiv` at several signature sizes. CI builds it, but does not run it.
 
+- `sinkContainer` sinks an entire container of sinkable expressions — an `IntMap` of terms, a `Map` keyed by something else — in O(1), by coercion, rather than walking the spine with `fmap sink`. The soundness argument for `sink` extends to a container of sinkables, and there was previously no way to say so, so downstream projects wrote their own `unsafeCoerce`. Note that a `Scope` is *not* sinkable (it must grow when a binder is entered) and a `NameMap` must stay total, so sinking one has to be paired with adding the new binder's entry; both are documented with the function.
+
+Performance:
+
+- `alphaEquiv` and `unsafeEqAST` no longer pair up the node they are comparing. They used to build a copy of the node with every field replaced by a tuple, and only then fold over the copy; they now recurse inside the zipping functions, which allocates no tuples and short-circuits on the first mismatch. On the benchmark this is 294 µs → 217 µs and 3.1 MB → 2.8 MB with a derived instance, and 541 µs → 362 µs with a generic one. Behaviour is unchanged.
+
+- The hot functions (`substitute`, `alphaEquiv`, `refreshAST` and friends) are now `INLINABLE`, so that a downstream call site can specialise them for its own signature instead of passing dictionaries. Worth a few percent on the benchmark, and more where the signature is bigger.
+
 Changed:
 
 - `soas` and `Language.LambdaPi.Impl.FreeFoilTH` now derive their `ZipMatchK` instances rather than taking the generic ones. `Language.LambdaPi.Impl.FreeFoil`, the implementation that does everything by hand, now writes them out by hand, so that the two implementations show the two ways.

--- a/haskell/free-foil/src/Control/Monad/Foil.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil.hs
@@ -40,6 +40,7 @@ module Control.Monad.Foil (
   CoSinkable(..),
   HasNameBinders(getNameBinders),
   sink,
+  sinkContainer,
   extendRenaming,
   extendNameBinderRenaming,
   composeNameBinderRenamings,

--- a/haskell/free-foil/src/Control/Monad/Foil/Internal.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/Internal.hs
@@ -48,6 +48,7 @@ module Control.Monad.Foil.Internal where
 import           Control.DeepSeq    (NFData (..))
 import           Data.Bifunctor
 import           Data.Coerce        (coerce)
+import           Data.Functor.Compose (Compose (..))
 import           Data.IntMap
 import qualified Data.IntMap        as IntMap
 import           Data.IntSet
@@ -58,6 +59,12 @@ import           Generics.Kind
 import           Unsafe.Coerce
 
 import Control.Monad.Foil.Internal.ValidNameBinders
+
+-- $setup
+-- >>> :set -XDataKinds
+-- >>> :set -XFlexibleContexts
+-- >>> :set -Wno-simplifiable-class-constraints
+-- >>> import qualified Data.Map as Map
 
 -- * Safe types and operations
 
@@ -662,12 +669,41 @@ class Sinkable (e :: S -> Type) where
 instance Sinkable Name where
   sinkabilityProof rename = rename
 
+-- | A container of sinkable expressions is sinkable, elementwise.
+--
+-- The point of this instance is 'sinkContainer': since the proof typechecks,
+-- sinking the whole container is a coercion, and does not walk its spine.
+instance (Functor f, Sinkable e) => Sinkable (Compose f e) where
+  sinkabilityProof rename (Compose xs) = Compose (fmap (sinkabilityProof rename) xs)
+
 -- | Efficient version of 'sinkabilityProof'.
 -- In fact, once 'sinkabilityProof' typechecks,
 -- it is safe to 'sink' by coercion.
 -- See Section 3.5 in [«The Foil: Capture-Avoiding Substitution With No Sharp Edges»](https://doi.org/10.1145/3587216.3587224) for the details.
 sink :: (Sinkable e, DExt n l) => e n -> e l
 sink = unsafeCoerce
+
+-- | Sink an entire container of sinkable expressions, in \(O(1)\).
+--
+-- The soundness argument for 'sink' extends to a container of sinkables — an
+-- 'Data.IntMap.IntMap' of terms, a 'Data.Map.Map' keyed by something else, a
+-- list of them — so there is no need to walk the spine with @'fmap' 'sink'@, and
+-- entering a binder need not be \(O(size)\).
+--
+-- >>> :{
+-- sinkEnv :: DExt n l => Map.Map String (Name n) -> Map.Map String (Name l)
+-- sinkEnv = sinkContainer
+-- :}
+--
+-- Two things this does /not/ cover:
+--
+-- * A 'Scope' is __not__ sinkable, and must not be sunk: it is the set of names
+--   /in/ scope @n@, and it has to grow when a binder is entered (see 'extendScope').
+-- * A 'NameMap' must stay __total__ on the names in scope ('lookupName' errors
+--   otherwise), so sinking one has to be paired with adding the new binder's
+--   entry (see 'addNameBinder').
+sinkContainer :: (Functor f, Sinkable e, DExt n l) => f (e n) -> f (e l)
+sinkContainer = getCompose . sink . Compose
 
 -- | Extend renaming when going under a 'CoSinkable' pattern (generalized binder).
 -- Note that the scope under pattern is independent of the codomain of the renaming.

--- a/haskell/free-foil/src/Control/Monad/Free/Foil.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil.hs
@@ -34,7 +34,6 @@ import           Data.Coerce                 (coerce)
 import           Data.Map                    (Map)
 import qualified Data.Map                    as Map
 import           Data.Maybe                  (mapMaybe)
-import           Data.Monoid                 (All (..))
 import           GHC.Generics                (Generic)
 import           Unsafe.Coerce               (unsafeCoerce)
 
@@ -83,6 +82,7 @@ instance Foil.InjectName (AST binder sig) where
 -- * Substitution
 
 -- | Substitution for free (scoped monads).
+{-# INLINABLE substitute #-}
 substitute
   :: (Bifunctor sig, Foil.Distinct o, Foil.CoSinkable binder, Foil.SinkableK binder)
   => Foil.Scope o
@@ -108,6 +108,7 @@ substitute scope subst = \case
 -- > substituteRefreshed scope subst = refreshAST scope . subtitute scope subst
 --
 -- In general, 'substitute' is more efficient since it does not always refresh binders.
+{-# INLINABLE substituteRefreshed #-}
 substituteRefreshed
   :: (Bifunctor sig, Foil.Distinct o, Foil.CoSinkable binder, Foil.SinkableK binder)
   => Foil.Scope o
@@ -158,6 +159,7 @@ substitutePattern scope env binders args body =
 -- * \(\alpha\)-equivalence
 
 -- | Refresh (force) all binders in a term, minimizing the used indices.
+{-# INLINABLE refreshAST #-}
 refreshAST
   :: (Bifunctor sig, Foil.Distinct n, Foil.CoSinkable binder, Foil.SinkableK binder)
   => Foil.Scope n
@@ -168,6 +170,7 @@ refreshAST scope = \case
   Node t -> Node (bimap (refreshScopedAST scope) (refreshAST scope) t)
 
 -- | Similar to `refreshAST`, but for scoped terms.
+{-# INLINABLE refreshScopedAST #-}
 refreshScopedAST :: (Bifunctor sig, Foil.Distinct n, Foil.CoSinkable binder, Foil.SinkableK binder)
   => Foil.Scope n
   -> ScopedAST binder sig n
@@ -183,6 +186,7 @@ refreshScopedAST scope (ScopedAST binder body) =
 --
 -- Compared to 'alphaEquiv', this function may perform some unnecessary
 -- changes of bound variables when the binders are the same on both sides.
+{-# INLINABLE alphaEquivRefreshed #-}
 alphaEquivRefreshed
   :: (Bitraversable sig, ZipMatchK sig, Foil.Distinct n, Foil.UnifiablePattern binder, Foil.SinkableK binder)
   => Foil.Scope n
@@ -196,6 +200,7 @@ alphaEquivRefreshed scope t1 t2 = refreshAST scope t1 `unsafeEqAST` refreshAST s
 --
 -- Compared to 'alphaEquivRefreshed', this function might skip unnecessary
 -- changes of bound variables when both binders in two matching scoped terms coincide.
+{-# INLINABLE alphaEquiv #-}
 alphaEquiv
   :: (Bitraversable sig, ZipMatchK sig, Foil.Distinct n, Foil.UnifiablePattern binder, Foil.SinkableK binder)
   => Foil.Scope n
@@ -204,12 +209,15 @@ alphaEquiv
   -> Bool
 alphaEquiv _scope (Var x) (Var y) = x == coerce y
 alphaEquiv scope (Node l) (Node r) =
-  case zipMatch2 l r of
+  case zipMatchWith2 (unit . alphaEquivScoped scope) (unit . alphaEquiv scope) l r of
     Nothing -> False
-    Just tt -> getAll (bifoldMap (All . uncurry (alphaEquivScoped scope)) (All . uncurry (alphaEquiv scope)) tt)
+    Just _  -> True
+  where
+    unit f x = if f x then Just () else Nothing
 alphaEquiv _ _ _ = False
 
 -- | Same as 'alphaEquiv' but for scoped terms.
+{-# INLINABLE alphaEquivScoped #-}
 alphaEquivScoped
   :: (Bitraversable sig, ZipMatchK sig, Foil.Distinct n, Foil.UnifiablePattern binder, Foil.SinkableK binder)
   => Foil.Scope n
@@ -255,6 +263,7 @@ alphaEquivScoped scope
 -- This check ignores the possibility that two terms might have different
 -- scope extensions under binders (which might happen due to substitution
 -- under a binder in absence of name conflicts).
+{-# INLINABLE unsafeEqAST #-}
 unsafeEqAST
   :: (Bitraversable sig, ZipMatchK sig, Foil.UnifiablePattern binder, Foil.Distinct n, Foil.Distinct l)
   => AST binder sig n
@@ -262,12 +271,15 @@ unsafeEqAST
   -> Bool
 unsafeEqAST (Var x) (Var y) = x == coerce y
 unsafeEqAST (Node t1) (Node t2) =
-  case zipMatch2 t1 t2 of
+  case zipMatchWith2 (unit . unsafeEqScopedAST) (unit . unsafeEqAST) t1 t2 of
     Nothing -> False
-    Just tt -> getAll (bifoldMap (All . uncurry unsafeEqScopedAST) (All . uncurry unsafeEqAST) tt)
+    Just _  -> True
+  where
+    unit f x = if f x then Just () else Nothing
 unsafeEqAST _ _ = False
 
 -- | A version of 'unsafeEqAST' for scoped terms.
+{-# INLINABLE unsafeEqScopedAST #-}
 unsafeEqScopedAST
   :: (Bitraversable sig, ZipMatchK sig, Foil.UnifiablePattern binder, Foil.Distinct n, Foil.Distinct l)
   => ScopedAST binder sig n


### PR DESCRIPTION
Three local changes to the hot paths, none of which changes behaviour. Numbers are the `zipmatchk` benchmark (`alphaEquiv` over a ~4000-leaf term, 44-constructor signature).

- **`alphaEquiv` and `unsafeEqAST` no longer pair the node they compare.** Both went through `zipMatch2`, which builds a copy of the node with every field replaced by a tuple, then folds over it; they now recurse inside `zipMatchWith2`'s mappings, so no tuples and a mismatch short-circuits in `Maybe`. **294 µs → 217 µs, 3.1 MB → 2.8 MB** derived, and it helps the generic instance too (541 µs → 362 µs). λΠ's α-equivalence properties still pass.
- **The hot functions are now `INLINABLE`** (`substitute`, `alphaEquiv`, `refreshAST`, …). They are polymorphic in the signature and live in the library, so without the pragma a downstream call passes dictionaries and can never specialise. Worth a few percent here; the payoff is at the call site.
- **`sinkContainer`** sinks a whole `Map`/`IntMap` of sinkables in O(1) by coercion, via a new `Sinkable (Compose f e)` instance, rather than walking the spine with `fmap sink`. Caveats documented with it: a `Scope` is not sinkable, and a `NameMap` must stay total.