### PR TITLE
MLTT: serialisation round trip for checked modules

### DIFF
--- a/haskell/mltt/mltt.cabal
+++ b/haskell/mltt/mltt.cabal
@@ -35,6 +35,7 @@ custom-setup
 
 library
   exposed-modules:
+      Language.MLTT.Artifact
       Language.MLTT.Eval
       Language.MLTT.FreeFoilConfig
       Language.MLTT.Impl
@@ -124,6 +125,7 @@ test-suite spec
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Language.MLTT.ArtifactSpec
       Language.MLTT.ImplSpec
       Language.MLTT.LinkSpec
       Language.MLTT.ModulesSpec

--- a/haskell/mltt/src/Language/MLTT/Artifact.hs
+++ b/haskell/mltt/src/Language/MLTT/Artifact.hs
@@ -1,0 +1,253 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-- | Serialisation of checked modules.
+--
+-- A 'Foil.Name' is an allocation artefact and cannot be written to disk, so a
+-- serialised declaration records /qualified spellings/ and is re-interned on
+-- load: the artifact stores each declaration's type and value as raw syntax
+-- in which every free variable is printed fully qualified (from 'envDisplay')
+-- and every bound variable canonically (@l0@, @l1@, …). Loading parses the
+-- terms back and converts them against the environment being assembled, so a
+-- loaded module is an ordinary 'CheckedModule': it links, and further modules
+-- check against it, exactly as if it had just been checked.
+--
+-- What makes the cache valid is recorded alongside the terms:
+--
+-- * the module's stripe index at check time, so a run whose registry agrees
+--   reconstructs the very same raw names (and one whose registry moved the
+--   stripe still loads, with the names landing where the new stripe says);
+-- * the content hash of each import at check time, so a changed dependency
+--   is detected and the artifact rejected rather than linked stale.
+--
+-- __Loading trusts the artifact's terms__: nothing is re-checked, which is
+-- the point of a cache. Integrity comes from the hash chain, and the hash is
+-- 'contentHash', a plain FNV-1a over the rendered content — collision
+-- resistance enough for a build cache, not for an adversary.
+--
+-- Three wire-format notes:
+--
+-- * Bound variables are printed @l\<i\>@ from their raw ids; a program whose
+--   fully qualified spelling matches that pattern would need escaping,
+--   which this demo does not implement.
+--
+-- * Source positions inside a loaded term point into the artifact text, not
+--   the original source.
+--
+-- * The bound spellings inherit the one place raw ids are not
+--   deterministic: a λ-binder allocated during checking takes the successor
+--   of the whole ambient scope's maximum, so its id — harmless in memory —
+--   leaks into the artifact text, and the content hash is reproducible only
+--   for a module checked in the same environment. The fix is for the
+--   conversion layer to allocate the binders it introduces in a
+--   caller-supplied region, not more code here.
+module Language.MLTT.Artifact (
+  ModuleArtifact (..),
+  ArtifactDecl (..),
+  ContentHash (..),
+  StoredTerm (..),
+  makeArtifact,
+  loadArtifact,
+  loadArtifactAfter,
+  renderArtifact,
+  readArtifact,
+  contentHash,
+) where
+
+import qualified Control.Monad.Foil        as Foil
+import qualified Control.Monad.Foil.Blocks as Blocks
+import           Data.Bits                 (xor, (.&.))
+import           Data.List                 (foldl')
+import           Data.Map                  (Map)
+import qualified Data.Map                  as Map
+import           Text.Read                 (readEither)
+
+import           Language.MLTT.Eval        (Def (..), desugar)
+import           Language.MLTT.Impl
+import           Language.MLTT.Impl.Generated
+import           Language.MLTT.Resolve     (Visibility (..), prettyVarIdent)
+import qualified Language.MLTT.Syntax.Abs  as Raw
+import qualified Language.MLTT.Syntax.Lex  as Raw
+import qualified Language.MLTT.Syntax.Par  as Raw
+import           Language.MLTT.Typecheck   (Ctx (..), extend)
+
+-- * The artifact
+
+-- | A checked module, as written to disk.
+data ModuleArtifact = ModuleArtifact
+  { artifactModule  :: Raw.VarIdent  -- ^ The module's qualified name.
+  , artifactStripe  :: StripeIndex   -- ^ From the registry, at check time.
+  , artifactImports :: [(Raw.VarIdent, ContentHash)]
+      -- ^ Each import, with its content hash at check time.
+  , artifactHash    :: ContentHash   -- ^ Over the declarations below.
+  , artifactDecls   :: [ArtifactDecl] -- ^ In declaration (= allocation) order.
+  }
+  deriving (Eq, Show, Read)
+
+-- | One declaration: everything the environment needs to hold for it.
+data ArtifactDecl = ArtifactDecl
+  { adSpelling   :: Raw.VarIdent  -- ^ Fully qualified.
+  , adVisibility :: Visibility
+  , adType       :: StoredTerm
+  , adValue      :: StoredTerm
+  }
+  deriving (Eq, Show, Read)
+
+-- | A term as stored: raw syntax with fully qualified free variables and
+-- canonically named bound ones.
+newtype StoredTerm = StoredTerm { storedText :: String }
+  deriving (Eq, Show, Read)
+
+-- | The 64-bit FNV-1a of some rendered content; see 'contentHash'.
+newtype ContentHash = ContentHash Integer
+  deriving (Eq, Show, Read)
+
+-- | Render an artifact for writing. 'readArtifact' is its inverse.
+renderArtifact :: ModuleArtifact -> String
+renderArtifact = show
+
+-- | Read an artifact back; reports rather than crashes on malformed input.
+readArtifact :: String -> Either String ModuleArtifact
+readArtifact = readEither
+
+-- | FNV-1a over a string, 64 bits. A build-cache checksum, not a defence.
+contentHash :: String -> ContentHash
+contentHash = ContentHash . foldl' step 0xcbf29ce484222325
+  where
+    step h c = ((h `xor` fromIntegral (fromEnum c)) * 0x100000001b3) .&. 0xffffffffffffffff
+
+-- * Writing
+
+-- | Serialise a checked module.
+--
+-- The declarations are exactly the names the module allocated in its stripe,
+-- in ascending order, which is declaration order; their spellings come from
+-- 'envDisplay' and are fully qualified, so the artifact does not depend on
+-- what was visible under which shorter spelling at check time.
+makeArtifact
+  :: Raw.VarIdent               -- ^ The module's name.
+  -> StripeIndex                -- ^ From the registry.
+  -> [(Raw.VarIdent, ContentHash)] -- ^ Its imports, with their content hashes.
+  -> CheckedModule c
+  -> ModuleArtifact
+makeArtifact name stripe imports cm = withCheckedModule cm $ \_ env _ ->
+  let Foil.NameRange lo hi = stripeRange stripe
+      ctx = envCtx env
+      own =
+        [ x
+        | x <- Foil.nameSetToList (Foil.scopeToNameSet (ctxScope ctx))
+        , lo <= Foil.nameId x, Foil.nameId x <= hi
+        ]
+      decls = map declOf own
+      declOf x = ArtifactDecl
+        { adSpelling   = spelling
+        , adVisibility = if Map.member spelling (envExports env) then Public else Private
+        , adType       = put (Foil.lookupName x (ctxTypes ctx))
+        , adValue      = case getDef (Foil.lookupName x (ctxDefs ctx)) of
+            Just value -> put value
+            Nothing    -> error "impossible: a top-level name with no definition"
+        }
+        where
+          spelling = Foil.lookupName x (envDisplay env)
+      put = StoredTerm . showTermNamed boundName (envDisplay env)
+   in ModuleArtifact
+        { artifactModule  = name
+        , artifactStripe  = stripe
+        , artifactImports = imports
+        , artifactHash    = contentHash (concatMap renderDecl decls)
+        , artifactDecls   = decls
+        }
+
+-- | The canonical spelling of a bound variable in an artifact.
+boundName :: Int -> Raw.VarIdent
+boundName i = Raw.VarIdent ("l" <> show i)
+
+-- | What the content hash covers: everything semantically relevant. The
+-- values are included, not only the types, because conversion unfolds
+-- definitions, so a changed body changes what dependants compute.
+renderDecl :: ArtifactDecl -> String
+renderDecl d = unwords
+  [ prettyVarIdent (adSpelling d), show (adVisibility d)
+  , storedText (adType d), storedText (adValue d), ";"
+  ]
+
+-- * Loading
+
+-- | Load a checked module from its artifact, into an environment holding
+-- what its imports export — the same starting point 'checkModule' has.
+--
+-- The load fails if an import's recorded content hash disagrees with the one
+-- supplied, which is how a stale artifact is detected. It does not compare
+-- the artifact's stripe with the range supplied: a registry that moved the
+-- stripe is the relocation case, and the module simply loads at its new
+-- names, consistently with everything else in this run.
+loadArtifact
+  :: forall c. Foil.Distinct c
+  => Map Raw.VarIdent ContentHash
+     -- ^ Content hashes of the modules loaded or checked so far.
+  -> Foil.NameRange       -- ^ The module's stripe, from this run's registry.
+  -> Env c                -- ^ Environment holding what its imports export.
+  -> ModuleArtifact
+  -> Either String (CheckedModule c)
+loadArtifact hashes range env artifact = do
+  mapM_ checkImport (artifactImports artifact)
+  go (Blocks.beginBlock range) env' (artifactDecls artifact)
+  where
+    checkImport (m, h) = case Map.lookup m hashes of
+      Just h' | h' == h -> Right ()
+      Just _ -> Left (stale <> prettyVarIdent m <> " has changed since then")
+      Nothing -> Left (stale <> prettyVarIdent m <> " is not among the modules loaded so far")
+    stale = "stale artifact for " <> prettyVarIdent (artifactModule artifact) <> ": import "
+
+    -- An import contributes the exporting module's public names, as in
+    -- 'checkModule'; the artifact's own references are fully qualified, so
+    -- no namespace-relative resolution is needed on top.
+    env' = env
+      { envDeclared = Map.unions
+          [ Map.findWithDefault Map.empty m (envModules env)
+          | (m, _) <- artifactImports artifact ]
+      , envExports = Map.empty
+      , envClosedOver = Map.empty
+      }
+
+    go :: Foil.DExt c n
+       => Blocks.Block c n -> Env n -> [ArtifactDecl] -> Either String (CheckedModule c)
+    go block envN [] =
+      Right (CheckedModule (Blocks.blockExt block)
+                           (finishModule (artifactModule artifact) envN)
+                           [])
+    go block envN (d : ds) = do
+      ty    <- reintern envN (adType d)
+      value <- reintern envN (adValue d)
+      Blocks.withFreshInBlock block (ctxScope (envCtx envN)) $ \binder block' ->
+        let ctx' = extend (envCtx envN) binder ty (Just value)
+            envN' = extendEnv ctx' binder (adSpelling d) (adVisibility d) envN
+         in go block' envN' ds
+
+    -- Parse a stored term and convert it against the environment assembled
+    -- so far: this is the re-interning the wire format promises.
+    reintern :: Foil.Distinct n => Env n -> StoredTerm -> Either String (Term n)
+    reintern envN (StoredTerm input) = do
+      raw <- Raw.pTerm (Raw.tokens input)
+      case tryToTerm' (ctxScope (envCtx envN)) (envDeclared envN) raw of
+        Left err -> Left ("artifact for " <> prettyVarIdent (artifactModule artifact)
+                            <> ": " <> notInScope err)
+        Right t  -> Right (desugar t)
+
+-- | Load a module from its artifact into the environment of an already
+-- loaded (or checked) unit, composing the evidence: the load-side mirror of
+-- 'checkModuleAfter', so a chain of cached modules folds into one unit over
+-- the chain's base and links like anything else.
+loadArtifactAfter
+  :: Map Raw.VarIdent ContentHash
+     -- ^ Content hashes of the modules loaded or checked so far.
+  -> Foil.NameRange       -- ^ The next module's stripe, from this run's registry.
+  -> CheckedModule c      -- ^ The chain so far.
+  -> ModuleArtifact
+  -> Either String (CheckedModule c)
+loadArtifactAfter hashes range (CheckedModule ext env results) artifact = do
+  cm <- loadArtifact hashes range env artifact
+  case cm of
+    CheckedModule ext' env' results' ->
+      Right (CheckedModule (Blocks.composeExtWithin ext ext') env' (results <> results'))

--- a/haskell/mltt/src/Language/MLTT/Impl.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl.hs
@@ -230,6 +230,12 @@ firstStripeBase = stripeSize
 paramRegion :: Foil.NameRange
 paramRegion = Foil.NameRange 0 (firstStripeBase - 1)
 
+-- | A stripe's position in the registry: which run of 'stripeSize' names a
+-- module draws from. Its own type, so that a stripe index cannot be confused
+-- with a name, a count, or an offset.
+newtype StripeIndex = StripeIndex Int
+  deriving (Eq, Ord, Show, Read)
+
 -- | Which stripe each module's declarations live in.
 --
 -- The assignment is what makes raw names deterministic: a module's
@@ -239,7 +245,7 @@ paramRegion = Foil.NameRange 0 (firstStripeBase - 1)
 -- artefacts survive changes elsewhere in the module graph exactly when the
 -- assignment does not move. Here it is threaded through one run, and a test
 -- (or a driver) can seed it.
-type Registry = Map Raw.VarIdent Int
+type Registry = Map Raw.VarIdent StripeIndex
 
 -- | The registry before any module has ever been checked.
 emptyRegistry :: Registry
@@ -250,12 +256,12 @@ emptyRegistry = Map.empty
 registerModule :: Raw.VarIdent -> Registry -> (Registry, Foil.NameRange)
 registerModule name registry = case Map.lookup name registry of
   Just i  -> (registry, stripeRange i)
-  Nothing -> let i = Map.size registry
+  Nothing -> let i = StripeIndex (Map.size registry)
               in (Map.insert name i registry, stripeRange i)
 
 -- | Stripe @i@ is the @i@-th run of 'stripeSize' names above 'firstStripeBase'.
-stripeRange :: Int -> Foil.NameRange
-stripeRange i = Foil.NameRange lo (lo + stripeSize - 1)
+stripeRange :: StripeIndex -> Foil.NameRange
+stripeRange (StripeIndex i) = Foil.NameRange lo (lo + stripeSize - 1)
   where
     lo = firstStripeBase + i * stripeSize
 

--- a/haskell/mltt/src/Language/MLTT/Impl/Generated.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl/Generated.hs
@@ -135,6 +135,35 @@ showTermWith
   => (Int -> Raw.VarIdent) -> Foil.NameMap n Raw.VarIdent -> Term' a n -> String
 showTermWith bound names = Raw.printTree . fromTermWith bound names
 
+-- | Convert a pattern back to raw syntax, naming its binders from their
+-- indices with a caller-supplied function.
+--
+-- The generated 'fromPattern'' bakes the display naming into the binder
+-- occurrences, while 'fromTermWith' applies its @bound@ function only to the
+-- bound-variable /references/. A serialiser needs the two to go through the
+-- same function, or a reference comes out free of its own binder.
+fromPatternNamed :: (Int -> Raw.VarIdent) -> Pattern' a o i -> Raw.Pattern' a
+fromPatternNamed _named (PatternWildcard loc) = Raw.PatternWildcard loc
+fromPatternNamed named (PatternVar loc binder) =
+  Raw.PatternVar loc (named (Foil.nameId (Foil.nameOf binder)))
+fromPatternNamed named (PatternPair loc p1 p2) =
+  Raw.PatternPair loc (fromPatternNamed named p1) (fromPatternNamed named p2)
+
+-- | 'fromTermWith', with one naming function covering both the binder
+-- occurrences and the bound-variable references.
+fromTermNamed
+  :: Foil.Distinct n
+  => (Int -> Raw.VarIdent) -> Foil.NameMap n Raw.VarIdent -> Term' a n -> Raw.Term' a
+fromTermNamed bound names =
+  convertFromASTWith fromTerm'Sig rawVar (fromPatternNamed bound) rawScopedTerm
+    (`Foil.lookupName` names) bound
+
+-- | Print a term with one naming function for everything bound.
+showTermNamed
+  :: Foil.Distinct n
+  => (Int -> Raw.VarIdent) -> Foil.NameMap n Raw.VarIdent -> Term' a n -> String
+showTermNamed bound names = Raw.printTree . fromTermNamed bound names
+
 -- * Convenient monomorphic synonyms
 --
 -- Everything downstream is written against terms annotated with a source

--- a/haskell/mltt/src/Language/MLTT/Resolve.hs
+++ b/haskell/mltt/src/Language/MLTT/Resolve.hs
@@ -154,7 +154,7 @@ data Visibility
   | Private
     -- ^ Not exported. An importing module cannot /name/ it — and can still
     -- /reduce/ through it, since withholding a spelling touches no term.
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 -- | Add a declaration to what a module exports, if it is public.
 --

--- a/haskell/mltt/test/Language/MLTT/ArtifactSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ArtifactSpec.hs
@@ -1,0 +1,146 @@
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes        #-}
+
+-- | The serialisation round trip, on the diamond of chains from
+-- "Language.MLTT.LinkSpec": check modules and write artifacts in one run,
+-- then start from nothing, load the artifacts instead of the sources, link,
+-- and check a client on top.
+module Language.MLTT.ArtifactSpec (spec) where
+
+import qualified Control.Monad.Foil           as Foil
+import           Data.Map                     (Map)
+import qualified Data.Map                     as Map
+import           Test.Hspec
+
+import           Language.MLTT.Artifact
+import           Language.MLTT.Impl
+import           Language.MLTT.Impl.Generated (parseProgram)
+import qualified Language.MLTT.Syntax.Abs     as Raw
+
+srcP, srcQ, srcR, srcS, srcT, srcU :: String
+srcP = unlines ["module P", "def base : 𝟙 := tt"]
+srcQ = unlines ["module Q", "import P", "def q : 𝟙 := base"]
+srcR = unlines ["module R", "import Q", "def r : 𝟙 := q"]
+srcS = unlines
+  [ "module S (A : 𝕌) (a : A)"
+  , "import P"
+  , "def s : A → A := λ u ⇒ a"
+  , "def sbase : 𝟙 := base"
+  ]
+srcT = unlines ["module T", "import S", "def t : 𝟙 → 𝟙 := s 𝟙 sbase"]
+srcU = unlines ["module U", "import R", "import T", "compute t r"]
+
+oneModule :: String -> Raw.Module
+oneModule src = case parseProgram src of
+  Right (Raw.AProgram _ [m]) -> m
+  Right _                    -> error "expected exactly one module"
+  Left err                   -> error err
+
+mP, mQ, mR, mS, mT, mU :: Raw.Module
+mP = oneModule srcP
+mQ = oneModule srcQ
+mR = oneModule srcR
+mS = oneModule srcS
+mT = oneModule srcT
+mU = oneModule srcU
+
+-- | Check modules sequentially (they are given in build order) and produce
+-- an artifact for each, exactly as a caching driver would.
+artifactsOf :: [Raw.Module] -> Map Raw.VarIdent ModuleArtifact
+artifactsOf = go (0 :: Int) Map.empty emptyEnv
+  where
+    go :: Foil.Distinct n
+       => Int -> Map Raw.VarIdent ModuleArtifact -> Env n -> [Raw.Module]
+       -> Map Raw.VarIdent ModuleArtifact
+    go _ acc _ [] = acc
+    go i acc env (m : ms) =
+      let importHashes =
+            [ (x, artifactHash (acc Map.! x))
+            | Raw.AnImport _ x <- moduleImports m ]
+          cm = checkModule (stripeRange (StripeIndex i)) env m
+          a  = makeArtifact (moduleName m) (StripeIndex i) importHashes cm
+       in withCheckedModule cm $ \_ env' results ->
+            if succeeded results
+              then go (i + 1) (Map.insert (artifactModule a) a acc) env' ms
+              else error ("module failed to check: " <> show results)
+
+arts :: Map Raw.VarIdent ModuleArtifact
+arts = artifactsOf [mP, mQ, mR, mS, mT]
+
+art :: Raw.VarIdent -> ModuleArtifact
+art m = arts Map.! m
+
+hashesOf :: [Raw.VarIdent] -> Map Raw.VarIdent ContentHash
+hashesOf ms = Map.fromList [(m, artifactHash (art m)) | m <- ms]
+
+-- | The raw name of everything a checked module can refer to, by spelling.
+declaredIds :: CheckedModule c -> [(Raw.VarIdent, Int)]
+declaredIds cm = withCheckedModule cm $ \_ env _ ->
+  Map.toList (fmap Foil.nameId (envDeclared env))
+
+resultsOf :: CheckedModule c -> [CommandResult]
+resultsOf cm = withCheckedModule cm (\_ _ rs -> rs)
+
+spec :: Spec
+spec = do
+  describe "the wire format" $ do
+    it "round-trips through render and read" $
+      readArtifact (renderArtifact (art "S")) `shouldBe` Right (art "S")
+
+    it "stores fully qualified spellings, not names" $
+      map adSpelling (artifactDecls (art "S")) `shouldBe` ["s", "sbase"]
+
+  describe "loading" $ do
+    it "reconstructs the very names the check allocated" $
+      case loadArtifact Map.empty (stripeRange (StripeIndex 0)) emptyEnv (art "P") of
+        Left err  -> expectationFailure err
+        Right cmP ->
+          declaredIds cmP `shouldBe`
+            declaredIds (checkModule (stripeRange (StripeIndex 0)) emptyEnv mP)
+
+    it "a module checks against a loaded import exactly as against a checked one" $
+      case loadArtifact Map.empty (stripeRange (StripeIndex 0)) emptyEnv (art "P") of
+        Left err  -> expectationFailure err
+        Right cmP ->
+          withCheckedModule cmP $ \_ envP _ ->
+            withCheckedModule (checkModule (stripeRange (StripeIndex 0)) emptyEnv mP) $ \_ envP' _ -> do
+              resultsOf (checkModule (stripeRange (StripeIndex 2)) envP mS)
+                `shouldBe` resultsOf (checkModule (stripeRange (StripeIndex 2)) envP' mS)
+              declaredIds (checkModule (stripeRange (StripeIndex 2)) envP mS)
+                `shouldBe` declaredIds (checkModule (stripeRange (StripeIndex 2)) envP' mS)
+
+    it "rejects a stale artifact instead of linking it" $
+      case loadArtifact Map.empty (stripeRange (StripeIndex 0)) emptyEnv (art "P") of
+        Left err  -> expectationFailure err
+        Right cmP ->
+          withCheckedModule cmP $ \_ envP _ ->
+            case loadArtifact (Map.singleton "P" (ContentHash 0)) (stripeRange (StripeIndex 1)) envP (art "Q") of
+              Left err -> err `shouldContain` "stale"
+              Right _  -> expectationFailure "a stale artifact was accepted"
+
+    it "loads at a moved stripe: the relocation case" $
+      case loadArtifact Map.empty (stripeRange (StripeIndex 7)) emptyEnv (art "P") of
+        Left err  -> expectationFailure err
+        Right cmP -> do
+          let Foil.NameRange lo _ = stripeRange (StripeIndex 7)
+          map snd (declaredIds cmP) `shouldBe` [lo]
+          withCheckedModule cmP $ \_ envP _ ->
+            resultsOf (checkModule (stripeRange (StripeIndex 1)) envP mQ)
+              `shouldBe` [EnteredModule "Q", Defined "q" []]
+
+  describe "the full diamond from cache" $
+    it "loads both chains, links them, and checks the client on top" $
+      let run = do
+            cmP <- loadArtifact Map.empty (stripeRange (StripeIndex 0)) emptyEnv (art "P")
+            withCheckedModule cmP $ \_ envP _ -> do
+              cmQ <- loadArtifact (hashesOf ["P"]) (stripeRange (StripeIndex 1)) envP (art "Q")
+              chainQR <- loadArtifactAfter (hashesOf ["Q"]) (stripeRange (StripeIndex 3)) cmQ (art "R")
+              cmS <- loadArtifact (hashesOf ["P"]) (stripeRange (StripeIndex 2)) envP (art "S")
+              chainST <- loadArtifactAfter (hashesOf ["S"]) (stripeRange (StripeIndex 4)) cmS (art "T")
+              let registry = Map.fromList
+                    [ (moduleName mP, StripeIndex 0), (moduleName mQ, StripeIndex 1)
+                    , (moduleName mS, StripeIndex 2), (moduleName mR, StripeIndex 3)
+                    , (moduleName mT, StripeIndex 4) ]
+              linkModules chainQR chainST $ \envU -> goModules registry envU [mU]
+       in run `shouldBe` Right [EnteredModule "U", Computed "tt"]

--- a/haskell/mltt/test/Language/MLTT/LinkSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/LinkSpec.hs
@@ -69,7 +69,8 @@ mU = oneModule srcU
 -- run and 'interpretModules' hand out the same stripes.
 registry :: Registry
 registry = Map.fromList
-  [ (moduleName mI, 0), (moduleName mA, 1), (moduleName mB, 2) ]
+  [ (moduleName mI, StripeIndex 0), (moduleName mA, StripeIndex 1)
+  , (moduleName mB, StripeIndex 2) ]
 
 -- | The results a checked module reported.
 resultsOf :: CheckedModule c -> [CommandResult]
@@ -84,9 +85,9 @@ declaredIds cm = withCheckedModule cm $ \_ env _ ->
 -- @C@ in the linked environment. The flag swaps the link order.
 linkedRun :: Bool -> Either String [CommandResult]
 linkedRun swapped =
-  withCheckedModule (checkModule (stripeRange 0) emptyEnv mI) $ \_ envI resultsI ->
-    let ca = checkModule (stripeRange 1) envI mA
-        cb = checkModule (stripeRange 2) envI mB
+  withCheckedModule (checkModule (stripeRange (StripeIndex 0)) emptyEnv mI) $ \_ envI resultsI ->
+    let ca = checkModule (stripeRange (StripeIndex 1)) envI mA
+        cb = checkModule (stripeRange (StripeIndex 2)) envI mB
         runC envK = goModules registry envK [mC]
         linked
           | swapped   = linkModules cb ca runC
@@ -107,17 +108,17 @@ spec = do
 
   describe "determinism of declaration names" $ do
     it "numbers a stripe's declarations from its base, in order" $
-      withCheckedModule (checkModule (stripeRange 0) emptyEnv mI) $ \_ envI _ ->
-        declaredIds (checkModule (stripeRange 1) envI mA) `shouldBe`
+      withCheckedModule (checkModule (stripeRange (StripeIndex 0)) emptyEnv mI) $ \_ envI _ ->
+        declaredIds (checkModule (stripeRange (StripeIndex 1)) envI mA) `shouldBe`
           [ (Raw.VarIdent "a", firstStripeBase + stripeSize)
           , (Raw.VarIdent "base", firstStripeBase)
           ]
 
     it "gives a module the same names whatever else was checked before" $
-      withCheckedModule (checkModule (stripeRange 0) emptyEnv mI) $ \_ envI _ ->
-        withCheckedModule (checkModule (stripeRange 3) envI mX) $ \_ envX _ ->
-          declaredIds (checkModule (stripeRange 1) envX mA)
-            `shouldBe` declaredIds (checkModule (stripeRange 1) envI mA)
+      withCheckedModule (checkModule (stripeRange (StripeIndex 0)) emptyEnv mI) $ \_ envI _ ->
+        withCheckedModule (checkModule (stripeRange (StripeIndex 3)) envI mX) $ \_ envX _ ->
+          declaredIds (checkModule (stripeRange (StripeIndex 1)) envX mA)
+            `shouldBe` declaredIds (checkModule (stripeRange (StripeIndex 1)) envI mA)
 
 
   describe "linking chains" $
@@ -125,29 +126,30 @@ spec = do
       -- The chains get interleaved stripes (Q = 1, S = 2, R = 3, T = 4), so
       -- the convex hulls of the two chains overlap while their reservations
       -- do not: the case that forces evidence over a set of ranges.
-      withCheckedModule (checkModule (stripeRange 0) emptyEnv mP) $ \_ envP resultsP ->
-        let chainQR = checkModuleAfter (stripeRange 3) (checkModule (stripeRange 1) envP mQ) mR
-            chainST = checkModuleAfter (stripeRange 4) (checkModule (stripeRange 2) envP mS) mT
+      withCheckedModule (checkModule (stripeRange (StripeIndex 0)) emptyEnv mP) $ \_ envP resultsP ->
+        let chainQR = checkModuleAfter (stripeRange (StripeIndex 3)) (checkModule (stripeRange (StripeIndex 1)) envP mQ) mR
+            chainST = checkModuleAfter (stripeRange (StripeIndex 4)) (checkModule (stripeRange (StripeIndex 2)) envP mS) mT
             chainRegistry = Map.fromList
-              [ (moduleName mP, 0), (moduleName mQ, 1), (moduleName mS, 2)
-              , (moduleName mR, 3), (moduleName mT, 4) ]
+              [ (moduleName mP, StripeIndex 0), (moduleName mQ, StripeIndex 1)
+              , (moduleName mS, StripeIndex 2), (moduleName mR, StripeIndex 3)
+              , (moduleName mT, StripeIndex 4) ]
             linked = linkModules chainQR chainST (\envU -> goModules chainRegistry envU [mU])
          in fmap (\resultsU -> resultsP <> resultsOf chainQR <> resultsOf chainST <> resultsU) linked
               `shouldBe` Right (interpretModules [mP, mQ, mR, mS, mT, mU])
 
   describe "linking failures" $
     it "refuses two modules whose stripes overlap" $
-      withCheckedModule (checkModule (stripeRange 0) emptyEnv mI) $ \_ envI _ ->
-        let ca  = checkModule (stripeRange 1) envI mA
-            cb' = checkModule (stripeRange 1) envI mB  -- a registry gone wrong
+      withCheckedModule (checkModule (stripeRange (StripeIndex 0)) emptyEnv mI) $ \_ envI _ ->
+        let ca  = checkModule (stripeRange (StripeIndex 1)) envI mA
+            cb' = checkModule (stripeRange (StripeIndex 1)) envI mB  -- a registry gone wrong
          in linkModules ca cb' (\_ -> ())
               `shouldSatisfy` isLeft
 
   describe "re-attachment by inclusion (checkExtScope)" $
     it "accepts each side against the union, and not the other way around" $
-      withCheckedModule (checkModule (stripeRange 0) emptyEnv mI) $ \_ envI _ ->
-        let ca = checkModule (stripeRange 1) envI mA
-            cb = checkModule (stripeRange 2) envI mB
+      withCheckedModule (checkModule (stripeRange (StripeIndex 0)) emptyEnv mI) $ \_ envI _ ->
+        let ca = checkModule (stripeRange (StripeIndex 1)) envI mA
+            cb = checkModule (stripeRange (StripeIndex 2)) envI mB
          in withCheckedModule ca $ \_ envA _ ->
               linkModules ca cb (\envK ->
                 ( isJust (Blocks.checkExtScope (ctxScope (envCtx envA)) (ctxScope (envCtx envK)))


### PR DESCRIPTION
A `Name` is an allocation artefact and cannot be written to disk, so an artifact records qualified spellings and is re-interned on load. Each declaration's type and value are stored as raw syntax with free variables printed fully qualified and bound ones canonically; loading parses them back and converts them against the environment being assembled. This is what module `S` of the linking diamond stores, with `s` closed over its two parameters:

```
s     : Π (l0 : 𝕌) → Π (l1 : l0) → Π (_ : l0) → l0
      = λ l0 ⇒ λ l1 ⇒ λ l2097153 ⇒ l1
sbase : 𝟙
      = base
```

The artifact also records the module's stripe at check time and the content hash of each import, and the spec pins what that buys: a run whose registry agrees reconstructs the very names the check allocated; a registry that moved the stripe still loads, at the new location — the relocation case; and a changed dependency is detected and the artifact rejected as stale rather than linked. Loading trusts the terms, which is the point of a cache; integrity is the hash chain, and the haddock states the trust boundary.

The artifact speaks in its own vocabulary rather than in `String`s and `Int`s: spellings and module names are `Raw.VarIdent`, a declaration's visibility is `Visibility`, the stripe is `StripeIndex` — now a type of its own in the registry too — and `ContentHash` and `StoredTerm` name the two wire-level notions.

A loaded module is an ordinary `CheckedModule`, so everything downstream works unchanged: `loadArtifactAfter` folds a cached chain the way `checkModuleAfter` folds a checked one, chains link, and further modules check on top. The spec drives the whole diamond from artifacts — both chains loaded with no sources present, linked, and the client checked on top, computing `tt`.

Printing needed one new piece. The generated `fromPattern'` bakes the display naming into binder occurrences, while `fromTermWith`'s naming function covers only bound-variable references — so `Π (x0 : 𝕌) → … l0` came out with `l0` free of its own binder. `fromPatternNamed`/`fromTermNamed` put both through one function.

One limitation, stated in the haddock: the `l2097153` above is a λ-binder that took the successor of the whole ambient scope's maximum at check time, so bound spellings — harmless in memory — leak the checking environment into the artifact text, and the content hash is reproducible only for a module checked in the same world. The fix belongs in the conversion layer: let it allocate the binders it introduces in a caller-supplied region, and stored terms become canonical by construction.