### PR TITLE
Enable DataKinds for the S kind signature (GHC 9.14)

### DIFF
--- a/haskell/free-foil/src/Control/Monad/Foil/Relative.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/Relative.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 module Control.Monad.Foil.Relative where


### PR DESCRIPTION
GHC 9.14 turns the DataKinds requirement for promoted kinds in class declarations into an error; `RelMonad`'s kind signature `(f :: S -> Type)` needs the extension explicitly. Warning-free on older GHCs.