### PR TITLE
Module parameters in `mltt`

### DIFF
--- a/haskell/free-foil/ChangeLog.md
+++ b/haskell/free-foil/ChangeLog.md
@@ -16,7 +16,11 @@ New:
 
     - `supportOf` is a term's support, the annotation co-de-Bruijn syntax carries intrinsically and the foil, having free weakening, does not. `withRelevantScope` cuts a term down to the scope of exactly the names it uses; that is restriction imposed a priori, so nothing is tested and nothing can fail. `unsinkAST` is the a-posteriori form and the one that has to be paid for, and it now compares two `IntSet`s instead of walking a list of names with a membership test each.
 
-    Verifying a declared dependency — a `uses` clause, a module's parameters — is `withRelevantScope` plus a comparison. When the dependencies are a telescope to be abstracted over one at a time, `unsinkAST` per binder answers it directly instead, and computes the dependency set rather than checking one; that is what `mltt` discharges module parameters with.
+    - `withThinnedNameBinderList` cuts a chain of binders down to those whose names are in a given set, handing the continuation `Ext n m` and `Ext m l` to place the thinned scope between the two. This is what turns a support into a smaller chain in one step: the alternative, asking `unsinkAST` at every binder whether the term can do without it, walks the term once per binder. The thinned scope is produced rather than given, since a term's relevant scope is a subset of `l` and generally not an extension of `n`.
+
+    - `NameSet` is `Sinkable`, so a support computed under a binder can be used outside it without rebuilding the set.
+
+    Verifying a declared dependency — a `uses` clause, a module's parameters — is `withRelevantScope` plus a comparison. Computing one is `supportOf` and then `withThinnedNameBinderList`; that is how `mltt` closes a declaration over the module parameters it uses.
 
 - `Control.Monad.Free.Foil.freeVarsOf` and `freeVarsOfScopedAST` come from `supportOf`, so they no longer repeat a variable that occurs more than once, and return names in ascending order of their identifiers. Previously each occurrence was listed, and the order followed the term.
 

--- a/haskell/free-foil/ChangeLog.md
+++ b/haskell/free-foil/ChangeLog.md
@@ -16,7 +16,7 @@ New:
 
     - `supportOf` is a term's support, the annotation co-de-Bruijn syntax carries intrinsically and the foil, having free weakening, does not. `withRelevantScope` cuts a term down to the scope of exactly the names it uses; that is restriction imposed a priori, so nothing is tested and nothing can fail. `unsinkAST` is the a-posteriori form and the one that has to be paid for, and it now compares two `IntSet`s instead of walking a list of names with a membership test each.
 
-    Verifying a declared dependency — a `uses` clause, a module's parameters — is `withRelevantScope` plus a comparison.
+    Verifying a declared dependency — a `uses` clause, a module's parameters — is `withRelevantScope` plus a comparison. When the dependencies are a telescope to be abstracted over one at a time, `unsinkAST` per binder answers it directly instead, and computes the dependency set rather than checking one; that is what `mltt` discharges module parameters with.
 
 - `Control.Monad.Free.Foil.freeVarsOf` and `freeVarsOfScopedAST` come from `supportOf`, so they no longer repeat a variable that occurs more than once, and return names in ascending order of their identifiers. Previously each occurrence was listed, and the order followed the term.
 

--- a/haskell/free-foil/ChangeLog.md
+++ b/haskell/free-foil/ChangeLog.md
@@ -20,6 +20,8 @@ New:
 
     - `NameSet` is `Sinkable`, so a support computed under a binder can be used outside it without rebuilding the set.
 
+- `mapWithName` is the keyed version of `NameMap`'s `Functor` instance. It cannot change which names the map is defined on, so a total map stays total, which makes it a safe way to build a `Substitution` out of one with `nameMapToSubstitution` — an elaborator that has to expand a reference into something larger than a variable can do it that way rather than by inserting into a substitution by name.
+
     Verifying a declared dependency — a `uses` clause, a module's parameters — is `withRelevantScope` plus a comparison. Computing one is `supportOf` and then `withThinnedNameBinderList`; that is how `mltt` closes a declaration over the module parameters it uses.
 
 - `Control.Monad.Free.Foil.freeVarsOf` and `freeVarsOfScopedAST` come from `supportOf`, so they no longer repeat a variable that occurs more than once, and return names in ascending order of their identifiers. Previously each occurrence was listed, and the order followed the term.

