### PR TITLE
MLTT: canonical elaboration, hence canonical artifacts

### DIFF
--- a/haskell/mltt/src/Language/MLTT/Artifact.hs
+++ b/haskell/mltt/src/Language/MLTT/Artifact.hs
@@ -26,22 +26,17 @@
 -- 'contentHash', a plain FNV-1a over the rendered content — collision
 -- resistance enough for a build cache, not for an adversary.
 --
--- Three wire-format notes:
+-- Two wire-format notes:
 --
 -- * Bound variables are printed @l\<i\>@ from their raw ids; a program whose
 --   fully qualified spelling matches that pattern would need escaping,
---   which this demo does not implement.
+--   which this demo does not implement. The ids themselves are canonical:
+--   elaboration allocates its binders in 'localRegion', whose content does
+--   not depend on what else is in scope, so the same module produces a
+--   byte-identical artifact — and hash — whatever world it is checked in.
 --
 -- * Source positions inside a loaded term point into the artifact text, not
 --   the original source.
---
--- * The bound spellings inherit the one place raw ids are not
---   deterministic: a λ-binder allocated during checking takes the successor
---   of the whole ambient scope's maximum, so its id — harmless in memory —
---   leaks into the artifact text, and the content hash is reproducible only
---   for a module checked in the same environment. The fix is for the
---   conversion layer to allocate the binders it introduces in a
---   caller-supplied region, not more code here.
 module Language.MLTT.Artifact (
   ModuleArtifact (..),
   ArtifactDecl (..),
@@ -230,7 +225,7 @@ loadArtifact hashes range env artifact = do
     reintern :: Foil.Distinct n => Env n -> StoredTerm -> Either String (Term n)
     reintern envN (StoredTerm input) = do
       raw <- Raw.pTerm (Raw.tokens input)
-      case tryToTerm' (ctxScope (envCtx envN)) (envDeclared envN) raw of
+      case tryToTerm'In localRegion (ctxScope (envCtx envN)) (envDeclared envN) raw of
         Left err -> Left ("artifact for " <> prettyVarIdent (artifactModule artifact)
                             <> ": " <> notInScope err)
         Right t  -> Right (desugar t)

--- a/haskell/mltt/src/Language/MLTT/Impl.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl.hs
@@ -218,17 +218,33 @@ moduleDecls (Raw.AModule _ _ _ _ decls) = decls
 stripeSize :: Int
 stripeSize = 0x100000
 
--- | Where the first stripe starts. Below it lies 'paramRegion'.
+-- | Where the first stripe starts. Below it lies 'localRegion'.
 firstStripeBase :: Int
 firstStripeBase = stripeSize
 
--- | The region module parameters are allocated in.
+-- | The region module parameters and elaboration-time binders live in.
 --
--- It lies below every stripe, so a parameter can never collide with a
--- declaration's name, and parameter indices stay small — a discharged type
--- prints as @Π (x0 : 𝕌) → …@ however many declarations precede it.
-paramRegion :: Foil.NameRange
-paramRegion = Foil.NameRange 0 (firstStripeBase - 1)
+-- It lies below every stripe, so nothing here can collide with a
+-- declaration's name, and the indices stay small — a discharged type prints
+-- as @Π (x0 : 𝕌) → …@ however many declarations precede it. More
+-- importantly, allocation inside the region depends only on the region's own
+-- content, so elaborating a declaration produces the same term whatever else
+-- the ambient scope holds: elaborated terms, and hence artifacts and their
+-- hashes, are canonical across worlds.
+--
+-- The region's budget is spent on syntax, not on computation. Evaluation and
+-- type checking allocate their transient names at the whole scope's
+-- successor, above every stripe, and nothing rests on those; what lands here
+-- is one name per binder /written/ in the declaration being elaborated, plus
+-- the parameters, and the region resets between declarations, since
+-- elaboration binders live inside terms and never enter the module's scope.
+-- So the occupancy bound is the source size of one declaration against a
+-- budget of \(2^{20}\). Were it ever exhausted, 'Foil.withFreshIn' fails
+-- loudly rather than colliding: the size is a liveness constant, not a
+-- soundness assumption, and widening the region relative to the stripes is a
+-- policy change confined to these constants.
+localRegion :: Foil.NameRange
+localRegion = Foil.NameRange 0 (firstStripeBase - 1)
 
 -- | A stripe's position in the registry: which run of 'stripeSize' names a
 -- module draws from. Its own type, so that a stripe index cannot be confused
@@ -434,7 +450,7 @@ data Two a = Two a a
 
 -- | Allocate a module's parameters, extending the environment with them.
 --
--- Parameters are allocated in 'paramRegion', below every stripe, so they can
+-- Parameters are allocated in 'localRegion', below every stripe, so they can
 -- never collide with a declaration's name — which is what used to force them
 -- to be re-allocated per declaration. They are still elaborated afresh for
 -- each declaration, but now only for simplicity: a parameter block is a few
@@ -452,11 +468,11 @@ withParams
   -> r
 withParams env [] _onErr cont = cont TelescopeEmpty env
 withParams env (Raw.AParam _loc name rawTy : rest) onErr cont =
-  case tryToTerm' (ctxScope ctx) (visibleAt [] (envDeclared env)) rawTy of
+  case tryToTerm'In localRegion (ctxScope ctx) (visibleAt [] (envDeclared env)) rawTy of
     Left err -> onErr (notInScope err)
     Right raw ->
       let ty = desugar raw
-       in withVarBinder paramRegion ctx ty $ \ctx' binder ->
+       in withVarBinder localRegion ctx ty $ \ctx' binder ->
             withParams (extendEnv ctx' binder name Private env) rest onErr $
               \tele envP -> cont (TelescopeCons name ty binder tele) envP
   where
@@ -593,7 +609,7 @@ withDecls me params path (decl : decls) cont = case decl of
       => Env p -> f Raw.Term -> (f (Term p) -> r) -> r
     withElaborated envP raws k =
       let (names, terms) = splitVisible envP (visibleAt path (envDeclared envP))
-       in case traverse (tryToTerm'With (ctxScope (envCtx envP)) names terms) raws of
+       in case traverse (tryToTerm'WithIn localRegion (ctxScope (envCtx envP)) names terms) raws of
             Left err -> continue (Failed (notInScope err))
             Right ts -> k (fmap desugar ts)
 

--- a/haskell/mltt/src/Language/MLTT/Impl/Generated.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl/Generated.hs
@@ -144,27 +144,14 @@ showTermWith
   => (Int -> Raw.VarIdent) -> Foil.NameMap n Raw.VarIdent -> Term' a n -> String
 showTermWith bound names = Raw.printTree . fromTermWith bound names
 
--- | Convert a pattern back to raw syntax, naming its binders from their
--- indices with a caller-supplied function.
---
--- The generated 'fromPattern'' bakes the display naming into the binder
--- occurrences, while 'fromTermWith' applies its @bound@ function only to the
--- bound-variable /references/. A serialiser needs the two to go through the
--- same function, or a reference comes out free of its own binder.
-fromPatternNamed :: (Int -> Raw.VarIdent) -> Pattern' a o i -> Raw.Pattern' a
-fromPatternNamed _named (PatternWildcard loc) = Raw.PatternWildcard loc
-fromPatternNamed named (PatternVar loc binder) =
-  Raw.PatternVar loc (named (Foil.nameId (Foil.nameOf binder)))
-fromPatternNamed named (PatternPair loc p1 p2) =
-  Raw.PatternPair loc (fromPatternNamed named p1) (fromPatternNamed named p2)
-
 -- | 'fromTermWith', with one naming function covering both the binder
--- occurrences and the bound-variable references.
+-- occurrences (through the generated 'fromPattern'With') and the
+-- bound-variable references.
 fromTermNamed
   :: Foil.Distinct n
   => (Int -> Raw.VarIdent) -> Foil.NameMap n Raw.VarIdent -> Term' a n -> Raw.Term' a
 fromTermNamed bound names =
-  convertFromASTWith fromTerm'Sig rawVar (fromPatternNamed bound) rawScopedTerm
+  convertFromASTWith fromTerm'Sig rawVar (fromPattern'With bound) rawScopedTerm
     (`Foil.lookupName` names) bound
 
 -- | Print a term with one naming function for everything bound.

--- a/haskell/mltt/test/Language/MLTT/ArtifactSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ArtifactSpec.hs
@@ -129,6 +129,27 @@ spec = do
             resultsOf (checkModule (stripeRange (StripeIndex 1)) envP mQ)
               `shouldBe` [EnteredModule "Q", Defined "q" []]
 
+  describe "canonical across worlds" $ do
+    it "produces the same artifact whatever else was checked around it" $
+      -- 'art "S"' comes from the sequential run, where Q was in scope when S
+      -- was checked; here S is checked with only P around. Byte-identical
+      -- artifacts, and hence hashes, are what let a cache survive changes
+      -- elsewhere in the module graph.
+      withCheckedModule (checkModule (stripeRange (StripeIndex 0)) emptyEnv mP) $ \_ envP _ ->
+        makeArtifact (moduleName mS) (StripeIndex 3)
+            [(moduleName mP, artifactHash (art "P"))]
+            (checkModule (stripeRange (StripeIndex 3)) envP mS)
+          `shouldBe` art "S"
+
+    it "a loaded module serialises back to the very same artifact" $
+      let roundTrip = do
+            cmP <- loadArtifact Map.empty (stripeRange (StripeIndex 0)) emptyEnv (art "P")
+            withCheckedModule cmP $ \_ envP _ -> do
+              cmS <- loadArtifact (hashesOf ["P"]) (stripeRange (StripeIndex 3)) envP (art "S")
+              Right (makeArtifact (moduleName mS) (StripeIndex 3)
+                       [(moduleName mP, artifactHash (art "P"))] cmS)
+       in roundTrip `shouldBe` Right (art "S")
+
   describe "the full diamond from cache" $
     it "loads both chains, links them, and checks the client on top" $
       let run = do


### PR DESCRIPTION
Elaboration now allocates its binders through the range-parametric conversions of #60, in the region below every stripe where the module parameters already lived: `paramRegion` becomes `localRegion`, and `tryToTerm'`/`tryToTerm'With` become their `In` siblings there — in checking and in artifact loading alike. Allocation inside the region depends only on the region's own content, so elaborating a declaration produces the same term whatever else the ambient scope holds.

That closes the last caveat of the artifact wire format from #59: bound spellings no longer leak the checking environment (module S's `λ l2097153 ⇒ …` is now `λ l2 ⇒ …`), and the content hash is reproducible across worlds. Two new tests say it directly:

- checking S with only P around produces a byte-identical artifact — hash included — to checking it in the full sequential run, which is what lets a cache survive changes elsewhere in the module graph;
- a loaded module serialises back to the very artifact it was loaded from.

The hand-written `fromPatternNamed` retires in favour of the generated `fromPattern'With`, the same fix now closed at its source.