### PR TITLE
Annotated: derive AnnSig's ZipMatchK, fix the blind example

### DIFF
--- a/haskell/free-foil/ChangeLog.md
+++ b/haskell/free-foil/ChangeLog.md
@@ -28,6 +28,8 @@ Changed:
 
 - `soas` and `Language.LambdaPi.Impl.FreeFoilTH` now derive their `ZipMatchK` instances rather than taking the generic ones. `Language.LambdaPi.Impl.FreeFoil`, the implementation that does everything by hand, now writes them out by hand, so that the two implementations show the two ways.
 
+- `Control.Monad.Free.Foil.Annotated` now derives `AnnSig`'s `ZipMatchK` instance with `deriveZipMatchK2` rather than taking the generic one, for the same reason the derivers exist: on an annotated signature the generic instance lands on the hottest path in a typechecker. The `Annotated` haddock's annotation-blind example is also corrected. It showed a *strict* instance (`TypeInfo <$> f t1 t2 <*> …`), which forces the annotation — this breaks blindness when the term-zipper fails (two nodes with different types would not match) and diverges for a finite or lazily-bottomed annotation. The example now returns `Just` unconditionally with a thunked annotation the annotation-skipping `Bifoldable` never forces, and the module documents why. Both prompted by the rzk port.
+
 # 0.3.1 — 2026-07-14
 
 A bug fix and a set of additions, all of them prompted by the projects built on free-foil. Nothing is removed or changed, so upgrading from 0.3.0 needs no work.

