### PR TITLE
CI: install GHC through the cached toolchain, not stack

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -42,9 +42,25 @@ jobs:
             haskell/lambda-pi/src/Language/LambdaPi/Syntax/Lex.hs
             haskell/lambda-pi/src/Language/LambdaPi/Syntax/Par.hs
 
+      # Install GHC and Stack through the toolchain cache, which is keyed on the
+      # GHC version alone. A stack-managed GHC would instead ride in the same
+      # cache as the built dependencies, and so be re-downloaded whenever a
+      # package.yaml or dependency changes. The version must match the resolver's
+      # GHC (nightly-2024-08-17 → 9.8.2); a mismatch makes '--system-ghc' fail loudly.
+      - name: 🧰 Setup GHC and Stack (cached toolchain)
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: "9.8.2"
+          enable-stack: true
+          stack-version: "latest"
+
       - name: 🧰 Setup Stack
         uses: freckle/stack-action@v5
         with:
+          # Use the GHC and Stack installed above, rather than a stack-managed GHC.
+          install-stack: false
+          upgrade-stack: false
+          stack-arguments: --system-ghc --no-install-ghc
           # Benchmarks are built (so that they cannot rot), but not run: timings
           # from a shared runner would mean nothing.
           stack-build-arguments: --pedantic --bench --no-run-benchmarks
@@ -71,9 +87,19 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      - name: 🧰 Setup GHC and Stack (cached toolchain)
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: "9.8.2"
+          enable-stack: true
+          stack-version: "latest"
+
       - name: 🧰 Setup Stack
         uses: freckle/stack-action@v5
         with:
+          install-stack: false
+          upgrade-stack: false
+          stack-arguments: --system-ghc --no-install-ghc
           test: false
           stack-build-arguments: --fast --haddock
           cache-prefix: docs-


### PR DESCRIPTION
`freckle/stack-action` caches its stack-managed GHC alongside the built dependencies, so GHC is re-downloaded whenever `package.yaml` or a dependency changes. Install it with `haskell-actions/setup` instead (as `release.yml` already does), which caches the toolchain by GHC version, and use it via `--system-ghc`. The pinned `9.8.2` must match the resolver's GHC.

Note: PRs run Linux only and `docs` is `main`-only, so this PR's run covers just the ubuntu `tests` job; run the workflow manually on the branch to check Windows and macOS.