--- a/haskell/free-foil/src/Control/Monad/Foil.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil.hs
@@ -99,6 +99,7 @@ module Control.Monad.Foil (
   fromNameBindersList,
   snocNameBinderList,
   concatNameBinderLists,
+  withThinnedNameBinderList,
   -- * Constraints
   Ext,
   ExtEvidence(..),

--- a/haskell/free-foil/src/Control/Monad/Foil.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil.hs
@@ -85,6 +85,7 @@ module Control.Monad.Foil (
   -- * Name maps
   NameMap,
   emptyNameMap,
+  mapWithName,
   lookupName,
   addNameBinder,
   popNameBinder,

--- a/haskell/free-foil/src/Control/Monad/Foil/Internal.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/Internal.hs
@@ -464,6 +464,14 @@ nameSetToList (UnsafeNameSet names) = Prelude.map UnsafeName (IntSet.toAscList n
 nameSetFromList :: [Name n] -> NameSet n
 nameSetFromList names = UnsafeNameSet (IntSet.fromList (Prelude.map nameId names))
 
+-- | A set of names sinks like anything else: rename each of its names.
+--
+-- As always, the proof is what makes 'sink' a coercion here, and a coercion is
+-- what it has to be for a support computed under a binder to be usable in the
+-- scope outside it without rebuilding the set.
+instance Sinkable NameSet where
+  sinkabilityProof rename = nameSetFromList . Prelude.map rename . nameSetToList
+
 -- | All the names in a scope.
 scopeToNameSet :: Scope n -> NameSet n
 scopeToNameSet (UnsafeScope names) = UnsafeNameSet names
@@ -681,6 +689,60 @@ nameBindersList (UnsafeNameBinders names) = go (IntSet.toList names)
   where
     go []     = unsafeCoerce NameBinderListEmpty
     go (x:xs) = NameBinderListCons (UnsafeNameBinder (UnsafeName x)) (go xs)
+
+-- | The raw names a list of binders binds, outermost first.
+rawNameBinderList :: NameBinderList n l -> [RawName]
+rawNameBinderList NameBinderListEmpty = []
+rawNameBinderList (NameBinderListCons binder binders) =
+  nameId (nameOf binder) : rawNameBinderList binders
+
+-- | Keep only those binders of a list whose names are in a given set.
+--
+-- This is the /thinning/ of a chain of binders, and it is what turns a support
+-- into a smaller chain in one step. The alternative — asking 'unsinkAST' at
+-- every binder whether the term can do without it — walks the term once per
+-- binder, whereas a caller can compute the support once and thin against it.
+--
+-- The thinned scope @m@ is produced rather than given, because there is nothing
+-- to give: a term\'s relevant scope (see @withRelevantScope@) is a subset of
+-- @l@ and generally not an extension of @n@, since a term need not use
+-- everything already in scope. What comes back is @n@ extended by the binders
+-- that survived, with @Ext n m@ and @Ext m l@ to place it between the two.
+--
+-- The set is taken as given. For a chain whose binders carry types, or anything
+-- else living in the intermediate scopes, the caller has to close the set under
+-- whatever those mention before thinning by it, since dropping a binder that a
+-- surviving binder\'s type refers to would leave that type unplaceable. The
+-- library cannot do that closure, having no view of what a binder carries.
+withThinnedNameBinderList
+  :: forall n l r. Distinct n
+  => NameSet l            -- ^ Names to keep, closed under whatever the binders carry.
+  -> NameBinderList n l   -- ^ The chain to thin.
+  -> (forall m. (Ext n m, Ext m l, Distinct m) => NameBinderList n m -> r)
+  -> r
+withThinnedNameBinderList (UnsafeNameSet keep) binders cont =
+    unsafeAssertThinned @n @l
+      (go (Prelude.filter (`IntSet.member` keep) (rawNameBinderList binders))) cont
+  where
+    go :: forall m m'. [RawName] -> NameBinderList m m'
+    go []       = unsafeCoerce NameBinderListEmpty
+    go (x : xs) = NameBinderListCons (UnsafeNameBinder (UnsafeName x)) (go xs)
+
+-- | Unsafely place a chain of binders between two scopes.
+--
+-- Sound for a chain thinned out of @n@ to @l@: its names are those of @n@ plus
+-- some of the binders between @n@ and @l@, so it extends @n@, is extended by
+-- @l@, and is distinct because @l@ was.
+unsafeAssertThinned
+  :: forall n l m r
+   . NameBinderList n m
+  -> ((Ext n m, Ext m l, Distinct m) => NameBinderList n m -> r)
+  -> r
+unsafeAssertThinned binders cont =
+  case unsafeDistinct @m of
+    Distinct -> case unsafeExt @n @m of
+      Ext -> case unsafeExt @m @l of
+        Ext -> cont binders
 
 -- | Add a binder to the end of an (ordered) list of binders.
 --

--- a/haskell/free-foil/src/Control/Monad/Foil/Internal.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/Internal.hs
@@ -1177,6 +1177,15 @@ newtype NameMap (n :: S) a = NameMap { getNameMap :: IntMap a } deriving (Functo
 emptyNameMap :: NameMap VoidS a
 emptyNameMap = NameMap IntMap.empty
 
+-- | Map over a 'NameMap', with the name each value belongs to.
+--
+-- This is the keyed version of the derived 'Functor' instance. It cannot change
+-- which names the map is defined on, so a map that was total stays total, which
+-- is what makes it a safe way to build a 'Substitution' out of one: see
+-- 'nameMapToSubstitution'.
+mapWithName :: (Name n -> a -> b) -> NameMap n a -> NameMap n b
+mapWithName f (NameMap m) = NameMap (IntMap.mapWithKey (f . UnsafeName) m)
+
 -- | Convert a 'NameMap' of expressions into a 'Substitution'.
 nameMapToSubstitution :: NameMap i (e o) -> Substitution e i o
 nameMapToSubstitution (NameMap m) = (UnsafeSubstitution m)

--- a/haskell/free-foil/test/Control/Monad/Free/Foil/SupportSpec.hs
+++ b/haskell/free-foil/test/Control/Monad/Free/Foil/SupportSpec.hs
@@ -90,6 +90,34 @@ withTwo k = Foil.withFresh Foil.emptyScope $ \b0 ->
           (Foil.sink (Foil.nameOf b0))
           (Foil.nameOf b1)
 
+-- | Work with a chain of three binders, and the set of all their names.
+withThree
+  :: (forall l. Foil.NameBinderList Foil.VoidS l -> Foil.NameSet l -> r) -> r
+withThree k =
+  Foil.withFresh Foil.emptyScope $ \b0 ->
+    let scope0 = Foil.extendScope b0 Foil.emptyScope
+     in Foil.withFresh scope0 $ \b1 ->
+          let scope1 = Foil.extendScope b1 scope0
+           in Foil.withFresh scope1 $ \b2 ->
+                let chain = Foil.NameBinderListCons b0
+                          ( Foil.NameBinderListCons b1
+                          ( Foil.NameBinderListCons b2 Foil.NameBinderListEmpty ))
+                 in k chain (Foil.nameSetOfPattern chain)
+
+-- | The raw identifiers a chain of binders binds, outermost first.
+binderNames :: Foil.NameBinderList n l -> [Int]
+binderNames Foil.NameBinderListEmpty = []
+binderNames (Foil.NameBinderListCons binder binders) =
+  Foil.nameId (Foil.nameOf binder) : binderNames binders
+
+-- | Thin a chain down to the binders whose identifiers pass a test.
+thinnedBy
+  :: (Int -> Bool) -> Foil.NameBinderList Foil.VoidS l -> Foil.NameSet l -> [Int]
+thinnedBy p chain names = Foil.withThinnedNameBinderList keep chain binderNames
+  where
+    keep = Foil.nameSetFromList
+      [x | x <- Foil.nameSetToList names, p (Foil.nameId x)]
+
 -- | The raw identifiers of a term's support, which is what the assertions
 -- compare.
 support :: Foil.Distinct n => Lam n -> [Int]
@@ -146,6 +174,16 @@ spec = do
               , support term'
               , Foil.member x relevant ))
         `shouldBe` (1, [1], False)
+
+  describe "withThinnedNameBinderList" $ do
+    it "keeps exactly the binders in the set, in order" $
+      withThree (thinnedBy (/= 1)) `shouldBe` [0, 2]
+
+    it "keeps all of them when the set has all of them" $
+      withThree (thinnedBy (const True)) `shouldBe` [0, 1, 2]
+
+    it "keeps none when the set has none" $
+      withThree (thinnedBy (const False)) `shouldBe` []
 
   describe "a binder sharing a raw name with the enclosing scope" $
     it "does not remove the enclosing name from the support" $

--- a/haskell/mltt/README.md
+++ b/haskell/mltt/README.md
@@ -67,10 +67,9 @@ waiting to be filled here.
   never printed; `let` substitutes rather than sharing; `conv` normalises both
   sides in full. Nothing here has been measured.
 
-Telescopes, module parameters with a verified `uses` clause, interned
-qualified names, separate checking with linking, and serialisation are not in
-this list. They are not out of scope — they are what comes next, and what is
-here was built to carry them.
+Named telescopes, interned qualified names, separate checking with linking, and
+serialisation are not in this list. They are not out of scope — they are what
+comes next, and what is here was built to carry them.
 
 ## The module layer
 
@@ -131,6 +130,54 @@ That distinction is the reason narrowing belongs above free foil rather than
 inside it, and `Language.MLTT.Resolve` is where it lives: nothing in that
 module mentions a scope, a `Foil.Name`, or the kind `S`.
 
+## Module parameters, and the `over` clause
+
+A module may take parameters. Every declaration is checked with them in scope,
+and leaves the module *discharged* over exactly the ones it turns out to use.
+
+```
+module Monoid (A : 𝕌) (unit : A) (mul : A → A → A)
+
+def square over (A, mul) : A → A := λ x ⇒ mul x x
+def neutral over (A, unit) : A := unit
+def flip : 𝟙 → 𝟙 := λ x ⇒ x
+```
+
+```
+module Monoid
+  ✓ defined square over (A, mul)
+  ✓ defined neutral over (A, unit)
+  ✓ defined flip
+```
+
+`flip` uses no parameter, so it is discharged over nothing and stays an
+ordinary constant. `neutral` is discharged over `A` even though its body
+mentions only `unit`: keeping `unit` puts `unit`'s type into the discharged
+type, and that type is `A`. Relevance is upward closed in the telescope.
+
+The `over` clause is optional and it never changes what is discharged. The
+computed set is authoritative, and the clause is *checked against it*:
+
+```
+✗ declared: over (mul)
+    actual: over (A, mul)
+```
+
+It is spelled `over` and not `uses` on purpose. rzk has a `uses` clause, and it
+is a different thing: mandatory, and listing the implicit assumptions of a
+definition rather than the parameters of its module.
+
+**Discharge is where the demo needs scope restriction rather than extension.**
+Checking happens in the scope the parameters extend the module's scope to, and
+the result has to come back, because the module's scope is where its exports
+live and where the next module starts. `Language.MLTT.Telescope` walks the
+parameters from the inside out and, at each one, asks free-foil's `unsinkAST`
+whether the term can do without it: if it can, the parameter is dropped; if it
+cannot, it is abstracted over with `Π` for the type and `λ` for the value. So
+the used set is not declared and believed, and not computed by a separate
+analysis either — it is whatever restriction turns out to reject, and the
+upward closure follows from asking about one parameter at a time.
+
 ## Running it
 
 ```sh
@@ -158,6 +205,7 @@ compute id 𝟙 tt
 | `Language.MLTT.Eval` | Reduction: pattern matching as a substitution, `whnf`, `nf`, `conv`, and the desugaring of `→` and `×`. |
 | `Language.MLTT.Typecheck` | A bidirectional type checker. |
 | `Language.MLTT.Resolve` | Name resolution: paths, name tables, `open`, and the free identifiers of a raw term. Deliberately free of any dependency on the foil. |
+| `Language.MLTT.Telescope` | Module parameters: the telescope they form, discharge over the ones a declaration uses, and the check of an `over` clause against that set. |
 | `Language.MLTT.Impl` | The interpreter: build order, modules, declarations, the growing top-level scope, and printing. |
 
 Two things are worth reading for the design rather than for the type theory.

--- a/haskell/mltt/README.md
+++ b/haskell/mltt/README.md
@@ -155,6 +155,19 @@ ordinary constant. `neutral` is discharged over `A` even though its body
 mentions only `unit`: keeping `unit` puts `unit`'s type into the discharged
 type, and that type is `A`. Relevance is upward closed in the telescope.
 
+A declaration is closed at the point it is defined, and not when the module
+ends. So a later declaration in the same module sees an earlier one already
+closed, and applies it to the parameters that one was closed over:
+
+```
+def squareNeutral over (A, unit, mul) : A := square A mul (neutral A unit)
+```
+
+The telescope is not put back automatically, and two declarations need not have
+taken the same prefix of it. This is Lean's `variable` rather than Coq's
+`Section`, which re-abstracts when the section closes and has to rewrite the
+references made inside it.
+
 The `over` clause is optional and it never changes what is discharged. The
 computed set is authoritative, and the clause is *checked against it*:
 

--- a/haskell/mltt/README.md
+++ b/haskell/mltt/README.md
@@ -156,17 +156,29 @@ mentions only `unit`: keeping `unit` puts `unit`'s type into the discharged
 type, and that type is `A`. Relevance is upward closed in the telescope.
 
 A declaration is closed at the point it is defined, and not when the module
-ends. So a later declaration in the same module sees an earlier one already
-closed, and applies it to the parameters that one was closed over:
+ends, so nothing has to be rewritten when the module ends. Inside the module
+the parameters are *put back on use*, so a later declaration reads as if none
+of that had happened:
 
 ```
-def squareNeutral over (A, unit, mul) : A := square A mul (neutral A unit)
+def squareNeutral over (A, unit, mul) : A := square neutral
 ```
 
-The telescope is not put back automatically, and two declarations need not have
-taken the same prefix of it. This is Lean's `variable` rather than Coq's
-`Section`, which re-abstracts when the section closes and has to rewrite the
-references made inside it.
+This elaborates to `square A mul (neutral A unit)`. Note that `square` and
+`neutral` were closed over different parameters, so there is no single
+telescope being reinstated: each reference gets back what that declaration
+took. Because the arguments really are there afterwards, they count as uses,
+which is why `squareNeutral` comes out closed over all three without saying so.
+
+Putting them back is elaboration and not textual replacement, so a local binder
+of the same name shadows the declaration:
+
+```
+def shadowing : 𝟙 → 𝟙 := λ square ⇒ square
+```
+
+is the identity and is closed over nothing. A client gets no such help, and
+wants none: it is applying a closed constant to a monoid of its choosing.
 
 The `over` clause is optional and it never changes what is discharged. The
 computed set is authoritative, and the clause is *checked against it*:

--- a/haskell/mltt/examples/parameters.mltt
+++ b/haskell/mltt/examples/parameters.mltt
@@ -5,7 +5,7 @@
 -- need. An `over` clause states that set in the source; it is checked against
 -- the computed one rather than believed, so it can only reject a program.
 
-module Monoid (A : 𝕌) (unit : A) (mul : A → A → A) ;
+module Monoid (A : 𝕌) (unit : A) (mul : A → A → A)
 
 -- Uses `A` and `mul`, and not `unit`.
 def square over (A, mul) : A → A := λ x ⇒ mul x x
@@ -21,13 +21,21 @@ def neutral over (A, unit) : A := unit
 def flip : 𝟙 → 𝟙 := λ x ⇒ x
 
 -- A declaration is closed at the point it is defined, and not when the module
--- ends. So a later declaration in the same module sees an earlier one already
--- closed, and applies it to the parameters it was closed over. The telescope is
--- not put back automatically, and `square` and `neutral` take different
--- prefixes of it.
-def squareNeutral over (A, unit, mul) : A := square A mul (neutral A unit)
+-- ends. Inside the module the parameters are put back on use, so this reads as
+-- if nothing had been closed over, and elaborates to
+-- `square A mul (neutral A unit)`. Note that `square` and `neutral` were closed
+-- over different parameters, so there is no one telescope to reinstate.
+--
+-- Because the arguments are really there afterwards, they count as uses, and
+-- this is closed over all three parameters without saying so.
+def squareNeutral over (A, unit, mul) : A := square neutral
 
-module Client ;
+-- Putting the parameters back is elaboration, not textual replacement: a local
+-- binder of the same name shadows the declaration, so this is the identity and
+-- is closed over nothing.
+def shadowing : 𝟙 → 𝟙 := λ square ⇒ square
+
+module Client
 import Monoid
 
 -- What left the module is closed, so a client instantiates it by application.
@@ -35,7 +43,10 @@ compute neutral 𝟙 tt
 compute square 𝟙 (λ x ⇒ λ y ⇒ x) tt
 compute flip tt
 
+-- A client gets no such help, and none is wanted: it is applying the constant
+-- to a monoid of its choosing.
 compute squareNeutral 𝟙 tt (λ x ⇒ λ y ⇒ x)
+compute shadowing tt
 
 -- And the discharged types say which parameters each one took.
 check neutral : Π (A : 𝕌) → Π (unit : A) → A

--- a/haskell/mltt/examples/parameters.mltt
+++ b/haskell/mltt/examples/parameters.mltt
@@ -1,0 +1,33 @@
+-- Module parameters, and discharge over the ones each declaration uses.
+--
+-- Everything in a parametrised module is checked with the parameters in scope,
+-- and leaves the module abstracted over exactly the parameters it turns out to
+-- need. An `over` clause states that set in the source; it is checked against
+-- the computed one rather than believed, so it can only reject a program.
+
+module Monoid (A : 𝕌) (unit : A) (mul : A → A → A) ;
+
+-- Uses `A` and `mul`, and not `unit`.
+def square over (A, mul) : A → A := λ x ⇒ mul x x
+
+-- Uses `A` and `unit`. Note that `A` is used even though it appears nowhere in
+-- the body: keeping `unit` puts its type into the discharged type, and that
+-- type mentions `A`. Relevance is upward closed in the telescope, and discharge
+-- gets that for free by asking about one parameter at a time, from the inside.
+def neutral over (A, unit) : A := unit
+
+-- Uses no parameter at all, so it is discharged over nothing and stays an
+-- ordinary constant. A client applies it to no arguments.
+def flip : 𝟙 → 𝟙 := λ x ⇒ x
+
+module Client ;
+import Monoid
+
+-- What left the module is closed, so a client instantiates it by application.
+compute neutral 𝟙 tt
+compute square 𝟙 (λ x ⇒ λ y ⇒ x) tt
+compute flip tt
+
+-- And the discharged types say which parameters each one took.
+check neutral : Π (A : 𝕌) → Π (unit : A) → A
+check flip : 𝟙 → 𝟙

--- a/haskell/mltt/examples/parameters.mltt
+++ b/haskell/mltt/examples/parameters.mltt
@@ -20,6 +20,13 @@ def neutral over (A, unit) : A := unit
 -- ordinary constant. A client applies it to no arguments.
 def flip : 𝟙 → 𝟙 := λ x ⇒ x
 
+-- A declaration is closed at the point it is defined, and not when the module
+-- ends. So a later declaration in the same module sees an earlier one already
+-- closed, and applies it to the parameters it was closed over. The telescope is
+-- not put back automatically, and `square` and `neutral` take different
+-- prefixes of it.
+def squareNeutral over (A, unit, mul) : A := square A mul (neutral A unit)
+
 module Client ;
 import Monoid
 
@@ -27,6 +34,8 @@ import Monoid
 compute neutral 𝟙 tt
 compute square 𝟙 (λ x ⇒ λ y ⇒ x) tt
 compute flip tt
+
+compute squareNeutral 𝟙 tt (λ x ⇒ λ y ⇒ x)
 
 -- And the discharged types say which parameters each one took.
 check neutral : Π (A : 𝕌) → Π (unit : A) → A

--- a/haskell/mltt/grammar/MLTT/Syntax.cf
+++ b/haskell/mltt/grammar/MLTT/Syntax.cf
@@ -31,20 +31,39 @@ token VarIdent letter (letter | digit | '_' | '\'' | '.')* ;
 AProgram. Program ::= [Module] ;
 terminator Module "" ;
 
-AModule.  Module ::= "module" VarIdent ";" [Import] [Decl] ;
+-- A module may take parameters. Every declaration inside it is checked with
+-- the parameters in scope, and is then discharged over exactly the ones it
+-- turns out to use, so a client applies it to those and to no others. See
+-- "Language.MLTT.Telescope".
+AModule.  Module ::= "module" VarIdent [Param] ";" [Import] [Decl] ;
+
+AParam.   Param ::= "(" VarIdent ":" Term ")" ;
+terminator Param "" ;
 
 AnImport. Import ::= "import" VarIdent ;
 terminator Import ";" ;
 
 -- * Declarations
 
-DeclDef.        Decl ::= "def" VarIdent ":" Term ":=" Term ;
-DeclPrivateDef. Decl ::= "private" "def" VarIdent ":" Term ":=" Term ;
+-- An `over` clause names the module parameters a declaration is discharged
+-- over. It is optional, and it is checked against the set computed during
+-- discharge rather than believed, so writing one can only reject a program,
+-- never change it.
+--
+-- It is deliberately not spelled `uses`, which in rzk is a mandatory clause
+-- listing the implicit assumptions of a definition. That is a different thing
+-- from a module parameter, and the two should not read alike.
+DeclDef.        Decl ::= "def" VarIdent Discharge ":" Term ":=" Term ;
+DeclPrivateDef. Decl ::= "private" "def" VarIdent Discharge ":" Term ":=" Term ;
 DeclNamespace.  Decl ::= "namespace" VarIdent "where" "{" [Decl] "}" ;
 DeclOpen.       Decl ::= "open" VarIdent ;
 DeclCheck.      Decl ::= "check" Term ":" Term ;
 DeclCompute.    Decl ::= "compute" Term ;
 separator Decl ";" ;
+
+NoDischarge.   Discharge ::= ;
+DischargeOver. Discharge ::= "over" "(" [VarIdent] ")" ;
+separator VarIdent "," ;
 
 -- * Terms
 --

--- a/haskell/mltt/mltt.cabal
+++ b/haskell/mltt/mltt.cabal
@@ -45,6 +45,7 @@ library
       Language.MLTT.Syntax.Lex
       Language.MLTT.Syntax.Par
       Language.MLTT.Syntax.Print
+      Language.MLTT.Telescope
       Language.MLTT.Typecheck
   other-modules:
       Paths_mltt
@@ -125,6 +126,7 @@ test-suite spec
   other-modules:
       Language.MLTT.ImplSpec
       Language.MLTT.ModulesSpec
+      Language.MLTT.ParametersSpec
       Paths_mltt
   hs-source-dirs:
       test

--- a/haskell/mltt/src/Language/MLTT/Impl.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl.hs
@@ -44,8 +44,9 @@ module Language.MLTT.Impl where
 import           Control.Monad                (foldM)
 import qualified Control.Monad.Foil           as Foil
 import           Data.Functor.Identity        (Identity (..))
-import           Control.Monad.Free.Foil      (UnresolvedName (..))
-import           Data.List                    (intercalate)
+import           Control.Monad.Free.Foil      (AST (Var), UnresolvedName (..),
+                                               substitute)
+import           Data.List                    (foldl', intercalate)
 import           Data.Map                     (Map)
 import qualified Data.Map                     as Map
 import qualified Data.Set                     as Set
@@ -89,11 +90,20 @@ data Env n = Env
     -- ^ What each module checked so far exports.
   , envDisplay  :: Display n Raw.VarIdent
     -- ^ What each top-level name is called.
+  , envClosedOver :: Table (Foil.Name n, [Raw.VarIdent])
+    -- ^ For each declaration of the module being checked, its name and the
+    -- parameters it was closed over. A reference to one of them from inside the
+    -- same module is put back together with those parameters; see 'reinstate'.
+    -- It is emptied at a module boundary, since a client sees the closed
+    -- constant and applies it itself.
+    --
+    -- The declaration's own 'Foil.Name' is recorded here, rather than looked up
+    -- by spelling later, because a module parameter may shadow the spelling.
   }
 
 -- | An empty environment, before any module is checked.
 emptyEnv :: Env Foil.VoidS
-emptyEnv = Env emptyCtx Map.empty Map.empty Map.empty Foil.emptyNameMap
+emptyEnv = Env emptyCtx Map.empty Map.empty Map.empty Foil.emptyNameMap Map.empty
 
 -- | Extend an environment with one top-level definition.
 --
@@ -113,6 +123,7 @@ extendEnv ctx binder full visibility env = Env
   , envExports  = export visibility full name (Foil.sinkContainer (envExports env))
   , envModules  = fmap Foil.sinkContainer (envModules env)
   , envDisplay  = Foil.addNameBinder binder full (envDisplay env)
+  , envClosedOver = Map.map (\(x, ps) -> (Foil.sink x, ps)) (envClosedOver env)
   }
   where
     name = Foil.nameOf binder
@@ -230,6 +241,7 @@ goModules env (m : ms) = EnteredModule (prettyVarIdent (moduleName m)) :
           [ Map.findWithDefault Map.empty x (envModules env)
           | Raw.AnImport _ x <- moduleImports m ]
       , envExports = Map.empty
+      , envClosedOver = Map.empty
       }
 
 -- | Record what a module exported, once it is checked.
@@ -279,6 +291,42 @@ withParams env (Raw.AParam _loc name rawTy : rest) onErr cont =
 -- | Elaborate a module's parameter types, reporting the first that fails.
 validateParams :: Foil.Distinct n => Env n -> [Raw.Param] -> Maybe String
 validateParams env params = withParams env params Just (\_tele _envP -> Nothing)
+
+-- | Put the module's parameters back into references to its own declarations.
+--
+-- A declaration is closed at the point it is defined, so a later one in the
+-- same module refers to a constant that expects the parameters it was closed
+-- over. Rather than making the source apply them, elaboration expands each such
+-- reference into that application.
+--
+-- It is a substitution, so the library sees to it that a local binder shadowing
+-- a declaration is left alone, and that nothing is captured. Outside the
+-- declaring module the table is empty and this is the identity, which is right:
+-- a client is handed a closed constant and instantiates it as it likes.
+--
+-- The substitution is built by mapping over 'envDisplay', which is total on the
+-- scope because every binder that extends the scope enters it. Nothing is ever
+-- inserted into a substitution by name, which would be a way to undo the
+-- shadowing that 'Foil.addRename' performs under a binder.
+reinstate
+  :: Foil.Distinct p
+  => Env p
+  -> Term p
+  -> Term p
+reinstate envP term
+  | Map.null closedOver = term
+  | otherwise = substitute (ctxScope (envCtx envP)) subst term
+  where
+    closedOver = envClosedOver envP
+    subst = Foil.nameMapToSubstitution (Foil.mapWithName expand (envDisplay envP))
+
+    expand name _spelling
+      | Just ps <- lookup name (Map.elems closedOver)
+      , Just args <- traverse (`Map.lookup` envDeclared envP) ps
+      = foldl' apply (Var name) args
+      | otherwise = Var name
+
+    apply f x = App Raw.BNFC'NoPosition f (Var x)
 
 -- | Report parameters a declaration needs that it is not being closed over.
 --
@@ -363,7 +411,7 @@ withDecls env params path (decl : decls) cont = case decl of
     withElaborated envP raws k =
       case traverse (tryToTerm' (ctxScope (envCtx envP)) (visibleAt path (envDeclared envP))) raws of
         Left err -> continue (Failed (notInScope err))
-        Right ts -> k (fmap desugar ts)
+        Right ts -> k (fmap (reinstate envP . desugar) ts)
 
     define loc visibility name over rawType rawValue =
       withParams env params (continue . Failed) $ \tele envP ->
@@ -382,7 +430,11 @@ withDecls env params path (decl : decls) cont = case decl of
                     Right () ->
                       withDefinition (envCtx env) ty' value' $ \ctx' binder ->
                         let full = qualify path name
-                            env' = extendEnv ctx' binder full visibility env
+                            env' = (extendEnv ctx' binder full visibility env)
+                              { envClosedOver = Map.insert full
+                                  (Foil.nameOf binder, over')
+                                  (Map.map (\(x, ps) -> (Foil.sink x, ps))
+                                           (envClosedOver env)) }
                          in withDecls env' params path decls $ \env'' rest ->
                               cont env''
                                 (Defined (prettyVarIdent full) (map prettyVarIdent over') : rest)

--- a/haskell/mltt/src/Language/MLTT/Impl.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl.hs
@@ -54,6 +54,7 @@ import           Language.MLTT.FreeFoilConfig (intToVarIdent)
 import           Language.MLTT.Impl.Generated
 import           Language.MLTT.Resolve
 import qualified Language.MLTT.Syntax.Abs     as Raw
+import           Language.MLTT.Telescope
 import           Language.MLTT.Typecheck
 import           System.Exit                  (exitFailure)
 
@@ -126,7 +127,8 @@ display env = showTermWith intToVarIdent (envDisplay env)
 -- | What interpreting one declaration produced.
 data CommandResult
   = EnteredModule String      -- ^ A module was reached in build order.
-  | Defined String            -- ^ @def@ succeeded, for the fully qualified name.
+  | Defined String [String]   -- ^ @def@ succeeded, for the fully qualified name
+                              -- and the module parameters it was discharged over.
   | Checked String String     -- ^ @check@ succeeded, for a term and its type.
   | Computed String           -- ^ @compute@ succeeded, with the normal form.
   | Failed String             -- ^ The declaration was rejected.
@@ -142,7 +144,9 @@ succeeded = all $ \case
 renderResult :: CommandResult -> String
 renderResult = \case
   EnteredModule name -> "module " <> name
-  Defined name       -> "  ✓ defined " <> name
+  Defined name []    -> "  ✓ defined " <> name
+  Defined name used  -> "  ✓ defined " <> name
+                          <> " over (" <> intercalate ", " used <> ")"
   Checked term ty    -> "  ✓ " <> term <> " : " <> ty
   Computed term      -> "  ↦ " <> term
   Failed err         -> "  ✗ " <> err
@@ -176,15 +180,19 @@ buildOrder modules
 
 -- | The name of a module.
 moduleName :: Raw.Module -> Raw.VarIdent
-moduleName (Raw.AModule _ name _ _) = name
+moduleName (Raw.AModule _ name _ _ _) = name
+
+-- | The parameters of a module.
+moduleParams :: Raw.Module -> [Raw.Param]
+moduleParams (Raw.AModule _ _ params _ _) = params
 
 -- | The imports of a module.
 moduleImports :: Raw.Module -> [Raw.Import]
-moduleImports (Raw.AModule _ _ imports _) = imports
+moduleImports (Raw.AModule _ _ _ imports _) = imports
 
 -- | The declarations of a module.
 moduleDecls :: Raw.Module -> [Raw.Decl]
-moduleDecls (Raw.AModule _ _ _ decls) = decls
+moduleDecls (Raw.AModule _ _ _ _ decls) = decls
 
 -- * Interpreting a program
 
@@ -202,13 +210,18 @@ interpretModules modules = case buildOrder modules of
   Right ordered -> goModules emptyEnv ordered
 
 -- | Check each module in turn, in the growing top-level scope.
+--
+-- A module's parameters are elaborated once here, before its declarations, so
+-- that a parameter block that does not resolve is reported once rather than
+-- against every declaration that would have been checked under it.
 goModules :: Foil.Distinct n => Env n -> [Raw.Module] -> [CommandResult]
 goModules _env [] = []
-goModules env (m : ms) =
-    withDecls env' [] (moduleDecls m) $ \env'' results ->
-      EnteredModule (prettyVarIdent (moduleName m))
-        : results
-        <> goModules (finishModule (moduleName m) env'') ms
+goModules env (m : ms) = EnteredModule (prettyVarIdent (moduleName m)) :
+    case validateParams env' (moduleParams m) of
+      Just err -> Failed err : goModules env ms
+      Nothing ->
+        withDecls env' (moduleParams m) [] (moduleDecls m) $ \env'' results ->
+          results <> goModules (finishModule (moduleName m) env'') ms
   where
     -- An import contributes the exporting module's public names, under the
     -- spellings it exported them with. Nothing else crosses a module boundary.
@@ -233,54 +246,102 @@ finishModule name env =
 data Two a = Two a a
   deriving (Functor, Foldable, Traversable)
 
+-- | Allocate a module's parameters, extending the environment with them.
+--
+-- Parameters are allocated afresh for each declaration rather than once for the
+-- module, because a declaration is added to the module's own scope after being
+-- discharged, and a name allocated there would otherwise collide with a
+-- parameter allocated before it. Re-elaborating a parameter block costs a few
+-- small terms and buys a scope that grows only by definitions.
+--
+-- A parameter is nameable by its bare spelling and is not exported, which is
+-- exactly what 'extendEnv' does for a private declaration.
+withParams
+  :: forall n r. Foil.Distinct n
+  => Env n
+  -> [Raw.Param]
+  -> (String -> r)        -- ^ A parameter's type did not resolve.
+  -> (forall p. Foil.DExt n p
+        => Telescope Raw.BNFC'Position n p -> Env p -> r)
+  -> r
+withParams env [] _onErr cont = cont TelescopeEmpty env
+withParams env (Raw.AParam _loc name rawTy : rest) onErr cont =
+  case tryToTerm' (ctxScope ctx) (visibleAt [] (envDeclared env)) rawTy of
+    Left err -> onErr (notInScope err)
+    Right raw ->
+      let ty = desugar raw
+       in withVarBinder ctx ty $ \ctx' binder ->
+            withParams (extendEnv ctx' binder name Private env) rest onErr $
+              \tele envP -> cont (TelescopeCons name ty (ctxScope ctx) binder tele) envP
+  where
+    ctx = envCtx env
+
+-- | Elaborate a module's parameter types, reporting the first that fails.
+validateParams :: Foil.Distinct n => Env n -> [Raw.Param] -> Maybe String
+validateParams env params = withParams env params Just (\_tele _envP -> Nothing)
+
+-- | Report an identifier that did not resolve, with any near spellings.
+notInScope :: UnresolvedName Raw.VarIdent -> String
+notInScope (UnresolvedName x inScope) =
+  case suggestions x inScope of
+    []    -> "not in scope: " <> prettyVarIdent x
+    hints -> "not in scope: " <> prettyVarIdent x
+               <> "; did you mean " <> intercalate ", " (map prettyVarIdent hints) <> "?"
+
 -- | Check a block of declarations at a namespace path.
 --
 -- The path is lexical, so a nested @namespace@ is just a recursive call with a
 -- longer path, and leaving it needs no bookkeeping: the qualified names stay in
 -- 'envDeclared' and the bare spellings were never stored, only computed by
 -- 'visibleAt'.
+--
+-- Every declaration is checked with the module's parameters in scope, and a
+-- @def@ is then discharged over the ones it uses, so that what is added to the
+-- environment lives in the parameter-free scope the module started in.
 withDecls
   :: forall n r. Foil.Distinct n
   => Env n
+  -> [Raw.Param]          -- ^ The parameters of the enclosing module.
   -> Path                 -- ^ The namespace path these declarations sit at.
   -> [Raw.Decl]
   -> (forall l. Foil.DExt n l => Env l -> [CommandResult] -> r)
   -> r
-withDecls env _path [] cont = cont env []
-withDecls env path (decl : decls) cont = case decl of
+withDecls env _params _path [] cont = cont env []
+withDecls env params path (decl : decls) cont = case decl of
 
-  Raw.DeclDef _loc name ty value        -> define Public name ty value
-  Raw.DeclPrivateDef _loc name ty value -> define Private name ty value
+  Raw.DeclDef loc name over ty value        -> define loc Public name over ty value
+  Raw.DeclPrivateDef loc name over ty value -> define loc Private name over ty value
 
   Raw.DeclNamespace _loc name inner ->
-    withDecls env (path <> segments name) inner $ \envInner innerResults ->
-      withDecls envInner path decls $ \envAfter rest ->
+    withDecls env params (path <> segments name) inner $ \envInner innerResults ->
+      withDecls envInner params path decls $ \envAfter rest ->
         cont envAfter (innerResults <> rest)
 
   Raw.DeclOpen _loc name ->
     withDecls (env { envDeclared = openNamespace (qualify path name) (envDeclared env) })
-              path decls cont
+              params path decls cont
 
   Raw.DeclCheck _loc rawTerm rawType ->
-    withElaborated (Two rawTerm rawType) $ \(Two term ty) ->
-      case check ctx ty universe >> check ctx term ty of
-        Left err -> continue (Failed err)
-        Right () -> continue (Checked (display' term) (display' ty))
+    withParams env params (continue . Failed) $ \_tele envP ->
+      withElaborated envP (Two rawTerm rawType) $ \(Two term ty) ->
+        case check (envCtx envP) ty universe >> check (envCtx envP) term ty of
+          Left err -> continue (Failed err)
+          Right () -> continue (Checked (display envP term) (display envP ty))
 
   Raw.DeclCompute _loc rawTerm ->
-    withElaborated (Identity rawTerm) $ \(Identity term) ->
-      case infer ctx term of
-        Left err  -> continue (Failed err)
-        Right _ty -> continue (Computed (display' (nf (ctxScope ctx) (ctxDefs ctx) term)))
+    withParams env params (continue . Failed) $ \_tele envP ->
+      withElaborated envP (Identity rawTerm) $ \(Identity term) ->
+        let ctxP = envCtx envP
+         in case infer ctxP term of
+              Left err  -> continue (Failed err)
+              Right _ty -> continue
+                (Computed (display envP (nf (ctxScope ctxP) (ctxDefs ctxP) term)))
 
   where
-    ctx = envCtx env
     universe = Universe Raw.BNFC'NoPosition
-    display' = display env
-    visible = visibleAt path (envDeclared env)
 
     -- Continue with the remaining declarations, with one result in front.
-    continue result = withDecls env path decls $ \env' rest -> cont env' (result : rest)
+    continue result = withDecls env params path decls $ \env' rest -> cont env' (result : rest)
 
     -- Convert some raw terms, or report the identifiers that do not resolve.
     --
@@ -288,34 +349,43 @@ withDecls env path (decl : decls) cont = case decl of
     -- declaration that needs two of them asks with 'Two' and is handed back a
     -- 'Two'.
     withElaborated
-      :: Traversable f => f Raw.Term -> (f (Term n) -> r) -> r
-    withElaborated raws k =
-      case traverse (tryToTerm' (ctxScope ctx) visible) raws of
+      :: forall p f. (Foil.Distinct p, Traversable f)
+      => Env p -> f Raw.Term -> (f (Term p) -> r) -> r
+    withElaborated envP raws k =
+      case traverse (tryToTerm' (ctxScope (envCtx envP)) (visibleAt path (envDeclared envP))) raws of
         Left err -> continue (Failed (notInScope err))
-        Right ts  -> k (fmap desugar ts)
+        Right ts -> k (fmap desugar ts)
 
-    notInScope (UnresolvedName x inScope) =
-      case suggestions x inScope of
-        []    -> "not in scope: " <> prettyVarIdent x
-        hints -> "not in scope: " <> prettyVarIdent x
-                   <> "; did you mean " <> intercalate ", " (map prettyVarIdent hints) <> "?"
-
-    define visibility name rawType rawValue =
-      withElaborated (Two rawType rawValue) $ \(Two ty value) ->
-        case check ctx ty universe >> check ctx value ty of
-          Left err -> continue (Failed err)
-          Right () ->
-            withDefinition ctx ty value $ \ctx' binder ->
-              let full = qualify path name
-                  env' = extendEnv ctx' binder full visibility env
-               in withDecls env' path decls $ \env'' rest ->
-                    cont env'' (Defined (prettyVarIdent full) : rest)
-
--- | Show a raw identifier as it was written.
-prettyVarIdent :: Raw.VarIdent -> String
-prettyVarIdent (Raw.VarIdent x) = x
+    define loc visibility name over rawType rawValue =
+      withParams env params (continue . Failed) $ \tele envP ->
+        withElaborated envP (Two rawType rawValue) $ \(Two ty value) ->
+          case check (envCtx envP) ty universe >> check (envCtx envP) value ty of
+            Left err -> continue (Failed err)
+            Right () ->
+              -- The discharged pair is well-typed by construction: abstracting a
+              -- checked term over a variable of a checked type is Π- and
+              -- λ-introduction, so it is not checked again here.
+              let Discharged ty' value' over' = discharge loc tele ty value
+               in case checkDischarge over over' of
+                    Left err -> continue (Failed err)
+                    Right () ->
+                      withDefinition (envCtx env) ty' value' $ \ctx' binder ->
+                        let full = qualify path name
+                            env' = extendEnv ctx' binder full visibility env
+                         in withDecls env' params path decls $ \env'' rest ->
+                              cont env''
+                                (Defined (prettyVarIdent full) (map prettyVarIdent over') : rest)
 
 -- | Parse and interpret one source.
+--
+-- >>> let report = mapM_ (putStrLn . renderResult) . either error id . interpret
+-- >>> report (unlines ["module M (A : 𝕌) (x : A)", "def k : A → A := λ y ⇒ y", "def one : A := x"])
+-- module M
+--   ✓ defined k over (A)
+--   ✓ defined one over (A, x)
+--
+-- Each declaration is discharged over the parameters it uses and no others, so
+-- what a client sees is a closed definition it applies for itself.
 interpret :: String -> Either String [CommandResult]
 interpret input = interpretProgram <$> parseProgram input
 

--- a/haskell/mltt/src/Language/MLTT/Impl.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl.hs
@@ -272,13 +272,22 @@ withParams env (Raw.AParam _loc name rawTy : rest) onErr cont =
       let ty = desugar raw
        in withVarBinder ctx ty $ \ctx' binder ->
             withParams (extendEnv ctx' binder name Private env) rest onErr $
-              \tele envP -> cont (TelescopeCons name ty (ctxScope ctx) binder tele) envP
+              \tele envP -> cont (TelescopeCons name ty binder tele) envP
   where
     ctx = envCtx env
 
 -- | Elaborate a module's parameter types, reporting the first that fails.
 validateParams :: Foil.Distinct n => Env n -> [Raw.Param] -> Maybe String
 validateParams env params = withParams env params Just (\_tele _envP -> Nothing)
+
+-- | Report parameters a declaration needs that it is not being closed over.
+--
+-- With the computed set this cannot arise, since that set is closed. It is the
+-- answer for a caller that supplies a set of its own.
+needsParameters :: [Raw.VarIdent] -> String
+needsParameters names =
+  "declaration needs module parameters it is not closed over: "
+    <> intercalate ", " (map prettyVarIdent names)
 
 -- | Report an identifier that did not resolve, with any near spellings.
 notInScope :: UnresolvedName Raw.VarIdent -> String
@@ -365,8 +374,10 @@ withDecls env params path (decl : decls) cont = case decl of
               -- The discharged pair is well-typed by construction: abstracting a
               -- checked term over a variable of a checked type is Π- and
               -- λ-introduction, so it is not checked again here.
-              let Discharged ty' value' over' = discharge loc tele ty value
-               in case checkDischarge over over' of
+              case discharge loc (ctxScope (envCtx env)) tele Nothing ty value of
+                Left missing -> continue (Failed (needsParameters missing))
+                Right (Discharged ty' value' over') ->
+                  case checkDischarge over over' of
                     Left err -> continue (Failed err)
                     Right () ->
                       withDefinition (envCtx env) ty' value' $ \ctx' binder ->

--- a/haskell/mltt/src/Language/MLTT/Resolve.hs
+++ b/haskell/mltt/src/Language/MLTT/Resolve.hs
@@ -66,6 +66,13 @@ segments (Raw.VarIdent x) = split x
       (seg, [])       -> [seg]
       (seg, _ : rest) -> seg : split rest
 
+-- | Show a raw identifier as it was written.
+--
+-- >>> prettyVarIdent (Raw.VarIdent "Data.Nat.zero")
+-- "Data.Nat.zero"
+prettyVarIdent :: Raw.VarIdent -> String
+prettyVarIdent (Raw.VarIdent x) = x
+
 -- | Join segments back into an identifier.
 --
 -- >>> joinSegments ["Data","Nat","zero"]

--- a/haskell/mltt/src/Language/MLTT/Syntax/Abs.hs
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Abs.hs
@@ -28,7 +28,12 @@ data Program' a = AProgram a [Module' a]
   deriving (C.Eq, C.Ord, C.Show, C.Read, C.Functor, C.Foldable, C.Traversable, C.Data, C.Typeable, C.Generic)
 
 type Module = Module' BNFC'Position
-data Module' a = AModule a VarIdent [Import' a] [Decl' a]
+data Module' a
+    = AModule a VarIdent [Param' a] [Import' a] [Decl' a]
+  deriving (C.Eq, C.Ord, C.Show, C.Read, C.Functor, C.Foldable, C.Traversable, C.Data, C.Typeable, C.Generic)
+
+type Param = Param' BNFC'Position
+data Param' a = AParam a VarIdent (Term' a)
   deriving (C.Eq, C.Ord, C.Show, C.Read, C.Functor, C.Foldable, C.Traversable, C.Data, C.Typeable, C.Generic)
 
 type Import = Import' BNFC'Position
@@ -37,12 +42,16 @@ data Import' a = AnImport a VarIdent
 
 type Decl = Decl' BNFC'Position
 data Decl' a
-    = DeclDef a VarIdent (Term' a) (Term' a)
-    | DeclPrivateDef a VarIdent (Term' a) (Term' a)
+    = DeclDef a VarIdent (Discharge' a) (Term' a) (Term' a)
+    | DeclPrivateDef a VarIdent (Discharge' a) (Term' a) (Term' a)
     | DeclNamespace a VarIdent [Decl' a]
     | DeclOpen a VarIdent
     | DeclCheck a (Term' a) (Term' a)
     | DeclCompute a (Term' a)
+  deriving (C.Eq, C.Ord, C.Show, C.Read, C.Functor, C.Foldable, C.Traversable, C.Data, C.Typeable, C.Generic)
+
+type Discharge = Discharge' BNFC'Position
+data Discharge' a = NoDischarge a | DischargeOver a [VarIdent]
   deriving (C.Eq, C.Ord, C.Show, C.Read, C.Functor, C.Foldable, C.Traversable, C.Data, C.Typeable, C.Generic)
 
 type Term = Term' BNFC'Position
@@ -102,7 +111,11 @@ instance HasPosition Program where
 
 instance HasPosition Module where
   hasPosition = \case
-    AModule p _ _ _ -> p
+    AModule p _ _ _ _ -> p
+
+instance HasPosition Param where
+  hasPosition = \case
+    AParam p _ _ -> p
 
 instance HasPosition Import where
   hasPosition = \case
@@ -110,12 +123,17 @@ instance HasPosition Import where
 
 instance HasPosition Decl where
   hasPosition = \case
-    DeclDef p _ _ _ -> p
-    DeclPrivateDef p _ _ _ -> p
+    DeclDef p _ _ _ _ -> p
+    DeclPrivateDef p _ _ _ _ -> p
     DeclNamespace p _ _ -> p
     DeclOpen p _ -> p
     DeclCheck p _ _ -> p
     DeclCompute p _ -> p
+
+instance HasPosition Discharge where
+  hasPosition = \case
+    NoDischarge p -> p
+    DischargeOver p _ -> p
 
 instance HasPosition Term where
   hasPosition = \case

--- a/haskell/mltt/src/Language/MLTT/Syntax/Doc.txt
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Doc.txt
@@ -23,16 +23,16 @@ The set of reserved words is the set of terminals appearing in the grammar. Thos
 The reserved words used in Syntax are the following:
   | ``Id`` | ``J`` | ``check`` | ``compute``
   | ``def`` | ``import`` | ``in`` | ``let``
-  | ``module`` | ``namespace`` | ``open`` | ``private``
-  | ``refl`` | ``tt`` | ``where`` | ``Π``
-  | ``Σ`` | ``λ`` | ``π₁`` | ``π₂``
-  | ``𝕌`` |  |  |
+  | ``module`` | ``namespace`` | ``open`` | ``over``
+  | ``private`` | ``refl`` | ``tt`` | ``where``
+  | ``Π`` | ``Σ`` | ``λ`` | ``π₁``
+  | ``π₂`` | ``𝕌`` |  |
 
 The symbols used in Syntax are the following:
-  | ; | : | := | {
-  | } | ( | ) | →
-  | × | ⇒ | = | 𝟙
-  | , | _ |  |
+  | ; | ( | : | )
+  | := | { | } | ,
+  | → | × | ⇒ | =
+  | 𝟙 | _ |  |
 
 ===Comments===
 Single-line comments begin with --.Multiple-line comments are  enclosed with {- and -}.
@@ -46,12 +46,15 @@ All other symbols are terminals.
   | //Program// | -> | //[Module]//
   | //[Module]// | -> | **eps**
   |  |  **|**  | //Module// //[Module]//
-  | //Module// | -> | ``module`` //VarIdent// ``;`` //[Import]// //[Decl]//
+  | //Module// | -> | ``module`` //VarIdent// //[Param]// ``;`` //[Import]// //[Decl]//
+  | //Param// | -> | ``(`` //VarIdent// ``:`` //Term// ``)``
+  | //[Param]// | -> | **eps**
+  |  |  **|**  | //Param// //[Param]//
   | //Import// | -> | ``import`` //VarIdent//
   | //[Import]// | -> | **eps**
   |  |  **|**  | //Import// ``;`` //[Import]//
-  | //Decl// | -> | ``def`` //VarIdent// ``:`` //Term// ``:=`` //Term//
-  |  |  **|**  | ``private`` ``def`` //VarIdent// ``:`` //Term// ``:=`` //Term//
+  | //Decl// | -> | ``def`` //VarIdent// //Discharge// ``:`` //Term// ``:=`` //Term//
+  |  |  **|**  | ``private`` ``def`` //VarIdent// //Discharge// ``:`` //Term// ``:=`` //Term//
   |  |  **|**  | ``namespace`` //VarIdent// ``where`` ``{`` //[Decl]// ``}``
   |  |  **|**  | ``open`` //VarIdent//
   |  |  **|**  | ``check`` //Term// ``:`` //Term//
@@ -59,6 +62,11 @@ All other symbols are terminals.
   | //[Decl]// | -> | **eps**
   |  |  **|**  | //Decl//
   |  |  **|**  | //Decl// ``;`` //[Decl]//
+  | //Discharge// | -> | **eps**
+  |  |  **|**  | ``over`` ``(`` //[VarIdent]// ``)``
+  | //[VarIdent]// | -> | **eps**
+  |  |  **|**  | //VarIdent//
+  |  |  **|**  | //VarIdent// ``,`` //[VarIdent]//
   | //Term// | -> | ``Π`` ``(`` //Pattern// ``:`` //Term// ``)`` ``→`` //ScopedTerm//
   |  |  **|**  | ``Σ`` ``(`` //Pattern// ``:`` //Term// ``)`` ``×`` //ScopedTerm//
   |  |  **|**  | ``λ`` //Pattern// ``⇒`` //ScopedTerm//

--- a/haskell/mltt/src/Language/MLTT/Syntax/Layout.hs
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Layout.hs
@@ -27,8 +27,8 @@ data LayoutDelimiters
     }
 
 layoutWords :: [(TokSymbol, LayoutDelimiters)]
-layoutWords = [( TokSymbol "where" 23
-               , LayoutDelimiters (TokSymbol ";" 6) (Just (TokSymbol "{" 24)) (Just (TokSymbol "}" 25))
+layoutWords = [( TokSymbol "where" 24
+               , LayoutDelimiters (TokSymbol ";" 6) (Just (TokSymbol "{" 25)) (Just (TokSymbol "}" 26))
                )]
 
 layoutStopWords :: [TokSymbol]

--- a/haskell/mltt/src/Language/MLTT/Syntax/Lex.hs
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Lex.hs
@@ -4858,22 +4858,23 @@ eitherResIdent tv s = treeFind resWords
 -- | The keywords and symbols of the language organized as binary search tree.
 resWords :: BTree
 resWords =
-  b "namespace" 18
-    (b "J" 9
+  b "open" 19
+    (b "_" 10
        (b ":=" 5
           (b "," 3 (b ")" 2 (b "(" 1 N N) N) (b ":" 4 N N))
-          (b "=" 7 (b ";" 6 N N) (b "Id" 8 N N)))
-       (b "import" 14
-          (b "compute" 12 (b "check" 11 (b "_" 10 N N) N) (b "def" 13 N N))
-          (b "let" 16 (b "in" 15 N N) (b "module" 17 N N))))
-    (b "\928" 27
-       (b "where" 23
-          (b "refl" 21 (b "private" 20 (b "open" 19 N N) N) (b "tt" 22 N N))
-          (b "}" 25 (b "{" 24 N N) (b "\215" 26 N N)))
-       (b "\8594" 32
-          (b "\960\8321" 30
-             (b "\955" 29 (b "\931" 28 N N) N) (b "\960\8322" 31 N N))
-          (b "\120140" 34 (b "\8658" 33 N N) (b "\120793" 35 N N))))
+          (b "Id" 8 (b "=" 7 (b ";" 6 N N) N) (b "J" 9 N N)))
+       (b "in" 15
+          (b "def" 13
+             (b "compute" 12 (b "check" 11 N N) N) (b "import" 14 N N))
+          (b "module" 17 (b "let" 16 N N) (b "namespace" 18 N N))))
+    (b "\928" 28
+       (b "where" 24
+          (b "refl" 22 (b "private" 21 (b "over" 20 N N) N) (b "tt" 23 N N))
+          (b "}" 26 (b "{" 25 N N) (b "\215" 27 N N)))
+       (b "\8594" 33
+          (b "\960\8321" 31
+             (b "\955" 30 (b "\931" 29 N N) N) (b "\960\8322" 32 N N))
+          (b "\120140" 35 (b "\8658" 34 N N) (b "\120793" 36 N N))))
   where
   b s n = B bs (TS bs n)
     where

--- a/haskell/mltt/src/Language/MLTT/Syntax/Par.hs
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Par.hs
@@ -8,10 +8,14 @@ module Language.MLTT.Syntax.Par
   , pProgram
   , pListModule
   , pModule
+  , pParam
+  , pListParam
   , pImport
   , pListImport
   , pDecl
   , pListDecl
+  , pDischarge
+  , pListVarIdent
   , pTerm
   , pTerm1
   , pTerm2
@@ -33,17 +37,21 @@ import Control.Monad (ap)
 data HappyAbsSyn 
 	= HappyTerminal (Token)
 	| HappyErrorToken Prelude.Int
-	| HappyAbsSyn15 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.VarIdent))
-	| HappyAbsSyn16 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Program))
-	| HappyAbsSyn17 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Module]))
-	| HappyAbsSyn18 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Module))
-	| HappyAbsSyn19 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Import))
-	| HappyAbsSyn20 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Import]))
-	| HappyAbsSyn21 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Decl))
-	| HappyAbsSyn22 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Decl]))
-	| HappyAbsSyn23 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Term))
-	| HappyAbsSyn26 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.ScopedTerm))
-	| HappyAbsSyn27 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Pattern))
+	| HappyAbsSyn19 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.VarIdent))
+	| HappyAbsSyn20 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Program))
+	| HappyAbsSyn21 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Module]))
+	| HappyAbsSyn22 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Module))
+	| HappyAbsSyn23 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Param))
+	| HappyAbsSyn24 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Param]))
+	| HappyAbsSyn25 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Import))
+	| HappyAbsSyn26 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Import]))
+	| HappyAbsSyn27 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Decl))
+	| HappyAbsSyn28 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Decl]))
+	| HappyAbsSyn29 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Discharge))
+	| HappyAbsSyn30 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.VarIdent]))
+	| HappyAbsSyn31 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Term))
+	| HappyAbsSyn34 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.ScopedTerm))
+	| HappyAbsSyn35 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Pattern))
 
 {- to allow type-synonyms as our monads (likely
  - with explicitly-specified bind and return)
@@ -206,7 +214,32 @@ action_0,
  action_143,
  action_144,
  action_145,
- action_146 :: () => Prelude.Int -> ({-HappyReduction (Err) = -}
+ action_146,
+ action_147,
+ action_148,
+ action_149,
+ action_150,
+ action_151,
+ action_152,
+ action_153,
+ action_154,
+ action_155,
+ action_156,
+ action_157,
+ action_158,
+ action_159,
+ action_160,
+ action_161,
+ action_162,
+ action_163,
+ action_164,
+ action_165,
+ action_166,
+ action_167,
+ action_168,
+ action_169,
+ action_170,
+ action_171 :: () => Prelude.Int -> ({-HappyReduction (Err) = -}
 	   Prelude.Int 
 	-> (Token)
 	-> HappyState (Token) (HappyStk HappyAbsSyn -> [(Token)] -> (Err) HappyAbsSyn)
@@ -214,11 +247,7 @@ action_0,
 	-> HappyStk HappyAbsSyn 
 	-> [(Token)] -> (Err) HappyAbsSyn)
 
-happyReduce_12,
- happyReduce_13,
- happyReduce_14,
- happyReduce_15,
- happyReduce_16,
+happyReduce_16,
  happyReduce_17,
  happyReduce_18,
  happyReduce_19,
@@ -255,7 +284,19 @@ happyReduce_12,
  happyReduce_50,
  happyReduce_51,
  happyReduce_52,
- happyReduce_53 :: () => ({-HappyReduction (Err) = -}
+ happyReduce_53,
+ happyReduce_54,
+ happyReduce_55,
+ happyReduce_56,
+ happyReduce_57,
+ happyReduce_58,
+ happyReduce_59,
+ happyReduce_60,
+ happyReduce_61,
+ happyReduce_62,
+ happyReduce_63,
+ happyReduce_64,
+ happyReduce_65 :: () => ({-HappyReduction (Err) = -}
 	   Prelude.Int 
 	-> (Token)
 	-> HappyState (Token) (HappyStk HappyAbsSyn -> [(Token)] -> (Err) HappyAbsSyn)
@@ -264,1487 +305,1656 @@ happyReduce_12,
 	-> [(Token)] -> (Err) HappyAbsSyn)
 
 happyExpList :: Happy_Data_Array.Array Prelude.Int Prelude.Int
-happyExpList = Happy_Data_Array.listArray (0,325) ([0,0,2048,0,0,0,2048,0,0,0,2048,0,0,0,256,0,0,0,256,0,0,0,28896,0,0,0,28896,0,0,2048,33804,29665,0,2048,32780,29441,0,2048,32780,29441,0,2048,33804,29665,0,2048,16,16384,0,0,0,16384,0,0,0,0,0,0,0,0,0,0,0,0,0,2048,16,16384,0,0,0,0,0,0,0,0,0,0,0,0,0,2048,32780,30481,0,0,0,0,0,0,0,0,0,2048,33804,29665,0,2048,0,0,0,2048,0,0,0,2048,16,16384,0,2048,0,0,0,0,0,0,0,2048,0,0,0,2048,0,0,0,2048,16,16384,0,2048,32780,29441,0,2048,32780,29441,0,0,0,0,0,0,0,0,0,0,0,0,0,2048,32780,29441,0,0,0,0,0,0,1,0,0,0,0,0,0,2048,33804,29665,0,2048,33804,29665,0,0,0,16384,0,0,0,16384,0,0,0,16384,0,0,128,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,16384,0,0,0,0,0,0,0,0,0,0,0,16384,0,0,0,0,0,0,2048,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,256,0,0,0,0,16384,0,0,0,0,0,0,0,2,0,16384,0,0,0,0,0,0,0,16384,0,0,0,0,28896,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2048,0,2048,16,16384,0,2048,16,16384,0,2048,33804,29665,0,0,2,0,0,2048,33804,29665,0,2048,33804,29665,0,28672,0,0,0,2048,33804,29665,0,2048,33804,29665,0,8192,0,0,0,2048,16,16384,0,0,0,0,0,0,0,0,0,0,0,0,0,2048,33804,29665,0,2048,33804,29665,0,8192,0,0,0,8192,0,0,0,2048,33804,29665,0,4096,0,0,0,16384,0,0,0,16384,0,0,0,2048,33804,29665,0,0,0,0,0,2048,33804,29665,0,2048,33804,29665,0,0,0,4,0,16384,0,0,0,0,0,0,0,0,256,0,0,0,28896,0,0,2048,33804,29665,0,0,28896,0,0,32768,0,0,0,0,0,0,0,0,0,0,0,2048,33804,29665,0,2048,33804,29665,0,0,0,0,0,0,512,0,0,2048,33804,29665,0,2048,33804,29665,0,4096,0,0,0,4096,0,0,0,4096,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8192,0,0,0,8192,0,0,0,2048,33804,29665,0,4096,0,0,0,4096,0,0,0,2048,33804,29665,0,0,0,8,0,32768,0,0,0,0,0,0,0,2048,33804,29665,0,0,0,0,0,0,0,0,0,0,0,16,0,0,0,1024,0,0,0,0,0,2048,33804,29665,0,2048,33804,29665,0,4096,0,0,0,4096,0,0,0,2048,33804,29665,0,2048,33804,29665,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+happyExpList = Happy_Data_Array.listArray (0,361) ([0,0,0,8,0,0,0,4096,0,0,0,0,32,0,0,16384,0,0,0,0,128,0,0,0,0,8192,0,0,0,0,64,0,0,0,28672,88,0,0,0,45280,0,0,0,0,128,0,0,0,0,0,2,0,24640,6176,1854,0,32768,192,24624,14,0,33024,24577,7360,0,0,770,61633,57,0,1024,8,16384,0,0,0,0,128,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,128,1,2048,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2048,12,60963,0,0,0,0,0,0,0,0,0,0,0,24640,6176,1854,0,32768,0,0,0,0,256,0,0,0,0,1026,0,32,0,1024,0,0,0,0,0,0,0,0,4096,0,0,0,0,32,0,0,0,16384,128,0,4,0,49280,12288,3680,0,0,385,49248,28,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,6160,1536,460,0,0,0,0,0,0,256,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,32768,0,0,0,0,0,0,0,0,4096,2072,53126,1,0,12320,3088,927,0,0,0,0,4,0,0,0,2048,0,0,0,0,16,0,0,32,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,32768,0,0,0,0,0,0,0,0,0,0,0,32,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,16384,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,16384,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8,0,0,0,0,0,8,0,0,0,0,0,0,0,256,0,0,0,8192,0,0,0,0,0,0,0,32768,0,0,0,0,32768,707,0,0,0,0,0,4,0,0,0,2048,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4096,0,0,8208,0,256,0,8192,64,0,2,0,24640,6176,1854,0,0,32,0,0,0,33024,24705,7416,0,0,770,61633,57,0,14336,0,0,0,0,3080,49924,231,0,4096,2072,53126,1,0,128,0,0,0,16384,128,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1540,57730,115,0,2048,1036,59331,0,0,64,0,0,0,32768,0,0,0,0,24640,6176,1854,0,0,1,0,0,0,2048,0,0,0,0,16,0,0,0,1024,33286,29665,0,0,0,0,0,0,8192,0,0,0,0,0,0,0,0,16384,8288,15896,7,0,1024,0,0,0,0,0,256,0,0,0,4096,0,0,0,0,0,0,0,2048,1036,59331,0,0,512,0,0,0,0,1024,0,0,0,128,0,0,0,0,4,0,0,0,0,5660,0,0,0,770,61633,57,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,12320,3088,927,0,16384,8288,15896,7,0,0,0,0,0,0,16384,0,0,0,512,49411,14832,0,0,1540,57730,115,0,4096,0,0,0,0,32,0,0,0,16384,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8,0,0,0,4096,0,0,0,0,3080,49924,231,0,8192,0,0,0,0,64,0,0,0,0,4,0,0,0,0,0,1,0,0,33153,63584,28,0,0,0,0,0,0,28672,88,0,0,0,0,0,0,0,256,0,0,0,0,0,0,0,0,24640,6176,1854,0,0,0,512,0,0,0,0,256,0,0,0,0,0,0,1024,33286,29665,0,0,3080,49924,231,0,8192,0,0,0,0,64,0,0,0,16384,8288,15896,7,0,49280,12352,3708,0,0,0,0,0,0,512,49411,14832,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 	])
 
 {-# NOINLINE happyExpListPerState #-}
 happyExpListPerState st =
     token_strs_expected
-  where token_strs = ["error","%dummy","%start_pProgram_internal","%start_pListModule_internal","%start_pModule_internal","%start_pImport_internal","%start_pListImport_internal","%start_pDecl_internal","%start_pListDecl_internal","%start_pTerm_internal","%start_pTerm1_internal","%start_pTerm2_internal","%start_pScopedTerm_internal","%start_pPattern_internal","VarIdent","Program","ListModule","Module","Import","ListImport","Decl","ListDecl","Term","Term1","Term2","ScopedTerm","Pattern","'('","')'","','","':'","':='","';'","'='","'Id'","'J'","'_'","'check'","'compute'","'def'","'import'","'in'","'let'","'module'","'namespace'","'open'","'private'","'refl'","'tt'","'where'","'{'","'}'","'\215'","'\928'","'\931'","'\955'","'\960\8321'","'\960\8322'","'\8594'","'\8658'","'\120140'","'\120793'","L_VarIdent","%eof"]
-        bit_start = st Prelude.* 64
-        bit_end = (st Prelude.+ 1) Prelude.* 64
+  where token_strs = ["error","%dummy","%start_pProgram_internal","%start_pListModule_internal","%start_pModule_internal","%start_pParam_internal","%start_pListParam_internal","%start_pImport_internal","%start_pListImport_internal","%start_pDecl_internal","%start_pListDecl_internal","%start_pDischarge_internal","%start_pListVarIdent_internal","%start_pTerm_internal","%start_pTerm1_internal","%start_pTerm2_internal","%start_pScopedTerm_internal","%start_pPattern_internal","VarIdent","Program","ListModule","Module","Param","ListParam","Import","ListImport","Decl","ListDecl","Discharge","ListVarIdent","Term","Term1","Term2","ScopedTerm","Pattern","'('","')'","','","':'","':='","';'","'='","'Id'","'J'","'_'","'check'","'compute'","'def'","'import'","'in'","'let'","'module'","'namespace'","'open'","'over'","'private'","'refl'","'tt'","'where'","'{'","'}'","'\215'","'\928'","'\931'","'\955'","'\960\8321'","'\960\8322'","'\8594'","'\8658'","'\120140'","'\120793'","L_VarIdent","%eof"]
+        bit_start = st Prelude.* 73
+        bit_end = (st Prelude.+ 1) Prelude.* 73
         read_bit = readArrayBit happyExpList
         bits = Prelude.map read_bit [bit_start..bit_end Prelude.- 1]
-        bits_indexed = Prelude.zip bits [0..63]
+        bits_indexed = Prelude.zip bits [0..72]
         token_strs_expected = Prelude.concatMap f bits_indexed
         f (Prelude.False, _) = []
         f (Prelude.True, nr) = [token_strs Prelude.!! nr]
 
-action_0 (44) = happyShift action_53
-action_0 (16) = happyGoto action_56
-action_0 (17) = happyGoto action_57
-action_0 (18) = happyGoto action_55
-action_0 _ = happyReduce_14
+action_0 (52) = happyShift action_65
+action_0 (20) = happyGoto action_68
+action_0 (21) = happyGoto action_69
+action_0 (22) = happyGoto action_67
+action_0 _ = happyReduce_18
 
-action_1 (44) = happyShift action_53
-action_1 (17) = happyGoto action_54
-action_1 (18) = happyGoto action_55
-action_1 _ = happyReduce_14
+action_1 (52) = happyShift action_65
+action_1 (21) = happyGoto action_66
+action_1 (22) = happyGoto action_67
+action_1 _ = happyReduce_18
 
-action_2 (44) = happyShift action_53
-action_2 (18) = happyGoto action_52
+action_2 (52) = happyShift action_65
+action_2 (22) = happyGoto action_64
 action_2 _ = happyFail (happyExpListPerState 2)
 
-action_3 (41) = happyShift action_50
-action_3 (19) = happyGoto action_51
+action_3 (36) = happyShift action_62
+action_3 (23) = happyGoto action_63
 action_3 _ = happyFail (happyExpListPerState 3)
 
-action_4 (41) = happyShift action_50
-action_4 (19) = happyGoto action_48
-action_4 (20) = happyGoto action_49
-action_4 _ = happyReduce_18
+action_4 (36) = happyShift action_62
+action_4 (23) = happyGoto action_60
+action_4 (24) = happyGoto action_61
+action_4 _ = happyReduce_22
 
-action_5 (38) = happyShift action_41
-action_5 (39) = happyShift action_42
-action_5 (40) = happyShift action_43
-action_5 (45) = happyShift action_44
-action_5 (46) = happyShift action_45
-action_5 (47) = happyShift action_46
-action_5 (21) = happyGoto action_47
+action_5 (49) = happyShift action_58
+action_5 (25) = happyGoto action_59
 action_5 _ = happyFail (happyExpListPerState 5)
 
-action_6 (38) = happyShift action_41
-action_6 (39) = happyShift action_42
-action_6 (40) = happyShift action_43
-action_6 (45) = happyShift action_44
-action_6 (46) = happyShift action_45
-action_6 (47) = happyShift action_46
-action_6 (21) = happyGoto action_39
-action_6 (22) = happyGoto action_40
-action_6 _ = happyReduce_26
+action_6 (49) = happyShift action_58
+action_6 (25) = happyGoto action_56
+action_6 (26) = happyGoto action_57
+action_6 _ = happyReduce_25
 
-action_7 (28) = happyShift action_23
-action_7 (35) = happyShift action_24
-action_7 (36) = happyShift action_25
-action_7 (43) = happyShift action_26
-action_7 (48) = happyShift action_27
-action_7 (49) = happyShift action_28
-action_7 (54) = happyShift action_29
-action_7 (55) = happyShift action_30
-action_7 (56) = happyShift action_31
-action_7 (57) = happyShift action_32
-action_7 (58) = happyShift action_33
-action_7 (61) = happyShift action_34
-action_7 (62) = happyShift action_35
-action_7 (63) = happyShift action_13
-action_7 (15) = happyGoto action_18
-action_7 (23) = happyGoto action_38
-action_7 (24) = happyGoto action_20
-action_7 (25) = happyGoto action_21
+action_7 (46) = happyShift action_49
+action_7 (47) = happyShift action_50
+action_7 (48) = happyShift action_51
+action_7 (53) = happyShift action_52
+action_7 (54) = happyShift action_53
+action_7 (56) = happyShift action_54
+action_7 (27) = happyGoto action_55
 action_7 _ = happyFail (happyExpListPerState 7)
 
-action_8 (28) = happyShift action_23
-action_8 (35) = happyShift action_24
-action_8 (36) = happyShift action_25
-action_8 (48) = happyShift action_27
-action_8 (49) = happyShift action_28
-action_8 (57) = happyShift action_32
-action_8 (58) = happyShift action_33
-action_8 (61) = happyShift action_34
-action_8 (62) = happyShift action_35
-action_8 (63) = happyShift action_13
-action_8 (15) = happyGoto action_18
-action_8 (24) = happyGoto action_37
-action_8 (25) = happyGoto action_21
-action_8 _ = happyFail (happyExpListPerState 8)
+action_8 (46) = happyShift action_49
+action_8 (47) = happyShift action_50
+action_8 (48) = happyShift action_51
+action_8 (53) = happyShift action_52
+action_8 (54) = happyShift action_53
+action_8 (56) = happyShift action_54
+action_8 (27) = happyGoto action_47
+action_8 (28) = happyGoto action_48
+action_8 _ = happyReduce_33
 
-action_9 (28) = happyShift action_23
-action_9 (35) = happyShift action_24
-action_9 (36) = happyShift action_25
-action_9 (48) = happyShift action_27
-action_9 (49) = happyShift action_28
-action_9 (57) = happyShift action_32
-action_9 (58) = happyShift action_33
-action_9 (61) = happyShift action_34
-action_9 (62) = happyShift action_35
-action_9 (63) = happyShift action_13
-action_9 (15) = happyGoto action_18
-action_9 (25) = happyGoto action_36
-action_9 _ = happyFail (happyExpListPerState 9)
+action_9 (55) = happyShift action_46
+action_9 (29) = happyGoto action_45
+action_9 _ = happyReduce_36
 
-action_10 (28) = happyShift action_23
-action_10 (35) = happyShift action_24
-action_10 (36) = happyShift action_25
-action_10 (43) = happyShift action_26
-action_10 (48) = happyShift action_27
-action_10 (49) = happyShift action_28
-action_10 (54) = happyShift action_29
-action_10 (55) = happyShift action_30
-action_10 (56) = happyShift action_31
-action_10 (57) = happyShift action_32
-action_10 (58) = happyShift action_33
-action_10 (61) = happyShift action_34
-action_10 (62) = happyShift action_35
-action_10 (63) = happyShift action_13
-action_10 (15) = happyGoto action_18
-action_10 (23) = happyGoto action_19
-action_10 (24) = happyGoto action_20
-action_10 (25) = happyGoto action_21
-action_10 (26) = happyGoto action_22
-action_10 _ = happyFail (happyExpListPerState 10)
+action_10 (72) = happyShift action_17
+action_10 (19) = happyGoto action_43
+action_10 (30) = happyGoto action_44
+action_10 _ = happyReduce_38
 
-action_11 (28) = happyShift action_16
-action_11 (37) = happyShift action_17
-action_11 (63) = happyShift action_13
-action_11 (15) = happyGoto action_14
-action_11 (27) = happyGoto action_15
+action_11 (36) = happyShift action_27
+action_11 (43) = happyShift action_28
+action_11 (44) = happyShift action_29
+action_11 (51) = happyShift action_30
+action_11 (57) = happyShift action_31
+action_11 (58) = happyShift action_32
+action_11 (63) = happyShift action_33
+action_11 (64) = happyShift action_34
+action_11 (65) = happyShift action_35
+action_11 (66) = happyShift action_36
+action_11 (67) = happyShift action_37
+action_11 (70) = happyShift action_38
+action_11 (71) = happyShift action_39
+action_11 (72) = happyShift action_17
+action_11 (19) = happyGoto action_22
+action_11 (31) = happyGoto action_42
+action_11 (32) = happyGoto action_24
+action_11 (33) = happyGoto action_25
 action_11 _ = happyFail (happyExpListPerState 11)
 
-action_12 (63) = happyShift action_13
+action_12 (36) = happyShift action_27
+action_12 (43) = happyShift action_28
+action_12 (44) = happyShift action_29
+action_12 (57) = happyShift action_31
+action_12 (58) = happyShift action_32
+action_12 (66) = happyShift action_36
+action_12 (67) = happyShift action_37
+action_12 (70) = happyShift action_38
+action_12 (71) = happyShift action_39
+action_12 (72) = happyShift action_17
+action_12 (19) = happyGoto action_22
+action_12 (32) = happyGoto action_41
+action_12 (33) = happyGoto action_25
 action_12 _ = happyFail (happyExpListPerState 12)
 
-action_13 _ = happyReduce_12
+action_13 (36) = happyShift action_27
+action_13 (43) = happyShift action_28
+action_13 (44) = happyShift action_29
+action_13 (57) = happyShift action_31
+action_13 (58) = happyShift action_32
+action_13 (66) = happyShift action_36
+action_13 (67) = happyShift action_37
+action_13 (70) = happyShift action_38
+action_13 (71) = happyShift action_39
+action_13 (72) = happyShift action_17
+action_13 (19) = happyGoto action_22
+action_13 (33) = happyGoto action_40
+action_13 _ = happyFail (happyExpListPerState 13)
 
-action_14 _ = happyReduce_52
+action_14 (36) = happyShift action_27
+action_14 (43) = happyShift action_28
+action_14 (44) = happyShift action_29
+action_14 (51) = happyShift action_30
+action_14 (57) = happyShift action_31
+action_14 (58) = happyShift action_32
+action_14 (63) = happyShift action_33
+action_14 (64) = happyShift action_34
+action_14 (65) = happyShift action_35
+action_14 (66) = happyShift action_36
+action_14 (67) = happyShift action_37
+action_14 (70) = happyShift action_38
+action_14 (71) = happyShift action_39
+action_14 (72) = happyShift action_17
+action_14 (19) = happyGoto action_22
+action_14 (31) = happyGoto action_23
+action_14 (32) = happyGoto action_24
+action_14 (33) = happyGoto action_25
+action_14 (34) = happyGoto action_26
+action_14 _ = happyFail (happyExpListPerState 14)
 
-action_15 (64) = happyAccept
+action_15 (36) = happyShift action_20
+action_15 (45) = happyShift action_21
+action_15 (72) = happyShift action_17
+action_15 (19) = happyGoto action_18
+action_15 (35) = happyGoto action_19
 action_15 _ = happyFail (happyExpListPerState 15)
 
-action_16 (28) = happyShift action_16
-action_16 (37) = happyShift action_17
-action_16 (63) = happyShift action_13
-action_16 (15) = happyGoto action_14
-action_16 (27) = happyGoto action_82
+action_16 (72) = happyShift action_17
 action_16 _ = happyFail (happyExpListPerState 16)
 
-action_17 _ = happyReduce_51
+action_17 _ = happyReduce_16
 
-action_18 _ = happyReduce_43
+action_18 _ = happyReduce_64
 
-action_19 _ = happyReduce_50
+action_19 (73) = happyAccept
+action_19 _ = happyFail (happyExpListPerState 19)
 
-action_20 (28) = happyShift action_23
-action_20 (35) = happyShift action_24
-action_20 (36) = happyShift action_25
-action_20 (48) = happyShift action_27
-action_20 (49) = happyShift action_28
-action_20 (53) = happyShift action_80
-action_20 (57) = happyShift action_32
-action_20 (58) = happyShift action_33
-action_20 (59) = happyShift action_81
-action_20 (61) = happyShift action_34
-action_20 (62) = happyShift action_35
-action_20 (63) = happyShift action_13
-action_20 (15) = happyGoto action_18
-action_20 (25) = happyGoto action_69
-action_20 _ = happyReduce_35
+action_20 (36) = happyShift action_20
+action_20 (45) = happyShift action_21
+action_20 (72) = happyShift action_17
+action_20 (19) = happyGoto action_18
+action_20 (35) = happyGoto action_98
+action_20 _ = happyFail (happyExpListPerState 20)
 
-action_21 _ = happyReduce_37
+action_21 _ = happyReduce_63
 
-action_22 (64) = happyAccept
-action_22 _ = happyFail (happyExpListPerState 22)
+action_22 _ = happyReduce_55
 
-action_23 (28) = happyShift action_23
-action_23 (35) = happyShift action_24
-action_23 (36) = happyShift action_25
-action_23 (43) = happyShift action_26
-action_23 (48) = happyShift action_27
-action_23 (49) = happyShift action_28
-action_23 (54) = happyShift action_29
-action_23 (55) = happyShift action_30
-action_23 (56) = happyShift action_31
-action_23 (57) = happyShift action_32
-action_23 (58) = happyShift action_33
-action_23 (61) = happyShift action_34
-action_23 (62) = happyShift action_35
-action_23 (63) = happyShift action_13
-action_23 (15) = happyGoto action_18
-action_23 (23) = happyGoto action_79
-action_23 (24) = happyGoto action_20
-action_23 (25) = happyGoto action_21
-action_23 _ = happyFail (happyExpListPerState 23)
+action_23 _ = happyReduce_62
 
-action_24 (28) = happyShift action_78
-action_24 _ = happyFail (happyExpListPerState 24)
+action_24 (36) = happyShift action_27
+action_24 (43) = happyShift action_28
+action_24 (44) = happyShift action_29
+action_24 (57) = happyShift action_31
+action_24 (58) = happyShift action_32
+action_24 (62) = happyShift action_96
+action_24 (66) = happyShift action_36
+action_24 (67) = happyShift action_37
+action_24 (68) = happyShift action_97
+action_24 (70) = happyShift action_38
+action_24 (71) = happyShift action_39
+action_24 (72) = happyShift action_17
+action_24 (19) = happyGoto action_22
+action_24 (33) = happyGoto action_85
+action_24 _ = happyReduce_47
 
-action_25 (28) = happyShift action_77
-action_25 _ = happyFail (happyExpListPerState 25)
+action_25 _ = happyReduce_49
 
-action_26 (28) = happyShift action_16
-action_26 (37) = happyShift action_17
-action_26 (63) = happyShift action_13
-action_26 (15) = happyGoto action_14
-action_26 (27) = happyGoto action_76
+action_26 (73) = happyAccept
 action_26 _ = happyFail (happyExpListPerState 26)
 
-action_27 (28) = happyShift action_75
+action_27 (36) = happyShift action_27
+action_27 (43) = happyShift action_28
+action_27 (44) = happyShift action_29
+action_27 (51) = happyShift action_30
+action_27 (57) = happyShift action_31
+action_27 (58) = happyShift action_32
+action_27 (63) = happyShift action_33
+action_27 (64) = happyShift action_34
+action_27 (65) = happyShift action_35
+action_27 (66) = happyShift action_36
+action_27 (67) = happyShift action_37
+action_27 (70) = happyShift action_38
+action_27 (71) = happyShift action_39
+action_27 (72) = happyShift action_17
+action_27 (19) = happyGoto action_22
+action_27 (31) = happyGoto action_95
+action_27 (32) = happyGoto action_24
+action_27 (33) = happyGoto action_25
 action_27 _ = happyFail (happyExpListPerState 27)
 
-action_28 _ = happyReduce_42
+action_28 (36) = happyShift action_94
+action_28 _ = happyFail (happyExpListPerState 28)
 
-action_29 (28) = happyShift action_74
+action_29 (36) = happyShift action_93
 action_29 _ = happyFail (happyExpListPerState 29)
 
-action_30 (28) = happyShift action_73
+action_30 (36) = happyShift action_20
+action_30 (45) = happyShift action_21
+action_30 (72) = happyShift action_17
+action_30 (19) = happyGoto action_18
+action_30 (35) = happyGoto action_92
 action_30 _ = happyFail (happyExpListPerState 30)
 
-action_31 (28) = happyShift action_16
-action_31 (37) = happyShift action_17
-action_31 (63) = happyShift action_13
-action_31 (15) = happyGoto action_14
-action_31 (27) = happyGoto action_72
+action_31 (36) = happyShift action_91
 action_31 _ = happyFail (happyExpListPerState 31)
 
-action_32 (28) = happyShift action_23
-action_32 (35) = happyShift action_24
-action_32 (36) = happyShift action_25
-action_32 (48) = happyShift action_27
-action_32 (49) = happyShift action_28
-action_32 (57) = happyShift action_32
-action_32 (58) = happyShift action_33
-action_32 (61) = happyShift action_34
-action_32 (62) = happyShift action_35
-action_32 (63) = happyShift action_13
-action_32 (15) = happyGoto action_18
-action_32 (25) = happyGoto action_71
-action_32 _ = happyFail (happyExpListPerState 32)
+action_32 _ = happyReduce_54
 
-action_33 (28) = happyShift action_23
-action_33 (35) = happyShift action_24
-action_33 (36) = happyShift action_25
-action_33 (48) = happyShift action_27
-action_33 (49) = happyShift action_28
-action_33 (57) = happyShift action_32
-action_33 (58) = happyShift action_33
-action_33 (61) = happyShift action_34
-action_33 (62) = happyShift action_35
-action_33 (63) = happyShift action_13
-action_33 (15) = happyGoto action_18
-action_33 (25) = happyGoto action_70
+action_33 (36) = happyShift action_90
 action_33 _ = happyFail (happyExpListPerState 33)
 
-action_34 _ = happyReduce_40
+action_34 (36) = happyShift action_89
+action_34 _ = happyFail (happyExpListPerState 34)
 
-action_35 _ = happyReduce_41
+action_35 (36) = happyShift action_20
+action_35 (45) = happyShift action_21
+action_35 (72) = happyShift action_17
+action_35 (19) = happyGoto action_18
+action_35 (35) = happyGoto action_88
+action_35 _ = happyFail (happyExpListPerState 35)
 
-action_36 (64) = happyAccept
+action_36 (36) = happyShift action_27
+action_36 (43) = happyShift action_28
+action_36 (44) = happyShift action_29
+action_36 (57) = happyShift action_31
+action_36 (58) = happyShift action_32
+action_36 (66) = happyShift action_36
+action_36 (67) = happyShift action_37
+action_36 (70) = happyShift action_38
+action_36 (71) = happyShift action_39
+action_36 (72) = happyShift action_17
+action_36 (19) = happyGoto action_22
+action_36 (33) = happyGoto action_87
 action_36 _ = happyFail (happyExpListPerState 36)
 
-action_37 (28) = happyShift action_23
-action_37 (35) = happyShift action_24
-action_37 (36) = happyShift action_25
-action_37 (48) = happyShift action_27
-action_37 (49) = happyShift action_28
-action_37 (57) = happyShift action_32
-action_37 (58) = happyShift action_33
-action_37 (61) = happyShift action_34
-action_37 (62) = happyShift action_35
-action_37 (63) = happyShift action_13
-action_37 (64) = happyAccept
-action_37 (15) = happyGoto action_18
-action_37 (25) = happyGoto action_69
+action_37 (36) = happyShift action_27
+action_37 (43) = happyShift action_28
+action_37 (44) = happyShift action_29
+action_37 (57) = happyShift action_31
+action_37 (58) = happyShift action_32
+action_37 (66) = happyShift action_36
+action_37 (67) = happyShift action_37
+action_37 (70) = happyShift action_38
+action_37 (71) = happyShift action_39
+action_37 (72) = happyShift action_17
+action_37 (19) = happyGoto action_22
+action_37 (33) = happyGoto action_86
 action_37 _ = happyFail (happyExpListPerState 37)
 
-action_38 (64) = happyAccept
-action_38 _ = happyFail (happyExpListPerState 38)
+action_38 _ = happyReduce_52
 
-action_39 (33) = happyShift action_68
-action_39 _ = happyReduce_27
+action_39 _ = happyReduce_53
 
-action_40 (64) = happyAccept
+action_40 (73) = happyAccept
 action_40 _ = happyFail (happyExpListPerState 40)
 
-action_41 (28) = happyShift action_23
-action_41 (35) = happyShift action_24
-action_41 (36) = happyShift action_25
-action_41 (43) = happyShift action_26
-action_41 (48) = happyShift action_27
-action_41 (49) = happyShift action_28
-action_41 (54) = happyShift action_29
-action_41 (55) = happyShift action_30
-action_41 (56) = happyShift action_31
-action_41 (57) = happyShift action_32
-action_41 (58) = happyShift action_33
-action_41 (61) = happyShift action_34
-action_41 (62) = happyShift action_35
-action_41 (63) = happyShift action_13
-action_41 (15) = happyGoto action_18
-action_41 (23) = happyGoto action_67
-action_41 (24) = happyGoto action_20
-action_41 (25) = happyGoto action_21
+action_41 (36) = happyShift action_27
+action_41 (43) = happyShift action_28
+action_41 (44) = happyShift action_29
+action_41 (57) = happyShift action_31
+action_41 (58) = happyShift action_32
+action_41 (66) = happyShift action_36
+action_41 (67) = happyShift action_37
+action_41 (70) = happyShift action_38
+action_41 (71) = happyShift action_39
+action_41 (72) = happyShift action_17
+action_41 (73) = happyAccept
+action_41 (19) = happyGoto action_22
+action_41 (33) = happyGoto action_85
 action_41 _ = happyFail (happyExpListPerState 41)
 
-action_42 (28) = happyShift action_23
-action_42 (35) = happyShift action_24
-action_42 (36) = happyShift action_25
-action_42 (43) = happyShift action_26
-action_42 (48) = happyShift action_27
-action_42 (49) = happyShift action_28
-action_42 (54) = happyShift action_29
-action_42 (55) = happyShift action_30
-action_42 (56) = happyShift action_31
-action_42 (57) = happyShift action_32
-action_42 (58) = happyShift action_33
-action_42 (61) = happyShift action_34
-action_42 (62) = happyShift action_35
-action_42 (63) = happyShift action_13
-action_42 (15) = happyGoto action_18
-action_42 (23) = happyGoto action_66
-action_42 (24) = happyGoto action_20
-action_42 (25) = happyGoto action_21
+action_42 (73) = happyAccept
 action_42 _ = happyFail (happyExpListPerState 42)
 
-action_43 (63) = happyShift action_13
-action_43 (15) = happyGoto action_65
-action_43 _ = happyFail (happyExpListPerState 43)
+action_43 (38) = happyShift action_84
+action_43 _ = happyReduce_39
 
-action_44 (63) = happyShift action_13
-action_44 (15) = happyGoto action_64
+action_44 (73) = happyAccept
 action_44 _ = happyFail (happyExpListPerState 44)
 
-action_45 (63) = happyShift action_13
-action_45 (15) = happyGoto action_63
+action_45 (73) = happyAccept
 action_45 _ = happyFail (happyExpListPerState 45)
 
-action_46 (40) = happyShift action_62
+action_46 (36) = happyShift action_83
 action_46 _ = happyFail (happyExpListPerState 46)
 
-action_47 (64) = happyAccept
-action_47 _ = happyFail (happyExpListPerState 47)
+action_47 (41) = happyShift action_82
+action_47 _ = happyReduce_34
 
-action_48 (33) = happyShift action_61
+action_48 (73) = happyAccept
 action_48 _ = happyFail (happyExpListPerState 48)
 
-action_49 (64) = happyAccept
+action_49 (36) = happyShift action_27
+action_49 (43) = happyShift action_28
+action_49 (44) = happyShift action_29
+action_49 (51) = happyShift action_30
+action_49 (57) = happyShift action_31
+action_49 (58) = happyShift action_32
+action_49 (63) = happyShift action_33
+action_49 (64) = happyShift action_34
+action_49 (65) = happyShift action_35
+action_49 (66) = happyShift action_36
+action_49 (67) = happyShift action_37
+action_49 (70) = happyShift action_38
+action_49 (71) = happyShift action_39
+action_49 (72) = happyShift action_17
+action_49 (19) = happyGoto action_22
+action_49 (31) = happyGoto action_81
+action_49 (32) = happyGoto action_24
+action_49 (33) = happyGoto action_25
 action_49 _ = happyFail (happyExpListPerState 49)
 
-action_50 (63) = happyShift action_13
-action_50 (15) = happyGoto action_60
+action_50 (36) = happyShift action_27
+action_50 (43) = happyShift action_28
+action_50 (44) = happyShift action_29
+action_50 (51) = happyShift action_30
+action_50 (57) = happyShift action_31
+action_50 (58) = happyShift action_32
+action_50 (63) = happyShift action_33
+action_50 (64) = happyShift action_34
+action_50 (65) = happyShift action_35
+action_50 (66) = happyShift action_36
+action_50 (67) = happyShift action_37
+action_50 (70) = happyShift action_38
+action_50 (71) = happyShift action_39
+action_50 (72) = happyShift action_17
+action_50 (19) = happyGoto action_22
+action_50 (31) = happyGoto action_80
+action_50 (32) = happyGoto action_24
+action_50 (33) = happyGoto action_25
 action_50 _ = happyFail (happyExpListPerState 50)
 
-action_51 (64) = happyAccept
+action_51 (72) = happyShift action_17
+action_51 (19) = happyGoto action_79
 action_51 _ = happyFail (happyExpListPerState 51)
 
-action_52 (64) = happyAccept
+action_52 (72) = happyShift action_17
+action_52 (19) = happyGoto action_78
 action_52 _ = happyFail (happyExpListPerState 52)
 
-action_53 (63) = happyShift action_13
-action_53 (15) = happyGoto action_59
+action_53 (72) = happyShift action_17
+action_53 (19) = happyGoto action_77
 action_53 _ = happyFail (happyExpListPerState 53)
 
-action_54 (64) = happyAccept
+action_54 (48) = happyShift action_76
 action_54 _ = happyFail (happyExpListPerState 54)
 
-action_55 (44) = happyShift action_53
-action_55 (17) = happyGoto action_58
-action_55 (18) = happyGoto action_55
-action_55 _ = happyReduce_14
+action_55 (73) = happyAccept
+action_55 _ = happyFail (happyExpListPerState 55)
 
-action_56 (64) = happyAccept
+action_56 (41) = happyShift action_75
 action_56 _ = happyFail (happyExpListPerState 56)
 
-action_57 _ = happyReduce_13
+action_57 (73) = happyAccept
+action_57 _ = happyFail (happyExpListPerState 57)
 
-action_58 _ = happyReduce_15
+action_58 (72) = happyShift action_17
+action_58 (19) = happyGoto action_74
+action_58 _ = happyFail (happyExpListPerState 58)
 
-action_59 (33) = happyShift action_102
+action_59 (73) = happyAccept
 action_59 _ = happyFail (happyExpListPerState 59)
 
-action_60 _ = happyReduce_17
+action_60 (36) = happyShift action_62
+action_60 (23) = happyGoto action_60
+action_60 (24) = happyGoto action_73
+action_60 _ = happyReduce_22
 
-action_61 (41) = happyShift action_50
-action_61 (19) = happyGoto action_48
-action_61 (20) = happyGoto action_101
-action_61 _ = happyReduce_18
+action_61 (73) = happyAccept
+action_61 _ = happyFail (happyExpListPerState 61)
 
-action_62 (63) = happyShift action_13
-action_62 (15) = happyGoto action_100
+action_62 (72) = happyShift action_17
+action_62 (19) = happyGoto action_72
 action_62 _ = happyFail (happyExpListPerState 62)
 
-action_63 _ = happyReduce_23
+action_63 (73) = happyAccept
+action_63 _ = happyFail (happyExpListPerState 63)
 
-action_64 (50) = happyShift action_99
+action_64 (73) = happyAccept
 action_64 _ = happyFail (happyExpListPerState 64)
 
-action_65 (31) = happyShift action_98
+action_65 (72) = happyShift action_17
+action_65 (19) = happyGoto action_71
 action_65 _ = happyFail (happyExpListPerState 65)
 
-action_66 _ = happyReduce_25
+action_66 (73) = happyAccept
+action_66 _ = happyFail (happyExpListPerState 66)
 
-action_67 (31) = happyShift action_97
-action_67 _ = happyFail (happyExpListPerState 67)
+action_67 (52) = happyShift action_65
+action_67 (21) = happyGoto action_70
+action_67 (22) = happyGoto action_67
+action_67 _ = happyReduce_18
 
-action_68 (38) = happyShift action_41
-action_68 (39) = happyShift action_42
-action_68 (40) = happyShift action_43
-action_68 (45) = happyShift action_44
-action_68 (46) = happyShift action_45
-action_68 (47) = happyShift action_46
-action_68 (21) = happyGoto action_39
-action_68 (22) = happyGoto action_96
-action_68 _ = happyReduce_26
+action_68 (73) = happyAccept
+action_68 _ = happyFail (happyExpListPerState 68)
 
-action_69 _ = happyReduce_36
+action_69 _ = happyReduce_17
 
-action_70 _ = happyReduce_39
+action_70 _ = happyReduce_19
 
-action_71 _ = happyReduce_38
+action_71 (36) = happyShift action_62
+action_71 (23) = happyGoto action_60
+action_71 (24) = happyGoto action_121
+action_71 _ = happyReduce_22
 
-action_72 (60) = happyShift action_95
+action_72 (39) = happyShift action_120
 action_72 _ = happyFail (happyExpListPerState 72)
 
-action_73 (28) = happyShift action_16
-action_73 (37) = happyShift action_17
-action_73 (63) = happyShift action_13
-action_73 (15) = happyGoto action_14
-action_73 (27) = happyGoto action_94
-action_73 _ = happyFail (happyExpListPerState 73)
+action_73 _ = happyReduce_23
 
-action_74 (28) = happyShift action_16
-action_74 (37) = happyShift action_17
-action_74 (63) = happyShift action_13
-action_74 (15) = happyGoto action_14
-action_74 (27) = happyGoto action_93
-action_74 _ = happyFail (happyExpListPerState 74)
+action_74 _ = happyReduce_24
 
-action_75 (28) = happyShift action_23
-action_75 (35) = happyShift action_24
-action_75 (36) = happyShift action_25
-action_75 (43) = happyShift action_26
-action_75 (48) = happyShift action_27
-action_75 (49) = happyShift action_28
-action_75 (54) = happyShift action_29
-action_75 (55) = happyShift action_30
-action_75 (56) = happyShift action_31
-action_75 (57) = happyShift action_32
-action_75 (58) = happyShift action_33
-action_75 (61) = happyShift action_34
-action_75 (62) = happyShift action_35
-action_75 (63) = happyShift action_13
-action_75 (15) = happyGoto action_18
-action_75 (23) = happyGoto action_92
-action_75 (24) = happyGoto action_20
-action_75 (25) = happyGoto action_21
-action_75 _ = happyFail (happyExpListPerState 75)
+action_75 (49) = happyShift action_58
+action_75 (25) = happyGoto action_56
+action_75 (26) = happyGoto action_119
+action_75 _ = happyReduce_25
 
-action_76 (34) = happyShift action_91
+action_76 (72) = happyShift action_17
+action_76 (19) = happyGoto action_118
 action_76 _ = happyFail (happyExpListPerState 76)
 
-action_77 (28) = happyShift action_23
-action_77 (35) = happyShift action_24
-action_77 (36) = happyShift action_25
-action_77 (43) = happyShift action_26
-action_77 (48) = happyShift action_27
-action_77 (49) = happyShift action_28
-action_77 (54) = happyShift action_29
-action_77 (55) = happyShift action_30
-action_77 (56) = happyShift action_31
-action_77 (57) = happyShift action_32
-action_77 (58) = happyShift action_33
-action_77 (61) = happyShift action_34
-action_77 (62) = happyShift action_35
-action_77 (63) = happyShift action_13
-action_77 (15) = happyGoto action_18
-action_77 (23) = happyGoto action_90
-action_77 (24) = happyGoto action_20
-action_77 (25) = happyGoto action_21
-action_77 _ = happyFail (happyExpListPerState 77)
+action_77 _ = happyReduce_30
 
-action_78 (28) = happyShift action_23
-action_78 (35) = happyShift action_24
-action_78 (36) = happyShift action_25
-action_78 (43) = happyShift action_26
-action_78 (48) = happyShift action_27
-action_78 (49) = happyShift action_28
-action_78 (54) = happyShift action_29
-action_78 (55) = happyShift action_30
-action_78 (56) = happyShift action_31
-action_78 (57) = happyShift action_32
-action_78 (58) = happyShift action_33
-action_78 (61) = happyShift action_34
-action_78 (62) = happyShift action_35
-action_78 (63) = happyShift action_13
-action_78 (15) = happyGoto action_18
-action_78 (23) = happyGoto action_89
-action_78 (24) = happyGoto action_20
-action_78 (25) = happyGoto action_21
+action_78 (59) = happyShift action_117
 action_78 _ = happyFail (happyExpListPerState 78)
 
-action_79 (29) = happyShift action_86
-action_79 (30) = happyShift action_87
-action_79 (31) = happyShift action_88
-action_79 _ = happyFail (happyExpListPerState 79)
+action_79 (55) = happyShift action_46
+action_79 (29) = happyGoto action_116
+action_79 _ = happyReduce_36
 
-action_80 (28) = happyShift action_23
-action_80 (35) = happyShift action_24
-action_80 (36) = happyShift action_25
-action_80 (43) = happyShift action_26
-action_80 (48) = happyShift action_27
-action_80 (49) = happyShift action_28
-action_80 (54) = happyShift action_29
-action_80 (55) = happyShift action_30
-action_80 (56) = happyShift action_31
-action_80 (57) = happyShift action_32
-action_80 (58) = happyShift action_33
-action_80 (61) = happyShift action_34
-action_80 (62) = happyShift action_35
-action_80 (63) = happyShift action_13
-action_80 (15) = happyGoto action_18
-action_80 (23) = happyGoto action_85
-action_80 (24) = happyGoto action_20
-action_80 (25) = happyGoto action_21
-action_80 _ = happyFail (happyExpListPerState 80)
+action_80 _ = happyReduce_32
 
-action_81 (28) = happyShift action_23
-action_81 (35) = happyShift action_24
-action_81 (36) = happyShift action_25
-action_81 (43) = happyShift action_26
-action_81 (48) = happyShift action_27
-action_81 (49) = happyShift action_28
-action_81 (54) = happyShift action_29
-action_81 (55) = happyShift action_30
-action_81 (56) = happyShift action_31
-action_81 (57) = happyShift action_32
-action_81 (58) = happyShift action_33
-action_81 (61) = happyShift action_34
-action_81 (62) = happyShift action_35
-action_81 (63) = happyShift action_13
-action_81 (15) = happyGoto action_18
-action_81 (23) = happyGoto action_84
-action_81 (24) = happyGoto action_20
-action_81 (25) = happyGoto action_21
+action_81 (39) = happyShift action_115
 action_81 _ = happyFail (happyExpListPerState 81)
 
-action_82 (30) = happyShift action_83
-action_82 _ = happyFail (happyExpListPerState 82)
+action_82 (46) = happyShift action_49
+action_82 (47) = happyShift action_50
+action_82 (48) = happyShift action_51
+action_82 (53) = happyShift action_52
+action_82 (54) = happyShift action_53
+action_82 (56) = happyShift action_54
+action_82 (27) = happyGoto action_47
+action_82 (28) = happyGoto action_114
+action_82 _ = happyReduce_33
 
-action_83 (28) = happyShift action_16
-action_83 (37) = happyShift action_17
-action_83 (63) = happyShift action_13
-action_83 (15) = happyGoto action_14
-action_83 (27) = happyGoto action_117
-action_83 _ = happyFail (happyExpListPerState 83)
+action_83 (72) = happyShift action_17
+action_83 (19) = happyGoto action_43
+action_83 (30) = happyGoto action_113
+action_83 _ = happyReduce_38
 
-action_84 _ = happyReduce_33
+action_84 (72) = happyShift action_17
+action_84 (19) = happyGoto action_43
+action_84 (30) = happyGoto action_112
+action_84 _ = happyReduce_38
 
-action_85 _ = happyReduce_34
+action_85 _ = happyReduce_48
 
-action_86 _ = happyReduce_49
+action_86 _ = happyReduce_51
 
-action_87 (28) = happyShift action_23
-action_87 (35) = happyShift action_24
-action_87 (36) = happyShift action_25
-action_87 (43) = happyShift action_26
-action_87 (48) = happyShift action_27
-action_87 (49) = happyShift action_28
-action_87 (54) = happyShift action_29
-action_87 (55) = happyShift action_30
-action_87 (56) = happyShift action_31
-action_87 (57) = happyShift action_32
-action_87 (58) = happyShift action_33
-action_87 (61) = happyShift action_34
-action_87 (62) = happyShift action_35
-action_87 (63) = happyShift action_13
-action_87 (15) = happyGoto action_18
-action_87 (23) = happyGoto action_116
-action_87 (24) = happyGoto action_20
-action_87 (25) = happyGoto action_21
-action_87 _ = happyFail (happyExpListPerState 87)
+action_87 _ = happyReduce_50
 
-action_88 (28) = happyShift action_23
-action_88 (35) = happyShift action_24
-action_88 (36) = happyShift action_25
-action_88 (43) = happyShift action_26
-action_88 (48) = happyShift action_27
-action_88 (49) = happyShift action_28
-action_88 (54) = happyShift action_29
-action_88 (55) = happyShift action_30
-action_88 (56) = happyShift action_31
-action_88 (57) = happyShift action_32
-action_88 (58) = happyShift action_33
-action_88 (61) = happyShift action_34
-action_88 (62) = happyShift action_35
-action_88 (63) = happyShift action_13
-action_88 (15) = happyGoto action_18
-action_88 (23) = happyGoto action_115
-action_88 (24) = happyGoto action_20
-action_88 (25) = happyGoto action_21
+action_88 (69) = happyShift action_111
 action_88 _ = happyFail (happyExpListPerState 88)
 
-action_89 (30) = happyShift action_114
+action_89 (36) = happyShift action_20
+action_89 (45) = happyShift action_21
+action_89 (72) = happyShift action_17
+action_89 (19) = happyGoto action_18
+action_89 (35) = happyGoto action_110
 action_89 _ = happyFail (happyExpListPerState 89)
 
-action_90 (30) = happyShift action_113
+action_90 (36) = happyShift action_20
+action_90 (45) = happyShift action_21
+action_90 (72) = happyShift action_17
+action_90 (19) = happyGoto action_18
+action_90 (35) = happyGoto action_109
 action_90 _ = happyFail (happyExpListPerState 90)
 
-action_91 (28) = happyShift action_23
-action_91 (35) = happyShift action_24
-action_91 (36) = happyShift action_25
-action_91 (43) = happyShift action_26
-action_91 (48) = happyShift action_27
-action_91 (49) = happyShift action_28
-action_91 (54) = happyShift action_29
-action_91 (55) = happyShift action_30
-action_91 (56) = happyShift action_31
-action_91 (57) = happyShift action_32
-action_91 (58) = happyShift action_33
-action_91 (61) = happyShift action_34
-action_91 (62) = happyShift action_35
-action_91 (63) = happyShift action_13
-action_91 (15) = happyGoto action_18
-action_91 (23) = happyGoto action_112
-action_91 (24) = happyGoto action_20
-action_91 (25) = happyGoto action_21
+action_91 (36) = happyShift action_27
+action_91 (43) = happyShift action_28
+action_91 (44) = happyShift action_29
+action_91 (51) = happyShift action_30
+action_91 (57) = happyShift action_31
+action_91 (58) = happyShift action_32
+action_91 (63) = happyShift action_33
+action_91 (64) = happyShift action_34
+action_91 (65) = happyShift action_35
+action_91 (66) = happyShift action_36
+action_91 (67) = happyShift action_37
+action_91 (70) = happyShift action_38
+action_91 (71) = happyShift action_39
+action_91 (72) = happyShift action_17
+action_91 (19) = happyGoto action_22
+action_91 (31) = happyGoto action_108
+action_91 (32) = happyGoto action_24
+action_91 (33) = happyGoto action_25
 action_91 _ = happyFail (happyExpListPerState 91)
 
-action_92 (29) = happyShift action_111
+action_92 (42) = happyShift action_107
 action_92 _ = happyFail (happyExpListPerState 92)
 
-action_93 (31) = happyShift action_110
+action_93 (36) = happyShift action_27
+action_93 (43) = happyShift action_28
+action_93 (44) = happyShift action_29
+action_93 (51) = happyShift action_30
+action_93 (57) = happyShift action_31
+action_93 (58) = happyShift action_32
+action_93 (63) = happyShift action_33
+action_93 (64) = happyShift action_34
+action_93 (65) = happyShift action_35
+action_93 (66) = happyShift action_36
+action_93 (67) = happyShift action_37
+action_93 (70) = happyShift action_38
+action_93 (71) = happyShift action_39
+action_93 (72) = happyShift action_17
+action_93 (19) = happyGoto action_22
+action_93 (31) = happyGoto action_106
+action_93 (32) = happyGoto action_24
+action_93 (33) = happyGoto action_25
 action_93 _ = happyFail (happyExpListPerState 93)
 
-action_94 (31) = happyShift action_109
+action_94 (36) = happyShift action_27
+action_94 (43) = happyShift action_28
+action_94 (44) = happyShift action_29
+action_94 (51) = happyShift action_30
+action_94 (57) = happyShift action_31
+action_94 (58) = happyShift action_32
+action_94 (63) = happyShift action_33
+action_94 (64) = happyShift action_34
+action_94 (65) = happyShift action_35
+action_94 (66) = happyShift action_36
+action_94 (67) = happyShift action_37
+action_94 (70) = happyShift action_38
+action_94 (71) = happyShift action_39
+action_94 (72) = happyShift action_17
+action_94 (19) = happyGoto action_22
+action_94 (31) = happyGoto action_105
+action_94 (32) = happyGoto action_24
+action_94 (33) = happyGoto action_25
 action_94 _ = happyFail (happyExpListPerState 94)
 
-action_95 (28) = happyShift action_23
-action_95 (35) = happyShift action_24
-action_95 (36) = happyShift action_25
-action_95 (43) = happyShift action_26
-action_95 (48) = happyShift action_27
-action_95 (49) = happyShift action_28
-action_95 (54) = happyShift action_29
-action_95 (55) = happyShift action_30
-action_95 (56) = happyShift action_31
-action_95 (57) = happyShift action_32
-action_95 (58) = happyShift action_33
-action_95 (61) = happyShift action_34
-action_95 (62) = happyShift action_35
-action_95 (63) = happyShift action_13
-action_95 (15) = happyGoto action_18
-action_95 (23) = happyGoto action_19
-action_95 (24) = happyGoto action_20
-action_95 (25) = happyGoto action_21
-action_95 (26) = happyGoto action_108
+action_95 (37) = happyShift action_102
+action_95 (38) = happyShift action_103
+action_95 (39) = happyShift action_104
 action_95 _ = happyFail (happyExpListPerState 95)
 
-action_96 _ = happyReduce_28
+action_96 (36) = happyShift action_27
+action_96 (43) = happyShift action_28
+action_96 (44) = happyShift action_29
+action_96 (51) = happyShift action_30
+action_96 (57) = happyShift action_31
+action_96 (58) = happyShift action_32
+action_96 (63) = happyShift action_33
+action_96 (64) = happyShift action_34
+action_96 (65) = happyShift action_35
+action_96 (66) = happyShift action_36
+action_96 (67) = happyShift action_37
+action_96 (70) = happyShift action_38
+action_96 (71) = happyShift action_39
+action_96 (72) = happyShift action_17
+action_96 (19) = happyGoto action_22
+action_96 (31) = happyGoto action_101
+action_96 (32) = happyGoto action_24
+action_96 (33) = happyGoto action_25
+action_96 _ = happyFail (happyExpListPerState 96)
 
-action_97 (28) = happyShift action_23
-action_97 (35) = happyShift action_24
-action_97 (36) = happyShift action_25
-action_97 (43) = happyShift action_26
-action_97 (48) = happyShift action_27
-action_97 (49) = happyShift action_28
-action_97 (54) = happyShift action_29
-action_97 (55) = happyShift action_30
-action_97 (56) = happyShift action_31
-action_97 (57) = happyShift action_32
-action_97 (58) = happyShift action_33
-action_97 (61) = happyShift action_34
-action_97 (62) = happyShift action_35
-action_97 (63) = happyShift action_13
-action_97 (15) = happyGoto action_18
-action_97 (23) = happyGoto action_107
-action_97 (24) = happyGoto action_20
-action_97 (25) = happyGoto action_21
+action_97 (36) = happyShift action_27
+action_97 (43) = happyShift action_28
+action_97 (44) = happyShift action_29
+action_97 (51) = happyShift action_30
+action_97 (57) = happyShift action_31
+action_97 (58) = happyShift action_32
+action_97 (63) = happyShift action_33
+action_97 (64) = happyShift action_34
+action_97 (65) = happyShift action_35
+action_97 (66) = happyShift action_36
+action_97 (67) = happyShift action_37
+action_97 (70) = happyShift action_38
+action_97 (71) = happyShift action_39
+action_97 (72) = happyShift action_17
+action_97 (19) = happyGoto action_22
+action_97 (31) = happyGoto action_100
+action_97 (32) = happyGoto action_24
+action_97 (33) = happyGoto action_25
 action_97 _ = happyFail (happyExpListPerState 97)
 
-action_98 (28) = happyShift action_23
-action_98 (35) = happyShift action_24
-action_98 (36) = happyShift action_25
-action_98 (43) = happyShift action_26
-action_98 (48) = happyShift action_27
-action_98 (49) = happyShift action_28
-action_98 (54) = happyShift action_29
-action_98 (55) = happyShift action_30
-action_98 (56) = happyShift action_31
-action_98 (57) = happyShift action_32
-action_98 (58) = happyShift action_33
-action_98 (61) = happyShift action_34
-action_98 (62) = happyShift action_35
-action_98 (63) = happyShift action_13
-action_98 (15) = happyGoto action_18
-action_98 (23) = happyGoto action_106
-action_98 (24) = happyGoto action_20
-action_98 (25) = happyGoto action_21
+action_98 (38) = happyShift action_99
 action_98 _ = happyFail (happyExpListPerState 98)
 
-action_99 (51) = happyShift action_105
+action_99 (36) = happyShift action_20
+action_99 (45) = happyShift action_21
+action_99 (72) = happyShift action_17
+action_99 (19) = happyGoto action_18
+action_99 (35) = happyGoto action_138
 action_99 _ = happyFail (happyExpListPerState 99)
 
-action_100 (31) = happyShift action_104
-action_100 _ = happyFail (happyExpListPerState 100)
+action_100 _ = happyReduce_45
 
-action_101 _ = happyReduce_19
+action_101 _ = happyReduce_46
 
-action_102 (41) = happyShift action_50
-action_102 (19) = happyGoto action_48
-action_102 (20) = happyGoto action_103
-action_102 _ = happyReduce_18
+action_102 _ = happyReduce_61
 
-action_103 (38) = happyShift action_41
-action_103 (39) = happyShift action_42
-action_103 (40) = happyShift action_43
-action_103 (45) = happyShift action_44
-action_103 (46) = happyShift action_45
-action_103 (47) = happyShift action_46
-action_103 (21) = happyGoto action_39
-action_103 (22) = happyGoto action_129
-action_103 _ = happyReduce_26
+action_103 (36) = happyShift action_27
+action_103 (43) = happyShift action_28
+action_103 (44) = happyShift action_29
+action_103 (51) = happyShift action_30
+action_103 (57) = happyShift action_31
+action_103 (58) = happyShift action_32
+action_103 (63) = happyShift action_33
+action_103 (64) = happyShift action_34
+action_103 (65) = happyShift action_35
+action_103 (66) = happyShift action_36
+action_103 (67) = happyShift action_37
+action_103 (70) = happyShift action_38
+action_103 (71) = happyShift action_39
+action_103 (72) = happyShift action_17
+action_103 (19) = happyGoto action_22
+action_103 (31) = happyGoto action_137
+action_103 (32) = happyGoto action_24
+action_103 (33) = happyGoto action_25
+action_103 _ = happyFail (happyExpListPerState 103)
 
-action_104 (28) = happyShift action_23
-action_104 (35) = happyShift action_24
-action_104 (36) = happyShift action_25
-action_104 (43) = happyShift action_26
-action_104 (48) = happyShift action_27
-action_104 (49) = happyShift action_28
-action_104 (54) = happyShift action_29
-action_104 (55) = happyShift action_30
-action_104 (56) = happyShift action_31
-action_104 (57) = happyShift action_32
-action_104 (58) = happyShift action_33
-action_104 (61) = happyShift action_34
-action_104 (62) = happyShift action_35
-action_104 (63) = happyShift action_13
-action_104 (15) = happyGoto action_18
-action_104 (23) = happyGoto action_128
-action_104 (24) = happyGoto action_20
-action_104 (25) = happyGoto action_21
+action_104 (36) = happyShift action_27
+action_104 (43) = happyShift action_28
+action_104 (44) = happyShift action_29
+action_104 (51) = happyShift action_30
+action_104 (57) = happyShift action_31
+action_104 (58) = happyShift action_32
+action_104 (63) = happyShift action_33
+action_104 (64) = happyShift action_34
+action_104 (65) = happyShift action_35
+action_104 (66) = happyShift action_36
+action_104 (67) = happyShift action_37
+action_104 (70) = happyShift action_38
+action_104 (71) = happyShift action_39
+action_104 (72) = happyShift action_17
+action_104 (19) = happyGoto action_22
+action_104 (31) = happyGoto action_136
+action_104 (32) = happyGoto action_24
+action_104 (33) = happyGoto action_25
 action_104 _ = happyFail (happyExpListPerState 104)
 
-action_105 (38) = happyShift action_41
-action_105 (39) = happyShift action_42
-action_105 (40) = happyShift action_43
-action_105 (45) = happyShift action_44
-action_105 (46) = happyShift action_45
-action_105 (47) = happyShift action_46
-action_105 (21) = happyGoto action_39
-action_105 (22) = happyGoto action_127
-action_105 _ = happyReduce_26
+action_105 (38) = happyShift action_135
+action_105 _ = happyFail (happyExpListPerState 105)
 
-action_106 (32) = happyShift action_126
+action_106 (38) = happyShift action_134
 action_106 _ = happyFail (happyExpListPerState 106)
 
-action_107 _ = happyReduce_24
+action_107 (36) = happyShift action_27
+action_107 (43) = happyShift action_28
+action_107 (44) = happyShift action_29
+action_107 (51) = happyShift action_30
+action_107 (57) = happyShift action_31
+action_107 (58) = happyShift action_32
+action_107 (63) = happyShift action_33
+action_107 (64) = happyShift action_34
+action_107 (65) = happyShift action_35
+action_107 (66) = happyShift action_36
+action_107 (67) = happyShift action_37
+action_107 (70) = happyShift action_38
+action_107 (71) = happyShift action_39
+action_107 (72) = happyShift action_17
+action_107 (19) = happyGoto action_22
+action_107 (31) = happyGoto action_133
+action_107 (32) = happyGoto action_24
+action_107 (33) = happyGoto action_25
+action_107 _ = happyFail (happyExpListPerState 107)
 
-action_108 _ = happyReduce_31
+action_108 (37) = happyShift action_132
+action_108 _ = happyFail (happyExpListPerState 108)
 
-action_109 (28) = happyShift action_23
-action_109 (35) = happyShift action_24
-action_109 (36) = happyShift action_25
-action_109 (43) = happyShift action_26
-action_109 (48) = happyShift action_27
-action_109 (49) = happyShift action_28
-action_109 (54) = happyShift action_29
-action_109 (55) = happyShift action_30
-action_109 (56) = happyShift action_31
-action_109 (57) = happyShift action_32
-action_109 (58) = happyShift action_33
-action_109 (61) = happyShift action_34
-action_109 (62) = happyShift action_35
-action_109 (63) = happyShift action_13
-action_109 (15) = happyGoto action_18
-action_109 (23) = happyGoto action_125
-action_109 (24) = happyGoto action_20
-action_109 (25) = happyGoto action_21
+action_109 (39) = happyShift action_131
 action_109 _ = happyFail (happyExpListPerState 109)
 
-action_110 (28) = happyShift action_23
-action_110 (35) = happyShift action_24
-action_110 (36) = happyShift action_25
-action_110 (43) = happyShift action_26
-action_110 (48) = happyShift action_27
-action_110 (49) = happyShift action_28
-action_110 (54) = happyShift action_29
-action_110 (55) = happyShift action_30
-action_110 (56) = happyShift action_31
-action_110 (57) = happyShift action_32
-action_110 (58) = happyShift action_33
-action_110 (61) = happyShift action_34
-action_110 (62) = happyShift action_35
-action_110 (63) = happyShift action_13
-action_110 (15) = happyGoto action_18
-action_110 (23) = happyGoto action_124
-action_110 (24) = happyGoto action_20
-action_110 (25) = happyGoto action_21
+action_110 (39) = happyShift action_130
 action_110 _ = happyFail (happyExpListPerState 110)
 
-action_111 _ = happyReduce_45
+action_111 (36) = happyShift action_27
+action_111 (43) = happyShift action_28
+action_111 (44) = happyShift action_29
+action_111 (51) = happyShift action_30
+action_111 (57) = happyShift action_31
+action_111 (58) = happyShift action_32
+action_111 (63) = happyShift action_33
+action_111 (64) = happyShift action_34
+action_111 (65) = happyShift action_35
+action_111 (66) = happyShift action_36
+action_111 (67) = happyShift action_37
+action_111 (70) = happyShift action_38
+action_111 (71) = happyShift action_39
+action_111 (72) = happyShift action_17
+action_111 (19) = happyGoto action_22
+action_111 (31) = happyGoto action_23
+action_111 (32) = happyGoto action_24
+action_111 (33) = happyGoto action_25
+action_111 (34) = happyGoto action_129
+action_111 _ = happyFail (happyExpListPerState 111)
 
-action_112 (42) = happyShift action_123
-action_112 _ = happyFail (happyExpListPerState 112)
+action_112 _ = happyReduce_40
 
-action_113 (28) = happyShift action_23
-action_113 (35) = happyShift action_24
-action_113 (36) = happyShift action_25
-action_113 (43) = happyShift action_26
-action_113 (48) = happyShift action_27
-action_113 (49) = happyShift action_28
-action_113 (54) = happyShift action_29
-action_113 (55) = happyShift action_30
-action_113 (56) = happyShift action_31
-action_113 (57) = happyShift action_32
-action_113 (58) = happyShift action_33
-action_113 (61) = happyShift action_34
-action_113 (62) = happyShift action_35
-action_113 (63) = happyShift action_13
-action_113 (15) = happyGoto action_18
-action_113 (23) = happyGoto action_122
-action_113 (24) = happyGoto action_20
-action_113 (25) = happyGoto action_21
+action_113 (37) = happyShift action_128
 action_113 _ = happyFail (happyExpListPerState 113)
 
-action_114 (28) = happyShift action_23
-action_114 (35) = happyShift action_24
-action_114 (36) = happyShift action_25
-action_114 (43) = happyShift action_26
-action_114 (48) = happyShift action_27
-action_114 (49) = happyShift action_28
-action_114 (54) = happyShift action_29
-action_114 (55) = happyShift action_30
-action_114 (56) = happyShift action_31
-action_114 (57) = happyShift action_32
-action_114 (58) = happyShift action_33
-action_114 (61) = happyShift action_34
-action_114 (62) = happyShift action_35
-action_114 (63) = happyShift action_13
-action_114 (15) = happyGoto action_18
-action_114 (23) = happyGoto action_121
-action_114 (24) = happyGoto action_20
-action_114 (25) = happyGoto action_21
-action_114 _ = happyFail (happyExpListPerState 114)
+action_114 _ = happyReduce_35
 
-action_115 (29) = happyShift action_120
+action_115 (36) = happyShift action_27
+action_115 (43) = happyShift action_28
+action_115 (44) = happyShift action_29
+action_115 (51) = happyShift action_30
+action_115 (57) = happyShift action_31
+action_115 (58) = happyShift action_32
+action_115 (63) = happyShift action_33
+action_115 (64) = happyShift action_34
+action_115 (65) = happyShift action_35
+action_115 (66) = happyShift action_36
+action_115 (67) = happyShift action_37
+action_115 (70) = happyShift action_38
+action_115 (71) = happyShift action_39
+action_115 (72) = happyShift action_17
+action_115 (19) = happyGoto action_22
+action_115 (31) = happyGoto action_127
+action_115 (32) = happyGoto action_24
+action_115 (33) = happyGoto action_25
 action_115 _ = happyFail (happyExpListPerState 115)
 
-action_116 (29) = happyShift action_119
+action_116 (39) = happyShift action_126
 action_116 _ = happyFail (happyExpListPerState 116)
 
-action_117 (29) = happyShift action_118
+action_117 (60) = happyShift action_125
 action_117 _ = happyFail (happyExpListPerState 117)
 
-action_118 _ = happyReduce_53
+action_118 (55) = happyShift action_46
+action_118 (29) = happyGoto action_124
+action_118 _ = happyReduce_36
 
-action_119 _ = happyReduce_47
+action_119 _ = happyReduce_26
 
-action_120 _ = happyReduce_48
+action_120 (36) = happyShift action_27
+action_120 (43) = happyShift action_28
+action_120 (44) = happyShift action_29
+action_120 (51) = happyShift action_30
+action_120 (57) = happyShift action_31
+action_120 (58) = happyShift action_32
+action_120 (63) = happyShift action_33
+action_120 (64) = happyShift action_34
+action_120 (65) = happyShift action_35
+action_120 (66) = happyShift action_36
+action_120 (67) = happyShift action_37
+action_120 (70) = happyShift action_38
+action_120 (71) = happyShift action_39
+action_120 (72) = happyShift action_17
+action_120 (19) = happyGoto action_22
+action_120 (31) = happyGoto action_123
+action_120 (32) = happyGoto action_24
+action_120 (33) = happyGoto action_25
+action_120 _ = happyFail (happyExpListPerState 120)
 
-action_121 (30) = happyShift action_137
+action_121 (41) = happyShift action_122
 action_121 _ = happyFail (happyExpListPerState 121)
 
-action_122 (30) = happyShift action_136
-action_122 _ = happyFail (happyExpListPerState 122)
+action_122 (49) = happyShift action_58
+action_122 (25) = happyGoto action_56
+action_122 (26) = happyGoto action_151
+action_122 _ = happyReduce_25
 
-action_123 (28) = happyShift action_23
-action_123 (35) = happyShift action_24
-action_123 (36) = happyShift action_25
-action_123 (43) = happyShift action_26
-action_123 (48) = happyShift action_27
-action_123 (49) = happyShift action_28
-action_123 (54) = happyShift action_29
-action_123 (55) = happyShift action_30
-action_123 (56) = happyShift action_31
-action_123 (57) = happyShift action_32
-action_123 (58) = happyShift action_33
-action_123 (61) = happyShift action_34
-action_123 (62) = happyShift action_35
-action_123 (63) = happyShift action_13
-action_123 (15) = happyGoto action_18
-action_123 (23) = happyGoto action_19
-action_123 (24) = happyGoto action_20
-action_123 (25) = happyGoto action_21
-action_123 (26) = happyGoto action_135
+action_123 (37) = happyShift action_150
 action_123 _ = happyFail (happyExpListPerState 123)
 
-action_124 (29) = happyShift action_134
+action_124 (39) = happyShift action_149
 action_124 _ = happyFail (happyExpListPerState 124)
 
-action_125 (29) = happyShift action_133
-action_125 _ = happyFail (happyExpListPerState 125)
+action_125 (46) = happyShift action_49
+action_125 (47) = happyShift action_50
+action_125 (48) = happyShift action_51
+action_125 (53) = happyShift action_52
+action_125 (54) = happyShift action_53
+action_125 (56) = happyShift action_54
+action_125 (27) = happyGoto action_47
+action_125 (28) = happyGoto action_148
+action_125 _ = happyReduce_33
 
-action_126 (28) = happyShift action_23
-action_126 (35) = happyShift action_24
-action_126 (36) = happyShift action_25
-action_126 (43) = happyShift action_26
-action_126 (48) = happyShift action_27
-action_126 (49) = happyShift action_28
-action_126 (54) = happyShift action_29
-action_126 (55) = happyShift action_30
-action_126 (56) = happyShift action_31
-action_126 (57) = happyShift action_32
-action_126 (58) = happyShift action_33
-action_126 (61) = happyShift action_34
-action_126 (62) = happyShift action_35
-action_126 (63) = happyShift action_13
-action_126 (15) = happyGoto action_18
-action_126 (23) = happyGoto action_132
-action_126 (24) = happyGoto action_20
-action_126 (25) = happyGoto action_21
+action_126 (36) = happyShift action_27
+action_126 (43) = happyShift action_28
+action_126 (44) = happyShift action_29
+action_126 (51) = happyShift action_30
+action_126 (57) = happyShift action_31
+action_126 (58) = happyShift action_32
+action_126 (63) = happyShift action_33
+action_126 (64) = happyShift action_34
+action_126 (65) = happyShift action_35
+action_126 (66) = happyShift action_36
+action_126 (67) = happyShift action_37
+action_126 (70) = happyShift action_38
+action_126 (71) = happyShift action_39
+action_126 (72) = happyShift action_17
+action_126 (19) = happyGoto action_22
+action_126 (31) = happyGoto action_147
+action_126 (32) = happyGoto action_24
+action_126 (33) = happyGoto action_25
 action_126 _ = happyFail (happyExpListPerState 126)
 
-action_127 (52) = happyShift action_131
-action_127 _ = happyFail (happyExpListPerState 127)
+action_127 _ = happyReduce_31
 
-action_128 (32) = happyShift action_130
-action_128 _ = happyFail (happyExpListPerState 128)
+action_128 _ = happyReduce_37
 
-action_129 _ = happyReduce_16
+action_129 _ = happyReduce_43
 
-action_130 (28) = happyShift action_23
-action_130 (35) = happyShift action_24
-action_130 (36) = happyShift action_25
-action_130 (43) = happyShift action_26
-action_130 (48) = happyShift action_27
-action_130 (49) = happyShift action_28
-action_130 (54) = happyShift action_29
-action_130 (55) = happyShift action_30
-action_130 (56) = happyShift action_31
-action_130 (57) = happyShift action_32
-action_130 (58) = happyShift action_33
-action_130 (61) = happyShift action_34
-action_130 (62) = happyShift action_35
-action_130 (63) = happyShift action_13
-action_130 (15) = happyGoto action_18
-action_130 (23) = happyGoto action_142
-action_130 (24) = happyGoto action_20
-action_130 (25) = happyGoto action_21
+action_130 (36) = happyShift action_27
+action_130 (43) = happyShift action_28
+action_130 (44) = happyShift action_29
+action_130 (51) = happyShift action_30
+action_130 (57) = happyShift action_31
+action_130 (58) = happyShift action_32
+action_130 (63) = happyShift action_33
+action_130 (64) = happyShift action_34
+action_130 (65) = happyShift action_35
+action_130 (66) = happyShift action_36
+action_130 (67) = happyShift action_37
+action_130 (70) = happyShift action_38
+action_130 (71) = happyShift action_39
+action_130 (72) = happyShift action_17
+action_130 (19) = happyGoto action_22
+action_130 (31) = happyGoto action_146
+action_130 (32) = happyGoto action_24
+action_130 (33) = happyGoto action_25
 action_130 _ = happyFail (happyExpListPerState 130)
 
-action_131 _ = happyReduce_22
+action_131 (36) = happyShift action_27
+action_131 (43) = happyShift action_28
+action_131 (44) = happyShift action_29
+action_131 (51) = happyShift action_30
+action_131 (57) = happyShift action_31
+action_131 (58) = happyShift action_32
+action_131 (63) = happyShift action_33
+action_131 (64) = happyShift action_34
+action_131 (65) = happyShift action_35
+action_131 (66) = happyShift action_36
+action_131 (67) = happyShift action_37
+action_131 (70) = happyShift action_38
+action_131 (71) = happyShift action_39
+action_131 (72) = happyShift action_17
+action_131 (19) = happyGoto action_22
+action_131 (31) = happyGoto action_145
+action_131 (32) = happyGoto action_24
+action_131 (33) = happyGoto action_25
+action_131 _ = happyFail (happyExpListPerState 131)
 
-action_132 _ = happyReduce_20
+action_132 _ = happyReduce_57
 
-action_133 (53) = happyShift action_141
+action_133 (50) = happyShift action_144
 action_133 _ = happyFail (happyExpListPerState 133)
 
-action_134 (59) = happyShift action_140
+action_134 (36) = happyShift action_27
+action_134 (43) = happyShift action_28
+action_134 (44) = happyShift action_29
+action_134 (51) = happyShift action_30
+action_134 (57) = happyShift action_31
+action_134 (58) = happyShift action_32
+action_134 (63) = happyShift action_33
+action_134 (64) = happyShift action_34
+action_134 (65) = happyShift action_35
+action_134 (66) = happyShift action_36
+action_134 (67) = happyShift action_37
+action_134 (70) = happyShift action_38
+action_134 (71) = happyShift action_39
+action_134 (72) = happyShift action_17
+action_134 (19) = happyGoto action_22
+action_134 (31) = happyGoto action_143
+action_134 (32) = happyGoto action_24
+action_134 (33) = happyGoto action_25
 action_134 _ = happyFail (happyExpListPerState 134)
 
-action_135 _ = happyReduce_32
+action_135 (36) = happyShift action_27
+action_135 (43) = happyShift action_28
+action_135 (44) = happyShift action_29
+action_135 (51) = happyShift action_30
+action_135 (57) = happyShift action_31
+action_135 (58) = happyShift action_32
+action_135 (63) = happyShift action_33
+action_135 (64) = happyShift action_34
+action_135 (65) = happyShift action_35
+action_135 (66) = happyShift action_36
+action_135 (67) = happyShift action_37
+action_135 (70) = happyShift action_38
+action_135 (71) = happyShift action_39
+action_135 (72) = happyShift action_17
+action_135 (19) = happyGoto action_22
+action_135 (31) = happyGoto action_142
+action_135 (32) = happyGoto action_24
+action_135 (33) = happyGoto action_25
+action_135 _ = happyFail (happyExpListPerState 135)
 
-action_136 (28) = happyShift action_23
-action_136 (35) = happyShift action_24
-action_136 (36) = happyShift action_25
-action_136 (43) = happyShift action_26
-action_136 (48) = happyShift action_27
-action_136 (49) = happyShift action_28
-action_136 (54) = happyShift action_29
-action_136 (55) = happyShift action_30
-action_136 (56) = happyShift action_31
-action_136 (57) = happyShift action_32
-action_136 (58) = happyShift action_33
-action_136 (61) = happyShift action_34
-action_136 (62) = happyShift action_35
-action_136 (63) = happyShift action_13
-action_136 (15) = happyGoto action_18
-action_136 (23) = happyGoto action_139
-action_136 (24) = happyGoto action_20
-action_136 (25) = happyGoto action_21
+action_136 (37) = happyShift action_141
 action_136 _ = happyFail (happyExpListPerState 136)
 
-action_137 (28) = happyShift action_23
-action_137 (35) = happyShift action_24
-action_137 (36) = happyShift action_25
-action_137 (43) = happyShift action_26
-action_137 (48) = happyShift action_27
-action_137 (49) = happyShift action_28
-action_137 (54) = happyShift action_29
-action_137 (55) = happyShift action_30
-action_137 (56) = happyShift action_31
-action_137 (57) = happyShift action_32
-action_137 (58) = happyShift action_33
-action_137 (61) = happyShift action_34
-action_137 (62) = happyShift action_35
-action_137 (63) = happyShift action_13
-action_137 (15) = happyGoto action_18
-action_137 (23) = happyGoto action_138
-action_137 (24) = happyGoto action_20
-action_137 (25) = happyGoto action_21
+action_137 (37) = happyShift action_140
 action_137 _ = happyFail (happyExpListPerState 137)
 
-action_138 (29) = happyShift action_146
+action_138 (37) = happyShift action_139
 action_138 _ = happyFail (happyExpListPerState 138)
 
-action_139 (29) = happyShift action_145
-action_139 _ = happyFail (happyExpListPerState 139)
+action_139 _ = happyReduce_65
 
-action_140 (28) = happyShift action_23
-action_140 (35) = happyShift action_24
-action_140 (36) = happyShift action_25
-action_140 (43) = happyShift action_26
-action_140 (48) = happyShift action_27
-action_140 (49) = happyShift action_28
-action_140 (54) = happyShift action_29
-action_140 (55) = happyShift action_30
-action_140 (56) = happyShift action_31
-action_140 (57) = happyShift action_32
-action_140 (58) = happyShift action_33
-action_140 (61) = happyShift action_34
-action_140 (62) = happyShift action_35
-action_140 (63) = happyShift action_13
-action_140 (15) = happyGoto action_18
-action_140 (23) = happyGoto action_19
-action_140 (24) = happyGoto action_20
-action_140 (25) = happyGoto action_21
-action_140 (26) = happyGoto action_144
-action_140 _ = happyFail (happyExpListPerState 140)
+action_140 _ = happyReduce_59
 
-action_141 (28) = happyShift action_23
-action_141 (35) = happyShift action_24
-action_141 (36) = happyShift action_25
-action_141 (43) = happyShift action_26
-action_141 (48) = happyShift action_27
-action_141 (49) = happyShift action_28
-action_141 (54) = happyShift action_29
-action_141 (55) = happyShift action_30
-action_141 (56) = happyShift action_31
-action_141 (57) = happyShift action_32
-action_141 (58) = happyShift action_33
-action_141 (61) = happyShift action_34
-action_141 (62) = happyShift action_35
-action_141 (63) = happyShift action_13
-action_141 (15) = happyGoto action_18
-action_141 (23) = happyGoto action_19
-action_141 (24) = happyGoto action_20
-action_141 (25) = happyGoto action_21
-action_141 (26) = happyGoto action_143
-action_141 _ = happyFail (happyExpListPerState 141)
+action_141 _ = happyReduce_60
 
-action_142 _ = happyReduce_21
+action_142 (38) = happyShift action_160
+action_142 _ = happyFail (happyExpListPerState 142)
 
-action_143 _ = happyReduce_30
+action_143 (38) = happyShift action_159
+action_143 _ = happyFail (happyExpListPerState 143)
 
-action_144 _ = happyReduce_29
+action_144 (36) = happyShift action_27
+action_144 (43) = happyShift action_28
+action_144 (44) = happyShift action_29
+action_144 (51) = happyShift action_30
+action_144 (57) = happyShift action_31
+action_144 (58) = happyShift action_32
+action_144 (63) = happyShift action_33
+action_144 (64) = happyShift action_34
+action_144 (65) = happyShift action_35
+action_144 (66) = happyShift action_36
+action_144 (67) = happyShift action_37
+action_144 (70) = happyShift action_38
+action_144 (71) = happyShift action_39
+action_144 (72) = happyShift action_17
+action_144 (19) = happyGoto action_22
+action_144 (31) = happyGoto action_23
+action_144 (32) = happyGoto action_24
+action_144 (33) = happyGoto action_25
+action_144 (34) = happyGoto action_158
+action_144 _ = happyFail (happyExpListPerState 144)
 
-action_145 _ = happyReduce_46
+action_145 (37) = happyShift action_157
+action_145 _ = happyFail (happyExpListPerState 145)
 
-action_146 _ = happyReduce_44
+action_146 (37) = happyShift action_156
+action_146 _ = happyFail (happyExpListPerState 146)
 
-happyReduce_12 = happySpecReduce_1  15 happyReduction_12
-happyReduction_12 (HappyTerminal happy_var_1)
-	 =  HappyAbsSyn15
+action_147 (40) = happyShift action_155
+action_147 _ = happyFail (happyExpListPerState 147)
+
+action_148 (61) = happyShift action_154
+action_148 _ = happyFail (happyExpListPerState 148)
+
+action_149 (36) = happyShift action_27
+action_149 (43) = happyShift action_28
+action_149 (44) = happyShift action_29
+action_149 (51) = happyShift action_30
+action_149 (57) = happyShift action_31
+action_149 (58) = happyShift action_32
+action_149 (63) = happyShift action_33
+action_149 (64) = happyShift action_34
+action_149 (65) = happyShift action_35
+action_149 (66) = happyShift action_36
+action_149 (67) = happyShift action_37
+action_149 (70) = happyShift action_38
+action_149 (71) = happyShift action_39
+action_149 (72) = happyShift action_17
+action_149 (19) = happyGoto action_22
+action_149 (31) = happyGoto action_153
+action_149 (32) = happyGoto action_24
+action_149 (33) = happyGoto action_25
+action_149 _ = happyFail (happyExpListPerState 149)
+
+action_150 _ = happyReduce_21
+
+action_151 (46) = happyShift action_49
+action_151 (47) = happyShift action_50
+action_151 (48) = happyShift action_51
+action_151 (53) = happyShift action_52
+action_151 (54) = happyShift action_53
+action_151 (56) = happyShift action_54
+action_151 (27) = happyGoto action_47
+action_151 (28) = happyGoto action_152
+action_151 _ = happyReduce_33
+
+action_152 _ = happyReduce_20
+
+action_153 (40) = happyShift action_166
+action_153 _ = happyFail (happyExpListPerState 153)
+
+action_154 _ = happyReduce_29
+
+action_155 (36) = happyShift action_27
+action_155 (43) = happyShift action_28
+action_155 (44) = happyShift action_29
+action_155 (51) = happyShift action_30
+action_155 (57) = happyShift action_31
+action_155 (58) = happyShift action_32
+action_155 (63) = happyShift action_33
+action_155 (64) = happyShift action_34
+action_155 (65) = happyShift action_35
+action_155 (66) = happyShift action_36
+action_155 (67) = happyShift action_37
+action_155 (70) = happyShift action_38
+action_155 (71) = happyShift action_39
+action_155 (72) = happyShift action_17
+action_155 (19) = happyGoto action_22
+action_155 (31) = happyGoto action_165
+action_155 (32) = happyGoto action_24
+action_155 (33) = happyGoto action_25
+action_155 _ = happyFail (happyExpListPerState 155)
+
+action_156 (62) = happyShift action_164
+action_156 _ = happyFail (happyExpListPerState 156)
+
+action_157 (68) = happyShift action_163
+action_157 _ = happyFail (happyExpListPerState 157)
+
+action_158 _ = happyReduce_44
+
+action_159 (36) = happyShift action_27
+action_159 (43) = happyShift action_28
+action_159 (44) = happyShift action_29
+action_159 (51) = happyShift action_30
+action_159 (57) = happyShift action_31
+action_159 (58) = happyShift action_32
+action_159 (63) = happyShift action_33
+action_159 (64) = happyShift action_34
+action_159 (65) = happyShift action_35
+action_159 (66) = happyShift action_36
+action_159 (67) = happyShift action_37
+action_159 (70) = happyShift action_38
+action_159 (71) = happyShift action_39
+action_159 (72) = happyShift action_17
+action_159 (19) = happyGoto action_22
+action_159 (31) = happyGoto action_162
+action_159 (32) = happyGoto action_24
+action_159 (33) = happyGoto action_25
+action_159 _ = happyFail (happyExpListPerState 159)
+
+action_160 (36) = happyShift action_27
+action_160 (43) = happyShift action_28
+action_160 (44) = happyShift action_29
+action_160 (51) = happyShift action_30
+action_160 (57) = happyShift action_31
+action_160 (58) = happyShift action_32
+action_160 (63) = happyShift action_33
+action_160 (64) = happyShift action_34
+action_160 (65) = happyShift action_35
+action_160 (66) = happyShift action_36
+action_160 (67) = happyShift action_37
+action_160 (70) = happyShift action_38
+action_160 (71) = happyShift action_39
+action_160 (72) = happyShift action_17
+action_160 (19) = happyGoto action_22
+action_160 (31) = happyGoto action_161
+action_160 (32) = happyGoto action_24
+action_160 (33) = happyGoto action_25
+action_160 _ = happyFail (happyExpListPerState 160)
+
+action_161 (37) = happyShift action_171
+action_161 _ = happyFail (happyExpListPerState 161)
+
+action_162 (37) = happyShift action_170
+action_162 _ = happyFail (happyExpListPerState 162)
+
+action_163 (36) = happyShift action_27
+action_163 (43) = happyShift action_28
+action_163 (44) = happyShift action_29
+action_163 (51) = happyShift action_30
+action_163 (57) = happyShift action_31
+action_163 (58) = happyShift action_32
+action_163 (63) = happyShift action_33
+action_163 (64) = happyShift action_34
+action_163 (65) = happyShift action_35
+action_163 (66) = happyShift action_36
+action_163 (67) = happyShift action_37
+action_163 (70) = happyShift action_38
+action_163 (71) = happyShift action_39
+action_163 (72) = happyShift action_17
+action_163 (19) = happyGoto action_22
+action_163 (31) = happyGoto action_23
+action_163 (32) = happyGoto action_24
+action_163 (33) = happyGoto action_25
+action_163 (34) = happyGoto action_169
+action_163 _ = happyFail (happyExpListPerState 163)
+
+action_164 (36) = happyShift action_27
+action_164 (43) = happyShift action_28
+action_164 (44) = happyShift action_29
+action_164 (51) = happyShift action_30
+action_164 (57) = happyShift action_31
+action_164 (58) = happyShift action_32
+action_164 (63) = happyShift action_33
+action_164 (64) = happyShift action_34
+action_164 (65) = happyShift action_35
+action_164 (66) = happyShift action_36
+action_164 (67) = happyShift action_37
+action_164 (70) = happyShift action_38
+action_164 (71) = happyShift action_39
+action_164 (72) = happyShift action_17
+action_164 (19) = happyGoto action_22
+action_164 (31) = happyGoto action_23
+action_164 (32) = happyGoto action_24
+action_164 (33) = happyGoto action_25
+action_164 (34) = happyGoto action_168
+action_164 _ = happyFail (happyExpListPerState 164)
+
+action_165 _ = happyReduce_27
+
+action_166 (36) = happyShift action_27
+action_166 (43) = happyShift action_28
+action_166 (44) = happyShift action_29
+action_166 (51) = happyShift action_30
+action_166 (57) = happyShift action_31
+action_166 (58) = happyShift action_32
+action_166 (63) = happyShift action_33
+action_166 (64) = happyShift action_34
+action_166 (65) = happyShift action_35
+action_166 (66) = happyShift action_36
+action_166 (67) = happyShift action_37
+action_166 (70) = happyShift action_38
+action_166 (71) = happyShift action_39
+action_166 (72) = happyShift action_17
+action_166 (19) = happyGoto action_22
+action_166 (31) = happyGoto action_167
+action_166 (32) = happyGoto action_24
+action_166 (33) = happyGoto action_25
+action_166 _ = happyFail (happyExpListPerState 166)
+
+action_167 _ = happyReduce_28
+
+action_168 _ = happyReduce_42
+
+action_169 _ = happyReduce_41
+
+action_170 _ = happyReduce_58
+
+action_171 _ = happyReduce_56
+
+happyReduce_16 = happySpecReduce_1  19 happyReduction_16
+happyReduction_16 (HappyTerminal happy_var_1)
+	 =  HappyAbsSyn19
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.VarIdent (tokenText happy_var_1))
 	)
-happyReduction_12 _  = notHappyAtAll 
+happyReduction_16 _  = notHappyAtAll 
 
-happyReduce_13 = happySpecReduce_1  16 happyReduction_13
-happyReduction_13 (HappyAbsSyn17  happy_var_1)
-	 =  HappyAbsSyn16
+happyReduce_17 = happySpecReduce_1  20 happyReduction_17
+happyReduction_17 (HappyAbsSyn21  happy_var_1)
+	 =  HappyAbsSyn20
 		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.AProgram (fst happy_var_1) (snd happy_var_1))
 	)
-happyReduction_13 _  = notHappyAtAll 
+happyReduction_17 _  = notHappyAtAll 
 
-happyReduce_14 = happySpecReduce_0  17 happyReduction_14
-happyReduction_14  =  HappyAbsSyn17
+happyReduce_18 = happySpecReduce_0  21 happyReduction_18
+happyReduction_18  =  HappyAbsSyn21
 		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
 	)
 
-happyReduce_15 = happySpecReduce_2  17 happyReduction_15
-happyReduction_15 (HappyAbsSyn17  happy_var_2)
-	(HappyAbsSyn18  happy_var_1)
-	 =  HappyAbsSyn17
+happyReduce_19 = happySpecReduce_2  21 happyReduction_19
+happyReduction_19 (HappyAbsSyn21  happy_var_2)
+	(HappyAbsSyn22  happy_var_1)
+	 =  HappyAbsSyn21
 		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_2))
 	)
-happyReduction_15 _ _  = notHappyAtAll 
+happyReduction_19 _ _  = notHappyAtAll 
 
-happyReduce_16 = happyReduce 5 18 happyReduction_16
-happyReduction_16 ((HappyAbsSyn22  happy_var_5) `HappyStk`
-	(HappyAbsSyn20  happy_var_4) `HappyStk`
+happyReduce_20 = happyReduce 6 22 happyReduction_20
+happyReduction_20 ((HappyAbsSyn28  happy_var_6) `HappyStk`
+	(HappyAbsSyn26  happy_var_5) `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn15  happy_var_2) `HappyStk`
+	(HappyAbsSyn24  happy_var_3) `HappyStk`
+	(HappyAbsSyn19  happy_var_2) `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
-	 = HappyAbsSyn18
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.AModule (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4) (snd happy_var_5))
+	 = HappyAbsSyn22
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.AModule (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_3) (snd happy_var_5) (snd happy_var_6))
 	) `HappyStk` happyRest
 
-happyReduce_17 = happySpecReduce_2  19 happyReduction_17
-happyReduction_17 (HappyAbsSyn15  happy_var_2)
-	(HappyTerminal happy_var_1)
-	 =  HappyAbsSyn19
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.AnImport (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
-	)
-happyReduction_17 _ _  = notHappyAtAll 
+happyReduce_21 = happyReduce 5 23 happyReduction_21
+happyReduction_21 (_ `HappyStk`
+	(HappyAbsSyn31  happy_var_4) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn19  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn23
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.AParam (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
+	) `HappyStk` happyRest
 
-happyReduce_18 = happySpecReduce_0  20 happyReduction_18
-happyReduction_18  =  HappyAbsSyn20
+happyReduce_22 = happySpecReduce_0  24 happyReduction_22
+happyReduction_22  =  HappyAbsSyn24
 		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
 	)
 
-happyReduce_19 = happySpecReduce_3  20 happyReduction_19
-happyReduction_19 (HappyAbsSyn20  happy_var_3)
-	_
-	(HappyAbsSyn19  happy_var_1)
-	 =  HappyAbsSyn20
-		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_3))
-	)
-happyReduction_19 _ _ _  = notHappyAtAll 
-
-happyReduce_20 = happyReduce 6 21 happyReduction_20
-happyReduction_20 ((HappyAbsSyn23  happy_var_6) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn23  happy_var_4) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn15  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn21
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclDef (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4) (snd happy_var_6))
-	) `HappyStk` happyRest
-
-happyReduce_21 = happyReduce 7 21 happyReduction_21
-happyReduction_21 ((HappyAbsSyn23  happy_var_7) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn23  happy_var_5) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn15  happy_var_3) `HappyStk`
-	_ `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn21
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclPrivateDef (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_7))
-	) `HappyStk` happyRest
-
-happyReduce_22 = happyReduce 6 21 happyReduction_22
-happyReduction_22 (_ `HappyStk`
-	(HappyAbsSyn22  happy_var_5) `HappyStk`
-	_ `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn15  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn21
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclNamespace (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_5))
-	) `HappyStk` happyRest
-
-happyReduce_23 = happySpecReduce_2  21 happyReduction_23
-happyReduction_23 (HappyAbsSyn15  happy_var_2)
-	(HappyTerminal happy_var_1)
-	 =  HappyAbsSyn21
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclOpen (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
+happyReduce_23 = happySpecReduce_2  24 happyReduction_23
+happyReduction_23 (HappyAbsSyn24  happy_var_2)
+	(HappyAbsSyn23  happy_var_1)
+	 =  HappyAbsSyn24
+		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_2))
 	)
 happyReduction_23 _ _  = notHappyAtAll 
 
-happyReduce_24 = happyReduce 4 21 happyReduction_24
-happyReduction_24 ((HappyAbsSyn23  happy_var_4) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn23  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn21
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclCheck (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
-	) `HappyStk` happyRest
-
-happyReduce_25 = happySpecReduce_2  21 happyReduction_25
-happyReduction_25 (HappyAbsSyn23  happy_var_2)
+happyReduce_24 = happySpecReduce_2  25 happyReduction_24
+happyReduction_24 (HappyAbsSyn19  happy_var_2)
 	(HappyTerminal happy_var_1)
-	 =  HappyAbsSyn21
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclCompute (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
+	 =  HappyAbsSyn25
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.AnImport (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
 	)
-happyReduction_25 _ _  = notHappyAtAll 
+happyReduction_24 _ _  = notHappyAtAll 
 
-happyReduce_26 = happySpecReduce_0  22 happyReduction_26
-happyReduction_26  =  HappyAbsSyn22
+happyReduce_25 = happySpecReduce_0  26 happyReduction_25
+happyReduction_25  =  HappyAbsSyn26
 		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
 	)
 
-happyReduce_27 = happySpecReduce_1  22 happyReduction_27
-happyReduction_27 (HappyAbsSyn21  happy_var_1)
-	 =  HappyAbsSyn22
-		 ((fst happy_var_1, (:[]) (snd happy_var_1))
-	)
-happyReduction_27 _  = notHappyAtAll 
-
-happyReduce_28 = happySpecReduce_3  22 happyReduction_28
-happyReduction_28 (HappyAbsSyn22  happy_var_3)
+happyReduce_26 = happySpecReduce_3  26 happyReduction_26
+happyReduction_26 (HappyAbsSyn26  happy_var_3)
 	_
-	(HappyAbsSyn21  happy_var_1)
-	 =  HappyAbsSyn22
+	(HappyAbsSyn25  happy_var_1)
+	 =  HappyAbsSyn26
 		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_3))
 	)
-happyReduction_28 _ _ _  = notHappyAtAll 
+happyReduction_26 _ _ _  = notHappyAtAll 
 
-happyReduce_29 = happyReduce 8 23 happyReduction_29
-happyReduction_29 ((HappyAbsSyn26  happy_var_8) `HappyStk`
+happyReduce_27 = happyReduce 7 27 happyReduction_27
+happyReduction_27 ((HappyAbsSyn31  happy_var_7) `HappyStk`
 	_ `HappyStk`
+	(HappyAbsSyn31  happy_var_5) `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn23  happy_var_5) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn27  happy_var_3) `HappyStk`
-	_ `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn23
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Pi (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_8))
-	) `HappyStk` happyRest
-
-happyReduce_30 = happyReduce 8 23 happyReduction_30
-happyReduction_30 ((HappyAbsSyn26  happy_var_8) `HappyStk`
-	_ `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn23  happy_var_5) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn27  happy_var_3) `HappyStk`
-	_ `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn23
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Sigma (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_8))
-	) `HappyStk` happyRest
-
-happyReduce_31 = happyReduce 4 23 happyReduction_31
-happyReduction_31 ((HappyAbsSyn26  happy_var_4) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn27  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn23
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Lam (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
-	) `HappyStk` happyRest
-
-happyReduce_32 = happyReduce 6 23 happyReduction_32
-happyReduction_32 ((HappyAbsSyn26  happy_var_6) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn23  happy_var_4) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn27  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn23
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Let (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4) (snd happy_var_6))
-	) `HappyStk` happyRest
-
-happyReduce_33 = happySpecReduce_3  23 happyReduction_33
-happyReduction_33 (HappyAbsSyn23  happy_var_3)
-	_
-	(HappyAbsSyn23  happy_var_1)
-	 =  HappyAbsSyn23
-		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.Arrow (fst happy_var_1) (snd happy_var_1) (snd happy_var_3))
-	)
-happyReduction_33 _ _ _  = notHappyAtAll 
-
-happyReduce_34 = happySpecReduce_3  23 happyReduction_34
-happyReduction_34 (HappyAbsSyn23  happy_var_3)
-	_
-	(HappyAbsSyn23  happy_var_1)
-	 =  HappyAbsSyn23
-		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.Product (fst happy_var_1) (snd happy_var_1) (snd happy_var_3))
-	)
-happyReduction_34 _ _ _  = notHappyAtAll 
-
-happyReduce_35 = happySpecReduce_1  23 happyReduction_35
-happyReduction_35 (HappyAbsSyn23  happy_var_1)
-	 =  HappyAbsSyn23
-		 ((fst happy_var_1, (snd happy_var_1))
-	)
-happyReduction_35 _  = notHappyAtAll 
-
-happyReduce_36 = happySpecReduce_2  24 happyReduction_36
-happyReduction_36 (HappyAbsSyn23  happy_var_2)
-	(HappyAbsSyn23  happy_var_1)
-	 =  HappyAbsSyn23
-		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.App (fst happy_var_1) (snd happy_var_1) (snd happy_var_2))
-	)
-happyReduction_36 _ _  = notHappyAtAll 
-
-happyReduce_37 = happySpecReduce_1  24 happyReduction_37
-happyReduction_37 (HappyAbsSyn23  happy_var_1)
-	 =  HappyAbsSyn23
-		 ((fst happy_var_1, (snd happy_var_1))
-	)
-happyReduction_37 _  = notHappyAtAll 
-
-happyReduce_38 = happySpecReduce_2  25 happyReduction_38
-happyReduction_38 (HappyAbsSyn23  happy_var_2)
-	(HappyTerminal happy_var_1)
-	 =  HappyAbsSyn23
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.First (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
-	)
-happyReduction_38 _ _  = notHappyAtAll 
-
-happyReduce_39 = happySpecReduce_2  25 happyReduction_39
-happyReduction_39 (HappyAbsSyn23  happy_var_2)
-	(HappyTerminal happy_var_1)
-	 =  HappyAbsSyn23
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Second (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
-	)
-happyReduction_39 _ _  = notHappyAtAll 
-
-happyReduce_40 = happySpecReduce_1  25 happyReduction_40
-happyReduction_40 (HappyTerminal happy_var_1)
-	 =  HappyAbsSyn23
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Universe (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
-	)
-happyReduction_40 _  = notHappyAtAll 
-
-happyReduce_41 = happySpecReduce_1  25 happyReduction_41
-happyReduction_41 (HappyTerminal happy_var_1)
-	 =  HappyAbsSyn23
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.UnitType (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
-	)
-happyReduction_41 _  = notHappyAtAll 
-
-happyReduce_42 = happySpecReduce_1  25 happyReduction_42
-happyReduction_42 (HappyTerminal happy_var_1)
-	 =  HappyAbsSyn23
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.UnitVal (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
-	)
-happyReduction_42 _  = notHappyAtAll 
-
-happyReduce_43 = happySpecReduce_1  25 happyReduction_43
-happyReduction_43 (HappyAbsSyn15  happy_var_1)
-	 =  HappyAbsSyn23
-		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.Var (fst happy_var_1) (snd happy_var_1))
-	)
-happyReduction_43 _  = notHappyAtAll 
-
-happyReduce_44 = happyReduce 8 25 happyReduction_44
-happyReduction_44 (_ `HappyStk`
-	(HappyAbsSyn23  happy_var_7) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn23  happy_var_5) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn23  happy_var_3) `HappyStk`
-	_ `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn23
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.IdType (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_7))
-	) `HappyStk` happyRest
-
-happyReduce_45 = happyReduce 4 25 happyReduction_45
-happyReduction_45 (_ `HappyStk`
-	(HappyAbsSyn23  happy_var_3) `HappyStk`
-	_ `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn23
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Refl (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3))
-	) `HappyStk` happyRest
-
-happyReduce_46 = happyReduce 8 25 happyReduction_46
-happyReduction_46 (_ `HappyStk`
-	(HappyAbsSyn23  happy_var_7) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn23  happy_var_5) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn23  happy_var_3) `HappyStk`
-	_ `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn23
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.J (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_7))
-	) `HappyStk` happyRest
-
-happyReduce_47 = happyReduce 5 25 happyReduction_47
-happyReduction_47 (_ `HappyStk`
-	(HappyAbsSyn23  happy_var_4) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn23  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn23
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Pair (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
-	) `HappyStk` happyRest
-
-happyReduce_48 = happyReduce 5 25 happyReduction_48
-happyReduction_48 (_ `HappyStk`
-	(HappyAbsSyn23  happy_var_4) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn23  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn23
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Ann (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
-	) `HappyStk` happyRest
-
-happyReduce_49 = happySpecReduce_3  25 happyReduction_49
-happyReduction_49 _
-	(HappyAbsSyn23  happy_var_2)
-	(HappyTerminal happy_var_1)
-	 =  HappyAbsSyn23
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), (snd happy_var_2))
-	)
-happyReduction_49 _ _ _  = notHappyAtAll 
-
-happyReduce_50 = happySpecReduce_1  26 happyReduction_50
-happyReduction_50 (HappyAbsSyn23  happy_var_1)
-	 =  HappyAbsSyn26
-		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.AScopedTerm (fst happy_var_1) (snd happy_var_1))
-	)
-happyReduction_50 _  = notHappyAtAll 
-
-happyReduce_51 = happySpecReduce_1  27 happyReduction_51
-happyReduction_51 (HappyTerminal happy_var_1)
-	 =  HappyAbsSyn27
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.PatternWildcard (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
-	)
-happyReduction_51 _  = notHappyAtAll 
-
-happyReduce_52 = happySpecReduce_1  27 happyReduction_52
-happyReduction_52 (HappyAbsSyn15  happy_var_1)
-	 =  HappyAbsSyn27
-		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.PatternVar (fst happy_var_1) (snd happy_var_1))
-	)
-happyReduction_52 _  = notHappyAtAll 
-
-happyReduce_53 = happyReduce 5 27 happyReduction_53
-happyReduction_53 (_ `HappyStk`
-	(HappyAbsSyn27  happy_var_4) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn27  happy_var_2) `HappyStk`
+	(HappyAbsSyn29  happy_var_3) `HappyStk`
+	(HappyAbsSyn19  happy_var_2) `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
 	 = HappyAbsSyn27
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclDef (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_3) (snd happy_var_5) (snd happy_var_7))
+	) `HappyStk` happyRest
+
+happyReduce_28 = happyReduce 8 27 happyReduction_28
+happyReduction_28 ((HappyAbsSyn31  happy_var_8) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn31  happy_var_6) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn29  happy_var_4) `HappyStk`
+	(HappyAbsSyn19  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn27
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclPrivateDef (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_4) (snd happy_var_6) (snd happy_var_8))
+	) `HappyStk` happyRest
+
+happyReduce_29 = happyReduce 6 27 happyReduction_29
+happyReduction_29 (_ `HappyStk`
+	(HappyAbsSyn28  happy_var_5) `HappyStk`
+	_ `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn19  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn27
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclNamespace (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_5))
+	) `HappyStk` happyRest
+
+happyReduce_30 = happySpecReduce_2  27 happyReduction_30
+happyReduction_30 (HappyAbsSyn19  happy_var_2)
+	(HappyTerminal happy_var_1)
+	 =  HappyAbsSyn27
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclOpen (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
+	)
+happyReduction_30 _ _  = notHappyAtAll 
+
+happyReduce_31 = happyReduce 4 27 happyReduction_31
+happyReduction_31 ((HappyAbsSyn31  happy_var_4) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn31  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn27
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclCheck (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
+	) `HappyStk` happyRest
+
+happyReduce_32 = happySpecReduce_2  27 happyReduction_32
+happyReduction_32 (HappyAbsSyn31  happy_var_2)
+	(HappyTerminal happy_var_1)
+	 =  HappyAbsSyn27
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclCompute (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
+	)
+happyReduction_32 _ _  = notHappyAtAll 
+
+happyReduce_33 = happySpecReduce_0  28 happyReduction_33
+happyReduction_33  =  HappyAbsSyn28
+		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
+	)
+
+happyReduce_34 = happySpecReduce_1  28 happyReduction_34
+happyReduction_34 (HappyAbsSyn27  happy_var_1)
+	 =  HappyAbsSyn28
+		 ((fst happy_var_1, (:[]) (snd happy_var_1))
+	)
+happyReduction_34 _  = notHappyAtAll 
+
+happyReduce_35 = happySpecReduce_3  28 happyReduction_35
+happyReduction_35 (HappyAbsSyn28  happy_var_3)
+	_
+	(HappyAbsSyn27  happy_var_1)
+	 =  HappyAbsSyn28
+		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_3))
+	)
+happyReduction_35 _ _ _  = notHappyAtAll 
+
+happyReduce_36 = happySpecReduce_0  29 happyReduction_36
+happyReduction_36  =  HappyAbsSyn29
+		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, Language.MLTT.Syntax.Abs.NoDischarge Language.MLTT.Syntax.Abs.BNFC'NoPosition)
+	)
+
+happyReduce_37 = happyReduce 4 29 happyReduction_37
+happyReduction_37 (_ `HappyStk`
+	(HappyAbsSyn30  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn29
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DischargeOver (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3))
+	) `HappyStk` happyRest
+
+happyReduce_38 = happySpecReduce_0  30 happyReduction_38
+happyReduction_38  =  HappyAbsSyn30
+		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
+	)
+
+happyReduce_39 = happySpecReduce_1  30 happyReduction_39
+happyReduction_39 (HappyAbsSyn19  happy_var_1)
+	 =  HappyAbsSyn30
+		 ((fst happy_var_1, (:[]) (snd happy_var_1))
+	)
+happyReduction_39 _  = notHappyAtAll 
+
+happyReduce_40 = happySpecReduce_3  30 happyReduction_40
+happyReduction_40 (HappyAbsSyn30  happy_var_3)
+	_
+	(HappyAbsSyn19  happy_var_1)
+	 =  HappyAbsSyn30
+		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_3))
+	)
+happyReduction_40 _ _ _  = notHappyAtAll 
+
+happyReduce_41 = happyReduce 8 31 happyReduction_41
+happyReduction_41 ((HappyAbsSyn34  happy_var_8) `HappyStk`
+	_ `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn31  happy_var_5) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn35  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn31
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Pi (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_8))
+	) `HappyStk` happyRest
+
+happyReduce_42 = happyReduce 8 31 happyReduction_42
+happyReduction_42 ((HappyAbsSyn34  happy_var_8) `HappyStk`
+	_ `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn31  happy_var_5) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn35  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn31
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Sigma (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_8))
+	) `HappyStk` happyRest
+
+happyReduce_43 = happyReduce 4 31 happyReduction_43
+happyReduction_43 ((HappyAbsSyn34  happy_var_4) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn35  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn31
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Lam (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
+	) `HappyStk` happyRest
+
+happyReduce_44 = happyReduce 6 31 happyReduction_44
+happyReduction_44 ((HappyAbsSyn34  happy_var_6) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn31  happy_var_4) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn35  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn31
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Let (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4) (snd happy_var_6))
+	) `HappyStk` happyRest
+
+happyReduce_45 = happySpecReduce_3  31 happyReduction_45
+happyReduction_45 (HappyAbsSyn31  happy_var_3)
+	_
+	(HappyAbsSyn31  happy_var_1)
+	 =  HappyAbsSyn31
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.Arrow (fst happy_var_1) (snd happy_var_1) (snd happy_var_3))
+	)
+happyReduction_45 _ _ _  = notHappyAtAll 
+
+happyReduce_46 = happySpecReduce_3  31 happyReduction_46
+happyReduction_46 (HappyAbsSyn31  happy_var_3)
+	_
+	(HappyAbsSyn31  happy_var_1)
+	 =  HappyAbsSyn31
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.Product (fst happy_var_1) (snd happy_var_1) (snd happy_var_3))
+	)
+happyReduction_46 _ _ _  = notHappyAtAll 
+
+happyReduce_47 = happySpecReduce_1  31 happyReduction_47
+happyReduction_47 (HappyAbsSyn31  happy_var_1)
+	 =  HappyAbsSyn31
+		 ((fst happy_var_1, (snd happy_var_1))
+	)
+happyReduction_47 _  = notHappyAtAll 
+
+happyReduce_48 = happySpecReduce_2  32 happyReduction_48
+happyReduction_48 (HappyAbsSyn31  happy_var_2)
+	(HappyAbsSyn31  happy_var_1)
+	 =  HappyAbsSyn31
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.App (fst happy_var_1) (snd happy_var_1) (snd happy_var_2))
+	)
+happyReduction_48 _ _  = notHappyAtAll 
+
+happyReduce_49 = happySpecReduce_1  32 happyReduction_49
+happyReduction_49 (HappyAbsSyn31  happy_var_1)
+	 =  HappyAbsSyn31
+		 ((fst happy_var_1, (snd happy_var_1))
+	)
+happyReduction_49 _  = notHappyAtAll 
+
+happyReduce_50 = happySpecReduce_2  33 happyReduction_50
+happyReduction_50 (HappyAbsSyn31  happy_var_2)
+	(HappyTerminal happy_var_1)
+	 =  HappyAbsSyn31
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.First (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
+	)
+happyReduction_50 _ _  = notHappyAtAll 
+
+happyReduce_51 = happySpecReduce_2  33 happyReduction_51
+happyReduction_51 (HappyAbsSyn31  happy_var_2)
+	(HappyTerminal happy_var_1)
+	 =  HappyAbsSyn31
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Second (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
+	)
+happyReduction_51 _ _  = notHappyAtAll 
+
+happyReduce_52 = happySpecReduce_1  33 happyReduction_52
+happyReduction_52 (HappyTerminal happy_var_1)
+	 =  HappyAbsSyn31
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Universe (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
+	)
+happyReduction_52 _  = notHappyAtAll 
+
+happyReduce_53 = happySpecReduce_1  33 happyReduction_53
+happyReduction_53 (HappyTerminal happy_var_1)
+	 =  HappyAbsSyn31
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.UnitType (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
+	)
+happyReduction_53 _  = notHappyAtAll 
+
+happyReduce_54 = happySpecReduce_1  33 happyReduction_54
+happyReduction_54 (HappyTerminal happy_var_1)
+	 =  HappyAbsSyn31
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.UnitVal (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
+	)
+happyReduction_54 _  = notHappyAtAll 
+
+happyReduce_55 = happySpecReduce_1  33 happyReduction_55
+happyReduction_55 (HappyAbsSyn19  happy_var_1)
+	 =  HappyAbsSyn31
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.Var (fst happy_var_1) (snd happy_var_1))
+	)
+happyReduction_55 _  = notHappyAtAll 
+
+happyReduce_56 = happyReduce 8 33 happyReduction_56
+happyReduction_56 (_ `HappyStk`
+	(HappyAbsSyn31  happy_var_7) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn31  happy_var_5) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn31  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn31
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.IdType (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_7))
+	) `HappyStk` happyRest
+
+happyReduce_57 = happyReduce 4 33 happyReduction_57
+happyReduction_57 (_ `HappyStk`
+	(HappyAbsSyn31  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn31
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Refl (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3))
+	) `HappyStk` happyRest
+
+happyReduce_58 = happyReduce 8 33 happyReduction_58
+happyReduction_58 (_ `HappyStk`
+	(HappyAbsSyn31  happy_var_7) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn31  happy_var_5) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn31  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn31
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.J (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_7))
+	) `HappyStk` happyRest
+
+happyReduce_59 = happyReduce 5 33 happyReduction_59
+happyReduction_59 (_ `HappyStk`
+	(HappyAbsSyn31  happy_var_4) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn31  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn31
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Pair (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
+	) `HappyStk` happyRest
+
+happyReduce_60 = happyReduce 5 33 happyReduction_60
+happyReduction_60 (_ `HappyStk`
+	(HappyAbsSyn31  happy_var_4) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn31  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn31
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Ann (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
+	) `HappyStk` happyRest
+
+happyReduce_61 = happySpecReduce_3  33 happyReduction_61
+happyReduction_61 _
+	(HappyAbsSyn31  happy_var_2)
+	(HappyTerminal happy_var_1)
+	 =  HappyAbsSyn31
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), (snd happy_var_2))
+	)
+happyReduction_61 _ _ _  = notHappyAtAll 
+
+happyReduce_62 = happySpecReduce_1  34 happyReduction_62
+happyReduction_62 (HappyAbsSyn31  happy_var_1)
+	 =  HappyAbsSyn34
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.AScopedTerm (fst happy_var_1) (snd happy_var_1))
+	)
+happyReduction_62 _  = notHappyAtAll 
+
+happyReduce_63 = happySpecReduce_1  35 happyReduction_63
+happyReduction_63 (HappyTerminal happy_var_1)
+	 =  HappyAbsSyn35
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.PatternWildcard (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
+	)
+happyReduction_63 _  = notHappyAtAll 
+
+happyReduce_64 = happySpecReduce_1  35 happyReduction_64
+happyReduction_64 (HappyAbsSyn19  happy_var_1)
+	 =  HappyAbsSyn35
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.PatternVar (fst happy_var_1) (snd happy_var_1))
+	)
+happyReduction_64 _  = notHappyAtAll 
+
+happyReduce_65 = happyReduce 5 35 happyReduction_65
+happyReduction_65 (_ `HappyStk`
+	(HappyAbsSyn35  happy_var_4) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn35  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn35
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.PatternPair (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
 	) `HappyStk` happyRest
 
 happyNewToken action sts stk [] =
-	action 64 64 notHappyAtAll (HappyState action) sts stk []
+	action 73 73 notHappyAtAll (HappyState action) sts stk []
 
 happyNewToken action sts stk (tk:tks) =
 	let cont i = action i i tk (HappyState action) sts stk tks in
 	case tk of {
-	PT _ (TS _ 1) -> cont 28;
-	PT _ (TS _ 2) -> cont 29;
-	PT _ (TS _ 3) -> cont 30;
-	PT _ (TS _ 4) -> cont 31;
-	PT _ (TS _ 5) -> cont 32;
-	PT _ (TS _ 6) -> cont 33;
-	PT _ (TS _ 7) -> cont 34;
-	PT _ (TS _ 8) -> cont 35;
-	PT _ (TS _ 9) -> cont 36;
-	PT _ (TS _ 10) -> cont 37;
-	PT _ (TS _ 11) -> cont 38;
-	PT _ (TS _ 12) -> cont 39;
-	PT _ (TS _ 13) -> cont 40;
-	PT _ (TS _ 14) -> cont 41;
-	PT _ (TS _ 15) -> cont 42;
-	PT _ (TS _ 16) -> cont 43;
-	PT _ (TS _ 17) -> cont 44;
-	PT _ (TS _ 18) -> cont 45;
-	PT _ (TS _ 19) -> cont 46;
-	PT _ (TS _ 20) -> cont 47;
-	PT _ (TS _ 21) -> cont 48;
-	PT _ (TS _ 22) -> cont 49;
-	PT _ (TS _ 23) -> cont 50;
-	PT _ (TS _ 24) -> cont 51;
-	PT _ (TS _ 25) -> cont 52;
-	PT _ (TS _ 26) -> cont 53;
-	PT _ (TS _ 27) -> cont 54;
-	PT _ (TS _ 28) -> cont 55;
-	PT _ (TS _ 29) -> cont 56;
-	PT _ (TS _ 30) -> cont 57;
-	PT _ (TS _ 31) -> cont 58;
-	PT _ (TS _ 32) -> cont 59;
-	PT _ (TS _ 33) -> cont 60;
-	PT _ (TS _ 34) -> cont 61;
-	PT _ (TS _ 35) -> cont 62;
-	PT _ (T_VarIdent _) -> cont 63;
+	PT _ (TS _ 1) -> cont 36;
+	PT _ (TS _ 2) -> cont 37;
+	PT _ (TS _ 3) -> cont 38;
+	PT _ (TS _ 4) -> cont 39;
+	PT _ (TS _ 5) -> cont 40;
+	PT _ (TS _ 6) -> cont 41;
+	PT _ (TS _ 7) -> cont 42;
+	PT _ (TS _ 8) -> cont 43;
+	PT _ (TS _ 9) -> cont 44;
+	PT _ (TS _ 10) -> cont 45;
+	PT _ (TS _ 11) -> cont 46;
+	PT _ (TS _ 12) -> cont 47;
+	PT _ (TS _ 13) -> cont 48;
+	PT _ (TS _ 14) -> cont 49;
+	PT _ (TS _ 15) -> cont 50;
+	PT _ (TS _ 16) -> cont 51;
+	PT _ (TS _ 17) -> cont 52;
+	PT _ (TS _ 18) -> cont 53;
+	PT _ (TS _ 19) -> cont 54;
+	PT _ (TS _ 20) -> cont 55;
+	PT _ (TS _ 21) -> cont 56;
+	PT _ (TS _ 22) -> cont 57;
+	PT _ (TS _ 23) -> cont 58;
+	PT _ (TS _ 24) -> cont 59;
+	PT _ (TS _ 25) -> cont 60;
+	PT _ (TS _ 26) -> cont 61;
+	PT _ (TS _ 27) -> cont 62;
+	PT _ (TS _ 28) -> cont 63;
+	PT _ (TS _ 29) -> cont 64;
+	PT _ (TS _ 30) -> cont 65;
+	PT _ (TS _ 31) -> cont 66;
+	PT _ (TS _ 32) -> cont 67;
+	PT _ (TS _ 33) -> cont 68;
+	PT _ (TS _ 34) -> cont 69;
+	PT _ (TS _ 35) -> cont 70;
+	PT _ (TS _ 36) -> cont 71;
+	PT _ (T_VarIdent _) -> cont 72;
 	_ -> happyError' ((tk:tks), [])
 	}
 
-happyError_ explist 64 tk tks = happyError' (tks, explist)
+happyError_ explist 73 tk tks = happyError' (tks, explist)
 happyError_ explist _ tk tks = happyError' ((tk:tks), explist)
 
 happyThen :: () => Err a -> (a -> Err b) -> Err b
@@ -1757,40 +1967,52 @@ happyReturn1 = \a tks -> (return) a
 happyError' :: () => ([(Token)], [Prelude.String]) -> Err a
 happyError' = (\(tokens, _) -> happyError tokens)
 pProgram_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_0 tks) (\x -> case x of {HappyAbsSyn16 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_0 tks) (\x -> case x of {HappyAbsSyn20 z -> happyReturn z; _other -> notHappyAtAll })
 
 pListModule_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_1 tks) (\x -> case x of {HappyAbsSyn17 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_1 tks) (\x -> case x of {HappyAbsSyn21 z -> happyReturn z; _other -> notHappyAtAll })
 
 pModule_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_2 tks) (\x -> case x of {HappyAbsSyn18 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_2 tks) (\x -> case x of {HappyAbsSyn22 z -> happyReturn z; _other -> notHappyAtAll })
+
+pParam_internal tks = happySomeParser where
+ happySomeParser = happyThen (happyParse action_3 tks) (\x -> case x of {HappyAbsSyn23 z -> happyReturn z; _other -> notHappyAtAll })
+
+pListParam_internal tks = happySomeParser where
+ happySomeParser = happyThen (happyParse action_4 tks) (\x -> case x of {HappyAbsSyn24 z -> happyReturn z; _other -> notHappyAtAll })
 
 pImport_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_3 tks) (\x -> case x of {HappyAbsSyn19 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_5 tks) (\x -> case x of {HappyAbsSyn25 z -> happyReturn z; _other -> notHappyAtAll })
 
 pListImport_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_4 tks) (\x -> case x of {HappyAbsSyn20 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_6 tks) (\x -> case x of {HappyAbsSyn26 z -> happyReturn z; _other -> notHappyAtAll })
 
 pDecl_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_5 tks) (\x -> case x of {HappyAbsSyn21 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_7 tks) (\x -> case x of {HappyAbsSyn27 z -> happyReturn z; _other -> notHappyAtAll })
 
 pListDecl_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_6 tks) (\x -> case x of {HappyAbsSyn22 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_8 tks) (\x -> case x of {HappyAbsSyn28 z -> happyReturn z; _other -> notHappyAtAll })
+
+pDischarge_internal tks = happySomeParser where
+ happySomeParser = happyThen (happyParse action_9 tks) (\x -> case x of {HappyAbsSyn29 z -> happyReturn z; _other -> notHappyAtAll })
+
+pListVarIdent_internal tks = happySomeParser where
+ happySomeParser = happyThen (happyParse action_10 tks) (\x -> case x of {HappyAbsSyn30 z -> happyReturn z; _other -> notHappyAtAll })
 
 pTerm_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_7 tks) (\x -> case x of {HappyAbsSyn23 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_11 tks) (\x -> case x of {HappyAbsSyn31 z -> happyReturn z; _other -> notHappyAtAll })
 
 pTerm1_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_8 tks) (\x -> case x of {HappyAbsSyn23 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_12 tks) (\x -> case x of {HappyAbsSyn31 z -> happyReturn z; _other -> notHappyAtAll })
 
 pTerm2_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_9 tks) (\x -> case x of {HappyAbsSyn23 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_13 tks) (\x -> case x of {HappyAbsSyn31 z -> happyReturn z; _other -> notHappyAtAll })
 
 pScopedTerm_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_10 tks) (\x -> case x of {HappyAbsSyn26 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_14 tks) (\x -> case x of {HappyAbsSyn34 z -> happyReturn z; _other -> notHappyAtAll })
 
 pPattern_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_11 tks) (\x -> case x of {HappyAbsSyn27 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_15 tks) (\x -> case x of {HappyAbsSyn35 z -> happyReturn z; _other -> notHappyAtAll })
 
 happySeq = happyDontSeq
 
@@ -1819,6 +2041,12 @@ pListModule = fmap snd . pListModule_internal
 pModule :: [Token] -> Err Language.MLTT.Syntax.Abs.Module
 pModule = fmap snd . pModule_internal
 
+pParam :: [Token] -> Err Language.MLTT.Syntax.Abs.Param
+pParam = fmap snd . pParam_internal
+
+pListParam :: [Token] -> Err [Language.MLTT.Syntax.Abs.Param]
+pListParam = fmap snd . pListParam_internal
+
 pImport :: [Token] -> Err Language.MLTT.Syntax.Abs.Import
 pImport = fmap snd . pImport_internal
 
@@ -1830,6 +2058,12 @@ pDecl = fmap snd . pDecl_internal
 
 pListDecl :: [Token] -> Err [Language.MLTT.Syntax.Abs.Decl]
 pListDecl = fmap snd . pListDecl_internal
+
+pDischarge :: [Token] -> Err Language.MLTT.Syntax.Abs.Discharge
+pDischarge = fmap snd . pDischarge_internal
+
+pListVarIdent :: [Token] -> Err [Language.MLTT.Syntax.Abs.VarIdent]
+pListVarIdent = fmap snd . pListVarIdent_internal
 
 pTerm :: [Token] -> Err Language.MLTT.Syntax.Abs.Term
 pTerm = fmap snd . pTerm_internal

--- a/haskell/mltt/src/Language/MLTT/Syntax/Print.hs
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Print.hs
@@ -149,7 +149,15 @@ instance Print [Language.MLTT.Syntax.Abs.Module' a] where
 
 instance Print (Language.MLTT.Syntax.Abs.Module' a) where
   prt i = \case
-    Language.MLTT.Syntax.Abs.AModule _ varident imports decls -> prPrec i 0 (concatD [doc (showString "module"), prt 0 varident, doc (showString ";"), prt 0 imports, prt 0 decls])
+    Language.MLTT.Syntax.Abs.AModule _ varident params imports decls -> prPrec i 0 (concatD [doc (showString "module"), prt 0 varident, prt 0 params, doc (showString ";"), prt 0 imports, prt 0 decls])
+
+instance Print (Language.MLTT.Syntax.Abs.Param' a) where
+  prt i = \case
+    Language.MLTT.Syntax.Abs.AParam _ varident term -> prPrec i 0 (concatD [doc (showString "("), prt 0 varident, doc (showString ":"), prt 0 term, doc (showString ")")])
+
+instance Print [Language.MLTT.Syntax.Abs.Param' a] where
+  prt _ [] = concatD []
+  prt _ (x:xs) = concatD [prt 0 x, prt 0 xs]
 
 instance Print (Language.MLTT.Syntax.Abs.Import' a) where
   prt i = \case
@@ -161,8 +169,8 @@ instance Print [Language.MLTT.Syntax.Abs.Import' a] where
 
 instance Print (Language.MLTT.Syntax.Abs.Decl' a) where
   prt i = \case
-    Language.MLTT.Syntax.Abs.DeclDef _ varident term1 term2 -> prPrec i 0 (concatD [doc (showString "def"), prt 0 varident, doc (showString ":"), prt 0 term1, doc (showString ":="), prt 0 term2])
-    Language.MLTT.Syntax.Abs.DeclPrivateDef _ varident term1 term2 -> prPrec i 0 (concatD [doc (showString "private"), doc (showString "def"), prt 0 varident, doc (showString ":"), prt 0 term1, doc (showString ":="), prt 0 term2])
+    Language.MLTT.Syntax.Abs.DeclDef _ varident discharge term1 term2 -> prPrec i 0 (concatD [doc (showString "def"), prt 0 varident, prt 0 discharge, doc (showString ":"), prt 0 term1, doc (showString ":="), prt 0 term2])
+    Language.MLTT.Syntax.Abs.DeclPrivateDef _ varident discharge term1 term2 -> prPrec i 0 (concatD [doc (showString "private"), doc (showString "def"), prt 0 varident, prt 0 discharge, doc (showString ":"), prt 0 term1, doc (showString ":="), prt 0 term2])
     Language.MLTT.Syntax.Abs.DeclNamespace _ varident decls -> prPrec i 0 (concatD [doc (showString "namespace"), prt 0 varident, doc (showString "where"), doc (showString "{"), prt 0 decls, doc (showString "}")])
     Language.MLTT.Syntax.Abs.DeclOpen _ varident -> prPrec i 0 (concatD [doc (showString "open"), prt 0 varident])
     Language.MLTT.Syntax.Abs.DeclCheck _ term1 term2 -> prPrec i 0 (concatD [doc (showString "check"), prt 0 term1, doc (showString ":"), prt 0 term2])
@@ -172,6 +180,16 @@ instance Print [Language.MLTT.Syntax.Abs.Decl' a] where
   prt _ [] = concatD []
   prt _ [x] = concatD [prt 0 x]
   prt _ (x:xs) = concatD [prt 0 x, doc (showString ";"), prt 0 xs]
+
+instance Print (Language.MLTT.Syntax.Abs.Discharge' a) where
+  prt i = \case
+    Language.MLTT.Syntax.Abs.NoDischarge _ -> prPrec i 0 (concatD [])
+    Language.MLTT.Syntax.Abs.DischargeOver _ varidents -> prPrec i 0 (concatD [doc (showString "over"), doc (showString "("), prt 0 varidents, doc (showString ")")])
+
+instance Print [Language.MLTT.Syntax.Abs.VarIdent] where
+  prt _ [] = concatD []
+  prt _ [x] = concatD [prt 0 x]
+  prt _ (x:xs) = concatD [prt 0 x, doc (showString ","), prt 0 xs]
 
 instance Print (Language.MLTT.Syntax.Abs.Term' a) where
   prt i = \case

--- a/haskell/mltt/src/Language/MLTT/Telescope.hs
+++ b/haskell/mltt/src/Language/MLTT/Telescope.hs
@@ -89,9 +89,6 @@ telescopeBinders (TelescopeCons _ _ binder rest) =
 -- Keeping a parameter puts its type into the result, so whatever that type
 -- mentions has to be kept too. A parameter's type mentions only the parameters
 -- before it, so working from the inside out settles it in one pass.
--- Note that this is a right fold, which is what "from the inside out" means
--- here: the innermost parameter is settled first, and each one further out sees
--- the set the ones after it produced.
 closeOverTelescope :: Foil.Distinct l => [Param a l] -> Foil.NameSet l -> Foil.NameSet l
 closeOverTelescope params wanted = foldr close wanted params
   where

--- a/haskell/mltt/src/Language/MLTT/Telescope.hs
+++ b/haskell/mltt/src/Language/MLTT/Telescope.hs
@@ -1,0 +1,125 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-- | Module parameters, and discharging a declaration over the ones it uses.
+--
+-- A parametrised module
+--
+-- > module Group (A : 𝕌) (m : A → A → A) ;
+-- > def twice : A → A := λ x ⇒ m x x
+--
+-- checks every declaration with its parameters in scope, and then /discharges/
+-- each one over exactly the parameters that declaration turns out to use, so
+-- that what leaves the module is an ordinary closed definition
+-- @Group.twice : Π (A : 𝕌) → Π (m : A → A → A) → A → A@. A declaration that
+-- uses no parameter is discharged over nothing and stays a plain constant. An
+-- optional @over (…)@ clause states that set in the source, and is checked
+-- against the computed one by 'checkDischarge'.
+--
+-- == Where the scope restriction is
+--
+-- Discharge is the place this demo needs free-foil's scope /restriction/ rather
+-- than its extension. Checking happens in the scope @p@ that the parameters
+-- extend the module's scope @n@ to; the discharged declaration has to come back
+-- to @n@, because @n@ is where the module's exports live and where the next
+-- module starts.
+--
+-- 'discharge' walks the telescope from the inside out and, at each parameter,
+-- simply asks 'unsinkAST' whether the term can do without it:
+--
+-- * if it can, the parameter is dropped, and the term is now one scope smaller;
+-- * if it cannot, the parameter is abstracted over, with @Π@ for the type and
+--   @λ@ for the value.
+--
+-- So the set of parameters a declaration uses is not declared and believed, and
+-- not computed by a separate analysis either: it is whatever restriction turns
+-- out to reject. That also makes the set upward closed in the telescope for
+-- free. Keeping @(x : A)@ puts @A@ into the discharged /type/, so the next step
+-- out cannot drop @A@ even when the declaration's body never mentions it.
+module Language.MLTT.Telescope where
+
+import qualified Control.Monad.Foil           as Foil
+import           Control.Monad.Free.Foil      (unsinkAST)
+import           Data.List                    (intercalate, sort)
+import           Language.MLTT.Impl.Generated
+import           Language.MLTT.Resolve        (prettyVarIdent)
+import qualified Language.MLTT.Syntax.Abs     as Raw
+
+-- | The parameters of a module: a name, a type, and a binder, in order.
+--
+-- The type of a parameter may mention the parameters before it, which is what
+-- makes this a telescope rather than a list, and is why each entry records the
+-- scope it sits in. That scope is what 'unsinkAST' needs in order to drop the
+-- parameter again.
+data Telescope a n l where
+  TelescopeEmpty :: Telescope a n n
+  TelescopeCons
+    :: (Foil.Distinct n, Foil.DExt n i)
+    => Raw.VarIdent           -- ^ How the parameter is spelled.
+    -> Term' a n              -- ^ Its type, in the scope before it.
+    -> Foil.Scope n           -- ^ That scope.
+    -> Foil.NameBinder n i    -- ^ The binder that introduced it.
+    -> Telescope a i l        -- ^ The parameters after it.
+    -> Telescope a n l
+
+-- | The parameters, outermost first.
+telescopeNames :: Telescope a n l -> [Raw.VarIdent]
+telescopeNames TelescopeEmpty                        = []
+telescopeNames (TelescopeCons name _ _ _ rest) = name : telescopeNames rest
+
+-- | A declaration after discharge: closed over the module's parameters.
+data Discharged a n = Discharged
+  { dischargedType  :: Term' a n
+    -- ^ The type, wrapped in a @Π@ for each parameter used.
+  , dischargedValue :: Term' a n
+    -- ^ The value, wrapped in a @λ@ for each parameter used.
+  , dischargedOver  :: [Raw.VarIdent]
+    -- ^ Which parameters those were, outermost first.
+  }
+
+-- | Discharge a checked declaration over the parameters it uses.
+--
+-- The type and the value are discharged together, over the same parameters,
+-- since @f : T@ and @f := v@ have to stay a matching pair: if only the value
+-- mentions a parameter, the type still gains a (non-dependent) @Π@ for it.
+discharge
+  :: a                  -- ^ The position to put on the abstractions introduced.
+  -> Telescope a n l
+  -> Term' a l          -- ^ The declaration's type, checked with parameters in scope.
+  -> Term' a l          -- ^ Its value, likewise.
+  -> Discharged a n
+discharge _loc TelescopeEmpty ty value = Discharged ty value []
+discharge loc (TelescopeCons name paramTy scope binder rest) ty value =
+  case (unsinkAST scope inner, unsinkAST scope innerValue) of
+    -- Neither side mentions the parameter, so the declaration does not use it.
+    (Just ty', Just value') -> Discharged ty' value' over
+    -- One of them does. Abstract over it, and note it as used.
+    _ -> Discharged
+      { dischargedType  = Pi loc paramTy (PatternVar loc binder) inner
+      , dischargedValue = Lam loc (PatternVar loc binder) innerValue
+      , dischargedOver  = name : over
+      }
+  where
+    Discharged inner innerValue over = discharge loc rest ty value
+
+-- | Check a declared @over@ clause against the parameters actually used.
+--
+-- The clause is optional, and it never changes what is discharged: the computed
+-- list is authoritative either way, so an accepted clause is one that agrees
+-- with it. Both directions are reported, since listing a parameter that is not
+-- used is as much a mistake in the documentation as omitting one that is.
+--
+-- It is spelled @over@ rather than @uses@ because rzk has a @uses@ clause that
+-- is a different thing: mandatory, and listing the implicit assumptions of a
+-- definition rather than the parameters of its module.
+checkDischarge :: Raw.Discharge -> [Raw.VarIdent] -> Either String ()
+checkDischarge (Raw.NoDischarge _loc) _ = Right ()
+checkDischarge (Raw.DischargeOver _loc declared) over
+  | sort declared == sort over = Right ()
+  | otherwise = Left $ unlines
+      [ "declared: over (" <> render declared <> ")"
+      , "  actual: over (" <> render over <> ")" ]
+  where
+    -- The clause may be written in any order; the report gives telescope order.
+    render = intercalate ", " . map prettyVarIdent

--- a/haskell/mltt/src/Language/MLTT/Telescope.hs
+++ b/haskell/mltt/src/Language/MLTT/Telescope.hs
@@ -2,45 +2,47 @@
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
--- | Module parameters, and discharging a declaration over the ones it uses.
+-- | Module parameters, and closing a declaration over the ones it uses.
 --
 -- A parametrised module
 --
 -- > module Group (A : 𝕌) (m : A → A → A) ;
 -- > def twice : A → A := λ x ⇒ m x x
 --
--- checks every declaration with its parameters in scope, and then /discharges/
--- each one over exactly the parameters that declaration turns out to use, so
--- that what leaves the module is an ordinary closed definition
+-- checks every declaration with its parameters in scope, and then closes each
+-- one over exactly the parameters that declaration turns out to use, so that
+-- what leaves the module is an ordinary closed definition
 -- @Group.twice : Π (A : 𝕌) → Π (m : A → A → A) → A → A@. A declaration that
--- uses no parameter is discharged over nothing and stays a plain constant. An
+-- uses no parameter is closed over nothing and stays a plain constant. An
 -- optional @over (…)@ clause states that set in the source, and is checked
 -- against the computed one by 'checkDischarge'.
 --
 -- == Where the scope restriction is
 --
--- Discharge is the place this demo needs free-foil's scope /restriction/ rather
--- than its extension. Checking happens in the scope @p@ that the parameters
--- extend the module's scope @n@ to; the discharged declaration has to come back
--- to @n@, because @n@ is where the module's exports live and where the next
--- module starts.
+-- This is the place the demo needs free-foil's scope /restriction/ rather than
+-- its extension. Checking happens in the scope @p@ that the parameters extend
+-- the module's scope @n@ to; the result has to come back to @n@, because @n@ is
+-- where the module's exports live and where the next module starts.
 --
--- 'discharge' walks the telescope from the inside out and, at each parameter,
--- simply asks 'unsinkAST' whether the term can do without it:
+-- It is done in three steps, and the point of the arrangement is that the term
+-- is walked a fixed number of times rather than once per parameter:
 --
--- * if it can, the parameter is dropped, and the term is now one scope smaller;
--- * if it cannot, the parameter is abstracted over, with @Π@ for the type and
---   @λ@ for the value.
+-- 1. 'supportOf' the type and the value, once each.
+-- 2. 'closeOverTelescope' closes that set under the parameter types. Keeping
+--    @(x : A)@ puts @A@ into the result, so @A@ has to be kept as well. One
+--    pass from the inside out is enough, since a parameter's type mentions only
+--    the parameters before it.
+-- 3. 'Foil.withThinnedNameBinderList' cuts the chain of binders down to that
+--    set in one step, and 'discharge' rebuilds the abstractions along the
+--    thinned chain, restricting each parameter type and the body into it.
 --
--- So the set of parameters a declaration uses is not declared and believed, and
--- not computed by a separate analysis either: it is whatever restriction turns
--- out to reject. That also makes the set upward closed in the telescope for
--- free. Keeping @(x : A)@ puts @A@ into the discharged /type/, so the next step
--- out cannot drop @A@ even when the declaration's body never mentions it.
+-- The alternative, asking 'unsinkAST' at every parameter whether the term can
+-- do without it, is shorter to write and walks the whole term once per
+-- parameter.
 module Language.MLTT.Telescope where
 
 import qualified Control.Monad.Foil           as Foil
-import           Control.Monad.Free.Foil      (unsinkAST)
+import           Control.Monad.Free.Foil      (supportOf, unsinkAST)
 import           Data.List                    (intercalate, sort)
 import           Language.MLTT.Impl.Generated
 import           Language.MLTT.Resolve        (prettyVarIdent)
@@ -49,63 +51,149 @@ import qualified Language.MLTT.Syntax.Abs     as Raw
 -- | The parameters of a module: a name, a type, and a binder, in order.
 --
 -- The type of a parameter may mention the parameters before it, which is what
--- makes this a telescope rather than a list, and is why each entry records the
--- scope it sits in. That scope is what 'unsinkAST' needs in order to drop the
--- parameter again.
+-- makes this a telescope rather than a list.
 data Telescope a n l where
   TelescopeEmpty :: Telescope a n n
   TelescopeCons
-    :: (Foil.Distinct n, Foil.DExt n i)
+    :: (Foil.Distinct n, Foil.DExt n i, Foil.Ext i l)
     => Raw.VarIdent           -- ^ How the parameter is spelled.
     -> Term' a n              -- ^ Its type, in the scope before it.
-    -> Foil.Scope n           -- ^ That scope.
     -> Foil.NameBinder n i    -- ^ The binder that introduced it.
     -> Telescope a i l        -- ^ The parameters after it.
     -> Telescope a n l
 
--- | The parameters, outermost first.
-telescopeNames :: Telescope a n l -> [Raw.VarIdent]
-telescopeNames TelescopeEmpty                        = []
-telescopeNames (TelescopeCons name _ _ _ rest) = name : telescopeNames rest
+-- | One parameter, with everything about it moved into the innermost scope.
+--
+-- Sinking is free, so this is the convenient form for anything that has to
+-- compare parameters with the names of a term checked under all of them.
+data Param a l = Param
+  { paramIdent :: Raw.VarIdent
+  , paramName  :: Foil.Name l
+  , paramType  :: Term' a l
+  }
 
--- | A declaration after discharge: closed over the module's parameters.
+-- | The parameters, outermost first.
+telescopeParams :: Foil.Distinct l => Telescope a n l -> [Param a l]
+telescopeParams TelescopeEmpty = []
+telescopeParams (TelescopeCons name ty binder rest) =
+  Param name (Foil.sink (Foil.nameOf binder)) (Foil.sink ty) : telescopeParams rest
+
+-- | The chain of binders the parameters form.
+telescopeBinders :: Telescope a n l -> Foil.NameBinderList n l
+telescopeBinders TelescopeEmpty = Foil.NameBinderListEmpty
+telescopeBinders (TelescopeCons _ _ binder rest) =
+  Foil.NameBinderListCons binder (telescopeBinders rest)
+
+-- | Close a set of parameters under the parameters their types need.
+--
+-- Keeping a parameter puts its type into the result, so whatever that type
+-- mentions has to be kept too. A parameter's type mentions only the parameters
+-- before it, so working from the inside out settles it in one pass.
+closeOverTelescope :: Foil.Distinct l => [Param a l] -> Foil.NameSet l -> Foil.NameSet l
+closeOverTelescope params wanted = foldl step wanted (reverse params)
+  where
+    step keep p
+      | Foil.nameSetMember (paramName p) keep = keep <> supportOf (paramType p)
+      | otherwise                             = keep
+
+-- | A declaration after being closed over the module's parameters.
 data Discharged a n = Discharged
   { dischargedType  :: Term' a n
-    -- ^ The type, wrapped in a @Π@ for each parameter used.
+    -- ^ The type, wrapped in a @Π@ for each parameter kept.
   , dischargedValue :: Term' a n
-    -- ^ The value, wrapped in a @λ@ for each parameter used.
+    -- ^ The value, wrapped in a @λ@ for each parameter kept.
   , dischargedOver  :: [Raw.VarIdent]
     -- ^ Which parameters those were, outermost first.
   }
 
--- | Discharge a checked declaration over the parameters it uses.
+-- | Close a checked declaration over a given set of the module's parameters.
 --
--- The type and the value are discharged together, over the same parameters,
+-- The type and the value are closed over together, over the same parameters,
 -- since @f : T@ and @f := v@ have to stay a matching pair: if only the value
 -- mentions a parameter, the type still gains a (non-dependent) @Π@ for it.
-discharge
-  :: a                  -- ^ The position to put on the abstractions introduced.
-  -> Telescope a n l
-  -> Term' a l          -- ^ The declaration's type, checked with parameters in scope.
-  -> Term' a l          -- ^ Its value, likewise.
-  -> Discharged a n
-discharge _loc TelescopeEmpty ty value = Discharged ty value []
-discharge loc (TelescopeCons name paramTy scope binder rest) ty value =
-  case (unsinkAST scope inner, unsinkAST scope innerValue) of
-    -- Neither side mentions the parameter, so the declaration does not use it.
-    (Just ty', Just value') -> Discharged ty' value' over
-    -- One of them does. Abstract over it, and note it as used.
-    _ -> Discharged
-      { dischargedType  = Pi loc paramTy (PatternVar loc binder) inner
-      , dischargedValue = Lam loc (PatternVar loc binder) innerValue
-      , dischargedOver  = name : over
-      }
-  where
-    Discharged inner innerValue over = discharge loc rest ty value
-
--- | Check a declared @over@ clause against the parameters actually used.
 --
--- The clause is optional, and it never changes what is discharged: the computed
+-- Given 'Nothing', the set is the computed one and the result is a 'Right'.
+-- Given a /declared/ set, 'Left' names the parameters the declaration needs and
+-- that set does not have, which is the useful thing to say about a wrong
+-- @over@ clause.
+discharge
+  :: forall a n l. (Foil.Distinct n, Foil.Distinct l)
+  => a                        -- ^ The position to put on the abstractions introduced.
+  -> Foil.Scope n             -- ^ The module's scope, which the result lives in.
+  -> Telescope a n l
+  -> Maybe (Foil.NameSet l)   -- ^ A declared set of parameters, if there is one.
+  -> Term' a l                -- ^ The declaration's type, checked with parameters in scope.
+  -> Term' a l                -- ^ Its value, likewise.
+  -> Either [Raw.VarIdent] (Discharged a n)
+discharge loc scope tele declared ty value
+  | not (null missing) = Left missing
+  | otherwise =
+      Foil.withThinnedNameBinderList keep (telescopeBinders tele) $
+        \(thinned :: Foil.NameBinderList n m) ->
+          let scopeM = Foil.extendScopePattern thinned scope
+           in case (unsinkAST scopeM ty, unsinkAST scopeM value,
+                    traverse (\p -> (,) (paramIdent p) <$> unsinkAST scopeM (paramType p)) kept) of
+                (Just tyM, Just valueM, Just paramsM) ->
+                  build scope thinned paramsM tyM valueM
+                -- Unreachable: 'keep' contains the support and is closed, which
+                -- is what 'missing' being empty says.
+                _ -> Left needs
+  where
+    params = telescopeParams tele
+
+    -- The support of the declaration, closed under the parameter types. Two
+    -- walks of the term, whatever the number of parameters.
+    needed = closeOverTelescope params (supportOf ty <> supportOf value)
+
+    keep = case declared of
+      Nothing -> needed
+      Just s  -> s
+    kept = [p | p <- params, Foil.nameSetMember (paramName p) keep]
+
+    -- A parameter the declaration needs and the set does not have. Testing this
+    -- up front is what leaves 'build' with nothing to report: every restriction
+    -- it performs is then into a scope that has what the term needs.
+    missing =
+      [ paramIdent p
+      | p <- params
+      , Foil.nameSetMember (paramName p) needed
+      , not (Foil.nameSetMember (paramName p) keep)
+      ]
+
+    -- Every parameter the declaration needs, whether or not it is being kept.
+    needs = [paramIdent p | p <- params, Foil.nameSetMember (paramName p) needed]
+
+    -- Rebuild the abstractions along the thinned chain. Everything has already
+    -- been restricted into the thinned scope @m@, so each step only has to take
+    -- the parameter type one scope further out, and the evidence for that is
+    -- the remaining chain.
+    build
+      :: forall m0 m. (Foil.Distinct m0, Foil.Distinct m)
+      => Foil.Scope m0
+      -> Foil.NameBinderList m0 m
+      -> [(Raw.VarIdent, Term' a m)]
+      -> Term' a m
+      -> Term' a m
+      -> Either [Raw.VarIdent] (Discharged a m0)
+    build scope' binders paramsM tyM valueM = case (binders, paramsM) of
+      (Foil.NameBinderListEmpty, _) -> Right (Discharged tyM valueM [])
+      (Foil.NameBinderListCons binder rest, (name, paramTyM) : ps) ->
+        case (Foil.assertExt binders, Foil.assertDistinct binder) of
+          (Foil.Ext, Foil.Distinct) -> case unsinkAST scope' paramTyM of
+            Nothing -> Left needs
+            Just paramTy -> do
+              inner <- build (Foil.extendScope binder scope') rest ps tyM valueM
+              return Discharged
+                { dischargedType  = Pi loc paramTy (PatternVar loc binder) (dischargedType inner)
+                , dischargedValue = Lam loc (PatternVar loc binder) (dischargedValue inner)
+                , dischargedOver  = name : dischargedOver inner
+                }
+      -- Unreachable: the chain and the parameters were filtered by one set.
+      (Foil.NameBinderListCons _ _, []) -> Left needs
+
+-- | Check a declared @over@ clause against the parameters actually kept.
+--
+-- The clause is optional, and it never changes what is defined: the computed
 -- list is authoritative either way, so an accepted clause is one that agrees
 -- with it. Both directions are reported, since listing a parameter that is not
 -- used is as much a mistake in the documentation as omitting one that is.

--- a/haskell/mltt/src/Language/MLTT/Telescope.hs
+++ b/haskell/mltt/src/Language/MLTT/Telescope.hs
@@ -89,10 +89,13 @@ telescopeBinders (TelescopeCons _ _ binder rest) =
 -- Keeping a parameter puts its type into the result, so whatever that type
 -- mentions has to be kept too. A parameter's type mentions only the parameters
 -- before it, so working from the inside out settles it in one pass.
+-- Note that this is a right fold, which is what "from the inside out" means
+-- here: the innermost parameter is settled first, and each one further out sees
+-- the set the ones after it produced.
 closeOverTelescope :: Foil.Distinct l => [Param a l] -> Foil.NameSet l -> Foil.NameSet l
-closeOverTelescope params wanted = foldl step wanted (reverse params)
+closeOverTelescope params wanted = foldr close wanted params
   where
-    step keep p
+    close p keep
       | Foil.nameSetMember (paramName p) keep = keep <> supportOf (paramType p)
       | otherwise                             = keep
 

--- a/haskell/mltt/src/Language/MLTT/Typecheck.hs
+++ b/haskell/mltt/src/Language/MLTT/Typecheck.hs
@@ -96,8 +96,22 @@ withVar
   -> Term' a n            -- ^ The type of the new variable.
   -> (forall l. Foil.DExt n l => Ctx a l -> Foil.Name l -> r)
   -> r
-withVar ctx ty cont = Foil.withFresh (ctxScope ctx) $ \binder ->
-  cont (extend ctx binder ty Nothing) (Foil.nameOf binder)
+withVar ctx ty cont = withVarBinder ctx ty $ \ctx' binder ->
+  cont ctx' (Foil.nameOf binder)
+
+-- | Extend a context with a fresh variable, handing back its /binder/.
+--
+-- A caller that intends to abstract over the variable again later needs the
+-- binder and not just the name, since a binder is what a @Π@ or a @λ@ is built
+-- from. See "Language.MLTT.Telescope".
+withVarBinder
+  :: Foil.Distinct n
+  => Ctx a n
+  -> Term' a n            -- ^ The type of the new variable.
+  -> (forall l. Foil.DExt n l => Ctx a l -> Foil.NameBinder n l -> r)
+  -> r
+withVarBinder ctx ty cont = Foil.withFresh (ctxScope ctx) $ \binder ->
+  cont (extend ctx binder ty Nothing) binder
 
 -- | Add one binder to a context. Sinking the two maps is \(O(1)\); only the
 -- new entry is inserted.

--- a/haskell/mltt/test/Language/MLTT/ModulesSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ModulesSpec.hs
@@ -65,7 +65,7 @@ spec = do
   describe "namespaces and qualified names" $ do
     it "qualifies a declaration by its namespace, not by its module" $
       run (withClient "check Nat.quadruple : Π (A : 𝕌) → (A → A) → A → A")
-        `shouldSatisfy` (Defined "Nat.quadruple" `elem`)
+        `shouldSatisfy` (Defined "Nat.quadruple" [] `elem`)
 
     it "does not make a namespaced name available unqualified" $
       failures (run (withClient "compute quadruple 𝟙 (λ x ⇒ x) tt"))
@@ -131,7 +131,7 @@ spec = do
         `shouldBe` ["λ x0 ⇒ x0"]
 
   describe "the example programs" $
-    forM_ ["examples/core.mltt", "examples/modules.mltt"] $ \path ->
+    forM_ ["examples/core.mltt", "examples/modules.mltt", "examples/parameters.mltt"] $ \path ->
       it (path <> " is accepted in full") $ do
         input <- readFile path
         let results = run input

--- a/haskell/mltt/test/Language/MLTT/ParametersSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ParametersSpec.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Module parameters and discharge.
+--
+-- The property under test is that a declaration leaves a parametrised module
+-- abstracted over exactly the parameters it uses, that this set is upward
+-- closed in the telescope, and that an @over@ clause is checked against it
+-- rather than believed.
+module Language.MLTT.ParametersSpec (spec) where
+
+import           Data.List          (isInfixOf)
+import           Language.MLTT.Impl
+import           Test.Hspec
+
+-- | Interpret a program, reporting a parse error as a failed command.
+run :: String -> [CommandResult]
+run input = case interpret input of
+  Left err      -> [Failed ("parse error: " <> err)]
+  Right results -> results
+
+-- | The messages of every command that was rejected.
+failures :: [CommandResult] -> [String]
+failures results = [err | Failed err <- results]
+
+-- | The normal forms every @compute@ produced.
+computed :: [CommandResult] -> [String]
+computed results = [term | Computed term <- results]
+
+-- | A monoid-shaped parameter block, and whatever declarations are given.
+inMonoid :: [String] -> String
+inMonoid decls = unlines
+  ("module Monoid (A : 𝕌) (unit : A) (mul : A → A → A)" : decls)
+
+spec :: Spec
+spec = do
+  describe "discharge" $ do
+    it "abstracts a declaration over exactly the parameters it uses" $
+      run (inMonoid ["def square : A → A := λ x ⇒ mul x x"])
+        `shouldSatisfy` (Defined "square" ["A", "mul"] `elem`)
+
+    it "leaves a declaration that uses no parameter a plain constant" $
+      run (inMonoid ["def flip : 𝟙 → 𝟙 := λ x ⇒ x"])
+        `shouldSatisfy` (Defined "flip" [] `elem`)
+
+    it "keeps a parameter that only the value mentions, in the type as well" $
+      -- The type `A` does not mention `unit`, the value does, and the two have
+      -- to stay a matching pair.
+      run (inMonoid ["def neutral : A := unit"])
+        `shouldSatisfy` (Defined "neutral" ["A", "unit"] `elem`)
+
+    it "closes the set upward: keeping a parameter keeps what its type needs" $
+      -- Nothing in the body mentions `A`. Keeping `unit` puts `unit`'s type
+      -- into the discharged type, and that type is `A`.
+      run (inMonoid ["def neutral : 𝟙 → A := λ _ ⇒ unit"])
+        `shouldSatisfy` (Defined "neutral" ["A", "unit"] `elem`)
+
+  describe "the over clause" $ do
+    it "accepts a clause that names exactly the parameters used" $
+      failures (run (inMonoid ["def square over (A, mul) : A → A := λ x ⇒ mul x x"]))
+        `shouldBe` []
+
+    it "accepts it in any order, since the telescope fixes the real one" $
+      failures (run (inMonoid ["def square over (mul, A) : A → A := λ x ⇒ mul x x"]))
+        `shouldBe` []
+
+    it "rejects a clause that omits a parameter, and reports the computed set" $
+      failures (run (inMonoid ["def square over (mul) : A → A := λ x ⇒ mul x x"]))
+        `shouldSatisfy` any (\err -> "declared: over (mul)" `isInfixOf` err
+                                  && "actual: over (A, mul)" `isInfixOf` err)
+
+    it "rejects a clause that names a parameter the declaration does not use" $
+      failures (run (inMonoid ["def flip over (A) : 𝟙 → 𝟙 := λ x ⇒ x"]))
+        `shouldSatisfy` any ("actual: over ()" `isInfixOf`)
+
+    it "rejects a clause that omits what the closure adds" $
+      failures (run (inMonoid ["def neutral over (unit) : A := unit"]))
+        `shouldSatisfy` any ("actual: over (A, unit)" `isInfixOf`)
+
+  describe "what leaves the module" $ do
+    it "is closed, so a client instantiates it by application" $
+      computed (run (unlines
+        [ inMonoid ["def neutral : A := unit"]
+        , "module Client"
+        , "import Monoid"
+        , "compute neutral 𝟙 tt" ]))
+        `shouldBe` ["tt"]
+
+    it "does not carry the parameters into the client's scope" $
+      failures (run (unlines
+        [ inMonoid ["def neutral : A := unit"]
+        , "module Client"
+        , "import Monoid"
+        , "compute unit" ]))
+        `shouldSatisfy` any ("not in scope: unit" `isInfixOf`)
+
+  describe "checking under parameters" $ do
+    it "lets a check see them" $
+      failures (run (inMonoid ["check unit : A"]))
+        `shouldBe` []
+
+    it "lets a later declaration use an earlier one, once applied" $
+      failures (run (inMonoid
+        [ "def neutral : A := unit"
+        , "def alsoNeutral : A := neutral A unit" ]))
+        `shouldBe` []
+
+    it "reports an unresolvable parameter type once, not once per declaration" $
+      failures (run (unlines
+        [ "module M (x : Nope)"
+        , "def a : 𝟙 := tt"
+        , "def b : 𝟙 := tt" ]))
+        `shouldBe` ["not in scope: Nope"]

--- a/haskell/mltt/test/Language/MLTT/ParametersSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ParametersSpec.hs
@@ -97,10 +97,41 @@ spec = do
       failures (run (inMonoid ["check unit : A"]))
         `shouldBe` []
 
-    it "lets a later declaration use an earlier one, once applied" $
+  describe "putting the parameters back on use" $ do
+    it "lets a later declaration name an earlier one without applying it" $
       failures (run (inMonoid
         [ "def neutral : A := unit"
-        , "def alsoNeutral : A := neutral A unit" ]))
+        , "def alsoNeutral : A := neutral" ]))
+        `shouldBe` []
+
+    it "counts the arguments it puts back as uses" $
+      -- `square` takes `A` and `mul`, `neutral` takes `A` and `unit`, so a
+      -- declaration naming both is closed over all three.
+      run (inMonoid
+        [ "def square : A → A := λ x ⇒ mul x x"
+        , "def neutral : A := unit"
+        , "def squareNeutral : A := square neutral" ])
+        `shouldSatisfy` (Defined "squareNeutral" ["A", "unit", "mul"] `elem`)
+
+    it "leaves a local binder of the same name alone" $
+      run (inMonoid ["def shadowing : 𝟙 → 𝟙 := λ square ⇒ square"])
+        `shouldSatisfy` (Defined "shadowing" [] `elem`)
+
+    it "leaves a parameter alone when it shadows a declaration of the same name" $
+      -- `dup` is both a parameter and a declaration. The spelling denotes the
+      -- parameter, so putting anything back for it would be wrong.
+      run (unlines
+        [ "module M (A : 𝕌) (dup : A)"
+        , "def dup : A := dup"
+        , "def use : A := dup" ])
+        `shouldSatisfy` (Defined "use" ["A", "dup"] `elem`)
+
+    it "does not do it for a client, which applies the constant itself" $
+      failures (run (unlines
+        [ inMonoid ["def neutral : A := unit"]
+        , "module Client"
+        , "import Monoid"
+        , "check neutral : Π (A : 𝕌) → Π (unit : A) → A" ]))
         `shouldBe` []
 
     it "reports an unresolvable parameter type once, not once per declaration" $


### PR DESCRIPTION
A module can take parameters. Each declaration is checked with them in scope and is then closed over exactly the ones it uses, at the point it is defined. Inside the module the parameters are put back on use, so nothing has to be applied by hand; a client applies the closed constant itself.

```
module Monoid (A : 𝕌) (unit : A) (mul : A → A → A)

def square over (A, mul) : A → A := λ x ⇒ mul x x
def neutral over (A, unit) : A := unit
def squareNeutral : A := square neutral
def flip : 𝟙 → 𝟙 := λ x ⇒ x
```

```
  ✓ defined square over (A, mul)
  ✓ defined neutral over (A, unit)
  ✓ defined squareNeutral over (A, unit, mul)
  ✓ defined flip
```

The `over (…)` clause is optional and is checked against the computed set rather than believed. It is not spelled `uses`, which in rzk is a mandatory clause about a definition's implicit assumptions. Note that `flip` is closed over nothing, and `neutral` over `A` although its body never mentions `A`: keeping `unit` puts `unit`'s type into the result, so the set is upward closed in the telescope.

This is the first client of the restriction API from #56, and the set falls out of it rather than out of a separate analysis. Two small library additions:

- `withThinnedNameBinderList` cuts a chain of binders down to the names in a set, in one step. Asking `unsinkAST` at each parameter instead walks the term once per parameter.
- `mapWithName`, the keyed `fmap` for `NameMap`, which is how the substitution that puts parameters back is built out of a map that is already total. Nothing is inserted into a substitution by name.