--- a/haskell/free-foil/src/Control/Monad/Free/Foil/Annotated.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil/Annotated.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE PatternSynonyms       #-}
 {-# LANGUAGE PolyKinds             #-}
 {-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
@@ -34,21 +35,32 @@
 -- >     | l == r    = Just (Const l)
 -- >     | otherwise = Nothing
 --
--- An annotation that holds terms (a type, with a memoised normal form) and is
--- /ignored/, so that two terms differing only in their types are α-equivalent:
+-- An annotation that holds terms (a type, say) and is /ignored/, so that two
+-- terms differing only in their types are α-equivalent. Make the held term
+-- optional, so that pairing can fail /without/ failing the match:
 --
--- > data TypeInfo term = TypeInfo { infoType :: term, infoWHNF :: Maybe term }
+-- > newtype TypeOf term = TypeOf (Maybe term)
 -- >
--- > instance ZipMatchK TypeInfo where
--- >   zipMatchWithK (f :^: M0) (TypeInfo t1 w1) (TypeInfo t2 w2) =
--- >     TypeInfo <$> f t1 t2 <*> pure (do { a <- w1; b <- w2; f a b })
+-- > instance ZipMatchK TypeOf where
+-- >   zipMatchWithK (f :^: M0) (TypeOf l) (TypeOf r) =
+-- >     Just (TypeOf (do { a <- l; b <- r; f a b }))
+--
+-- __The instance must return 'Just' unconditionally, and lazily.__ Matching is
+-- annotation-blind, so it must succeed whatever the annotations are; the paired
+-- annotation is a thunk the (annotation-skipping) 'Bifoldable' never forces. A
+-- /strict/ shape — @TypeOf '<$>' f l r@, or anything that yields 'Nothing' when
+-- @f@ fails — is a footgun twice over: it breaks blindness (two nodes with
+-- different types would fail to match), and it /diverges/ for a finite or
+-- lazily-bottomed annotation (a universe tower ending in 'error', say), because
+-- forcing the annotation runs off the end. This is why the held term is a 'Maybe':
+-- a plain @term@ field would have no value to pair when @f@ fails, forcing a
+-- bottom into the result.
 --
 -- __Do not reach for the generic instance here.__ It compares the annotation's
 -- /shape/, so a node carrying a memoised normal form would fail to match the same
--- node without one. An annotation-blind instance is one that always succeeds,
--- pairing the terms it can and dropping the rest — as above. (Nor is
--- 'zipMatchViaChooseLeft' available: an annotation holding terms must /construct/ a
--- value at the result index, and cannot simply pick a side.)
+-- node without one. (Nor is 'zipMatchViaChooseLeft' available: an annotation
+-- holding terms must /construct/ a value at the result index, and cannot simply
+-- pick a side.)
 --
 -- __Note the asymmetry__ in the instances below: 'Bifunctor' and 'Bitraversable'
 -- traverse the annotation, but 'Bifoldable' does /not/. This is deliberate — see
@@ -67,7 +79,7 @@ import           Data.Bifunctor
 import           Data.Bitraversable
 import           Data.Kind             (Type)
 import           Data.Maybe            (mapMaybe)
-import           Data.ZipMatchK
+import           Data.ZipMatchK.TH     (deriveZipMatchK2)
 import           Generics.Kind         (GenericK (..), Field, Var0, Var1, (:$:),
                                         Atom ((:@:)), (:*:))
 import qualified GHC.Generics          as GHC
@@ -112,8 +124,16 @@ instance GenericK (AnnSig ann sig) where
   type RepK (AnnSig ann sig) =
     Field (ann :$: Var1) :*: Field ((sig :$: Var0) :@: Var1)
 
-instance (ZipMatchK ann, ZipMatchK sig)
-  => ZipMatchK (AnnSig (ann :: Type -> Type) (sig :: Type -> Type -> Type))
+-- | Matching for 'AnnSig' is /derived/, not left to the generic default.
+--
+-- The generic default would rebuild the "Generics.Kind" view of every node on
+-- every comparison, and comparing terms is most of what a typechecker does, so
+-- for an annotated signature — where it lands on the hottest path — that is a
+-- measurable cost. 'Data.ZipMatchK.TH.deriveZipMatchK2' generates the
+-- written-out instance instead: the annotation matched with the term zipper (an
+-- annotation is a functor of the term), the inner signature with both. Write
+-- @deriveZipMatchK2 ''YourAnnSig@ for a bespoke annotated signature.
+deriveZipMatchK2 ''AnnSig
 
 -- | An annotated scope-safe term.
 type AnnAST binder ann sig = AST binder (AnnSig ann sig)

--- a/haskell/free-foil/test/Control/Monad/Free/Foil/AnnotatedSpec.hs
+++ b/haskell/free-foil/test/Control/Monad/Free/Foil/AnnotatedSpec.hs
@@ -112,6 +112,15 @@ spec = do
     it "still distinguishes terms that differ in the term itself" $
       alphaEquiv Foil.emptyScope (typed Nothing) selfApp `shouldBe` False
 
+    it "never forces the annotation: matching is lazy in it" $
+      -- The blind instance returns 'Just' unconditionally with a thunked
+      -- annotation, so an annotation that is bottom must not break the match.
+      -- A strict instance would throw here instead of returning True.
+      alphaEquiv Foil.emptyScope
+        (typed (Just (error "annotation forced")))
+        (typed (Just (error "annotation forced")))
+        `shouldBe` True
+
   describe "freeVarsOfAnnotated" $
     it "sees a variable that freeVarsOf misses, because it occurs in an annotation" $
       Foil.withFresh Foil.emptyScope $ \outer ->


### PR DESCRIPTION
Two changes to `Control.Monad.Free.Foil.Annotated`, both on the path α-equivalence takes through an annotated term.

- **`AnnSig`'s `ZipMatchK` is now derived, not generic.** The empty instance head went through `genericZipMatchWithK`, rebuilding the `Generics.Kind` view of every node on every comparison — the cost the derivers exist to remove. It now uses `deriveZipMatchK2 ''AnnSig`, which also dogfoods the deriver on a real library type.
- **The annotation-blind example in the haddock was a strict footgun.** `TypeInfo <$> f t1 t2 <*> …` forces the annotation, which breaks blindness (nodes with different types fail to match) and diverges for a finite or lazily-bottomed annotation, such as a universe tower ending in `error`. It now returns `Just` unconditionally with a thunked annotation the annotation-skipping `Bifoldable` never forces, holding the term in a `Maybe` so pairing can fail without failing the match, and the module documents why.

Both were surfaced by porting rzk's typechecker.