### PR TITLE
MLTT: an interactive session, parallel checking, and a caching builder

### DIFF
--- a/haskell/free-foil/ChangeLog.md
+++ b/haskell/free-foil/ChangeLog.md
@@ -56,6 +56,8 @@ New:
 
   On the way out, the binding converter gains a naming-parametric sibling (`fromPatternWith` beside `fromPattern`, for a binding type named `Pattern`), taking the binder-naming function instead of baking `intToRawIdentName` in. The same function must name the bound-variable references, or a reference comes out free of its own binder; that mismatch is exactly the bug a serialiser hits with the baked naming, and `mltt` hit it.
 
+- `withDisjointUnion` hands its continuation two more things. The union's own `ExtWithin`: the linked scope extends the common base only within the union of the two range sets, which is exact, so a linked unit is itself linkable and a whole build folds through the one function. And the `Ext c k` constraint, which a caller cannot derive on the spot: obtaining it from `Ext c n` and `Ext n k` is exactly the chain the solver refuses when both sides' paths are in scope, since either given offers a candidate and it commits to neither.
+
 Changed:
 
 - `convertToAST` and `convertToScopedAST` are deprecated in favour of `unsafeConvertToAST` and `unsafeConvertToScopedAST`, which are the same functions under names that admit they call `error`. The old names still work.

--- a/haskell/free-foil/src/Control/Monad/Foil/Blocks.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/Blocks.hs
@@ -269,17 +269,21 @@ unsafeExtendedWithin scope binders ext cont =
 -- side, and the union would conflate them; hence no evidence is produced.
 --
 -- Both extension facts are handed to the continuation at once, as
--- 'withThinnedNameBinderList' does, together with a 'ScopeUnion' witness:
--- the constraints say that @k@ contains @n@ and @m@, and the witness says
+-- 'withThinnedNameBinderList' does, together with a 'ScopeUnion' witness
+-- (the constraints say that @k@ contains @n@ and @m@, and the witness says
 -- that it contains nothing else, which is what a total map on the union
--- needs ('unionNameMaps').
+-- needs — 'unionNameMaps') and with the union's own 'ExtWithin': the linked
+-- scope extends the common base only within the union of the two range
+-- sets, which is exact, so a linked unit is itself linkable and a whole
+-- build folds through this one function.
 withDisjointUnion
   :: forall c n m r. (Distinct n, Distinct m)
   => ExtWithin c n  -- ^ Evidence for the first unit.
   -> ExtWithin c m  -- ^ Evidence for the second unit.
   -> Scope n        -- ^ The first unit's scope.
   -> Scope m        -- ^ The second unit's scope.
-  -> (forall k. (Ext n k, Ext m k, Distinct k) => Scope k -> ScopeUnion n m k -> r)
+  -> (forall k. (Ext n k, Ext m k, Ext c k, Distinct k)
+        => Scope k -> ScopeUnion n m k -> ExtWithin c k -> r)
   -> Maybe r
 withDisjointUnion (UnsafeExtWithin rs1) (UnsafeExtWithin rs2) (UnsafeScope s1) (UnsafeScope s2) cont
   | rangeSetsOverlap rs1 rs2 = Nothing
@@ -290,7 +294,14 @@ withDisjointUnion (UnsafeExtWithin rs1) (UnsafeExtWithin rs2) (UnsafeScope s1) (
       case unsafeDistinct @k of
         Distinct -> case unsafeExt @n @k of
           Ext -> case unsafeExt @m @k of
-            Ext -> cont scope UnsafeScopeUnion
+            Ext -> case unsafeExt @c @k of
+              -- The base is below both sides: each delta lies within its
+              -- ranges over @c@, so the names of @c@ are in @n@ and in @m@,
+              -- hence in the union. Handing this as a given matters for
+              -- folds: deriving it from @Ext c n@ and @Ext n k@ is exactly
+              -- the two-candidate chain GHC refuses.
+              Ext -> cont scope UnsafeScopeUnion
+                          (UnsafeExtWithin (normaliseRanges (rs1 <> rs2)))
 
 -- | Evidence that scope @k@ is /precisely/ the union of scopes @n@ and @m@:
 -- every name of @n@ and of @m@ is a name of @k@, and nothing else is.

--- a/haskell/free-foil/test/Control/Monad/Foil/BlocksSpec.hs
+++ b/haskell/free-foil/test/Control/Monad/Foil/BlocksSpec.hs
@@ -79,7 +79,7 @@ spec = do
                 withExtendScopeRange Foil.emptyScope (NameRange 20 29) 1 $ \t1 _ f1 ->
                   withExtendScopeRange t1 (NameRange 40 49) 1 $ \t2 _ f2 ->
                     withDisjointUnion (composeExtWithin e1 e2) (composeExtWithin f1 f2)
-                      s2 t2 (\s _ -> scopeIds s)
+                      s2 t2 (\s _ _ -> scopeIds s)
        in linked `shouldBe` Just (Just (Just (Just (Just [10, 20, 30, 40]))))
 
   describe "withDisjointUnion" $ do
@@ -89,14 +89,14 @@ spec = do
             linked =
               withExtendScopeRange c ra 2 $ \sa _ ea ->
                 withExtendScopeRange c rb 1 $ \sb _ eb ->
-                  withDisjointUnion ea eb sa sb (\s _ -> scopeIds s)
+                  withDisjointUnion ea eb sa sb (\s _ _ -> scopeIds s)
          in linked `shouldBe` Just (Just (Just [0, 100, 101, 200]))
 
     it "refuses overlapping reservations" $
       let linked =
             withExtendScopeRange Foil.emptyScope ra 2 $ \sa _ ea ->
               withExtendScopeRange Foil.emptyScope ra 1 $ \sb _ eb ->
-                withDisjointUnion ea eb sa sb (\s _ -> scopeIds s)
+                withDisjointUnion ea eb sa sb (\s _ _ -> scopeIds s)
        in linked `shouldBe` Just (Just Nothing)
 
     it "extends both sides' maps to the union" $
@@ -107,7 +107,7 @@ spec = do
                     m2 = Foil.addNameBinderList bsb ["b"] Foil.emptyNameMap
                  in case (Foil.namesOfPattern bsa, Foil.namesOfPattern bsb) of
                       ([x1], [x2]) ->
-                        withDisjointUnion ea eb sa sb $ \_scope union ->
+                        withDisjointUnion ea eb sa sb $ \_scope union _ext ->
                           let u = unionNameMaps union m1 m2
                            in ( Foil.lookupName (Foil.sink x1) u
                               , Foil.lookupName (Foil.sink x2) u
@@ -120,7 +120,7 @@ spec = do
       let checked =
             withExtendScopeRange Foil.emptyScope ra 1 $ \sa _ ea ->
               withExtendScopeRange Foil.emptyScope rb 1 $ \sb _ eb ->
-                withDisjointUnion ea eb sa sb $ \scope _ ->
+                withDisjointUnion ea eb sa sb $ \scope _ _ ->
                   ( isJust (checkScopeUnion sa sb scope)
                   , isJust (checkScopeUnion sa sa scope)  -- misses b's delta
                   )

--- a/haskell/mltt/app/MLTT.hs
+++ b/haskell/mltt/app/MLTT.hs
@@ -1,7 +1,7 @@
 module Main where
 
-import Language.MLTT.Impl  (defaultMain)
+import Language.MLTT.Build (buildMain)
 import System.Environment (getArgs)
 
 main :: IO ()
-main = defaultMain =<< getArgs
+main = buildMain =<< getArgs

--- a/haskell/mltt/mltt.cabal
+++ b/haskell/mltt/mltt.cabal
@@ -36,6 +36,7 @@ custom-setup
 library
   exposed-modules:
       Language.MLTT.Artifact
+      Language.MLTT.Build
       Language.MLTT.Eval
       Language.MLTT.FreeFoilConfig
       Language.MLTT.Impl
@@ -64,6 +65,8 @@ library
     , bifunctors
     , containers
     , deepseq
+    , directory
+    , filepath
     , free-foil >=0.3.3
     , kind-generics-th
     , template-haskell
@@ -88,6 +91,8 @@ executable mltt
     , bifunctors
     , containers
     , deepseq
+    , directory
+    , filepath
     , free-foil >=0.3.3
     , kind-generics-th
     , mltt
@@ -113,7 +118,9 @@ test-suite doctests
     , bifunctors
     , containers
     , deepseq
+    , directory
     , doctest-parallel
+    , filepath
     , free-foil >=0.3.3
     , kind-generics-th
     , mltt
@@ -126,6 +133,7 @@ test-suite spec
   main-is: Spec.hs
   other-modules:
       Language.MLTT.ArtifactSpec
+      Language.MLTT.BuildSpec
       Language.MLTT.ImplSpec
       Language.MLTT.LinkSpec
       Language.MLTT.ModulesSpec
@@ -146,6 +154,8 @@ test-suite spec
     , bifunctors
     , containers
     , deepseq
+    , directory
+    , filepath
     , free-foil
     , hspec
     , hspec-discover

--- a/haskell/mltt/mltt.cabal
+++ b/haskell/mltt/mltt.cabal
@@ -130,6 +130,7 @@ test-suite spec
       Language.MLTT.LinkSpec
       Language.MLTT.ModulesSpec
       Language.MLTT.ParametersSpec
+      Language.MLTT.ReplSpec
       Paths_mltt
   hs-source-dirs:
       test

--- a/haskell/mltt/package.yaml
+++ b/haskell/mltt/package.yaml
@@ -37,6 +37,8 @@ dependencies:
   text: ">= 1.2.3.1"
   containers:
   bifunctors:
+  directory:
+  filepath:
   template-haskell:
   deepseq:
   free-foil: ">= 0.3.3"
@@ -85,6 +87,8 @@ tests:
     dependencies:
       - mltt
       - free-foil
+      - directory
+      - filepath
       - hspec
       - hspec-discover
 

--- a/haskell/mltt/src/Language/MLTT/Artifact.hs
+++ b/haskell/mltt/src/Language/MLTT/Artifact.hs
@@ -73,6 +73,8 @@ import           Language.MLTT.Typecheck   (Ctx (..), extend)
 data ModuleArtifact = ModuleArtifact
   { artifactModule  :: Raw.VarIdent  -- ^ The module's qualified name.
   , artifactStripe  :: StripeIndex   -- ^ From the registry, at check time.
+  , artifactSource  :: ContentHash   -- ^ Of the module's printed source:
+                                     -- what an incremental rebuild compares.
   , artifactImports :: [(Raw.VarIdent, ContentHash)]
       -- ^ Each import, with its content hash at check time.
   , artifactHash    :: ContentHash   -- ^ Over the declarations below.
@@ -123,10 +125,11 @@ contentHash = ContentHash . foldl' step 0xcbf29ce484222325
 makeArtifact
   :: Raw.VarIdent               -- ^ The module's name.
   -> StripeIndex                -- ^ From the registry.
+  -> ContentHash                -- ^ Of the module's printed source.
   -> [(Raw.VarIdent, ContentHash)] -- ^ Its imports, with their content hashes.
   -> CheckedModule c
   -> ModuleArtifact
-makeArtifact name stripe imports cm = withCheckedModule cm $ \_ env _ ->
+makeArtifact name stripe source imports cm = withCheckedModule cm $ \_ env _ ->
   let Foil.NameRange lo hi = stripeRange stripe
       ctx = envCtx env
       own =
@@ -149,6 +152,7 @@ makeArtifact name stripe imports cm = withCheckedModule cm $ \_ env _ ->
    in ModuleArtifact
         { artifactModule  = name
         , artifactStripe  = stripe
+        , artifactSource  = source
         , artifactImports = imports
         , artifactHash    = contentHash (concatMap renderDecl decls)
         , artifactDecls   = decls

--- a/haskell/mltt/src/Language/MLTT/Build.hs
+++ b/haskell/mltt/src/Language/MLTT/Build.hs
@@ -41,13 +41,16 @@ module Language.MLTT.Build (
 
 import           Control.Concurrent       (forkIO, newEmptyMVar, putMVar,
                                            takeMVar)
+import           Control.DeepSeq          (force)
 import           Control.Exception        (evaluate)
 import           Control.Monad            (foldM, forM, forM_, unless, when)
 import qualified Control.Monad.Foil       as Foil
 import           Data.Char                (isSpace)
 import           Data.Function            (on)
-import           Data.List                (foldl', groupBy, isPrefixOf, sortOn,
+import           Data.List                (foldl', isPrefixOf, sortOn,
                                            stripPrefix)
+import           Data.List.NonEmpty       (NonEmpty (..))
+import qualified Data.List.NonEmpty       as NonEmpty
 import           Data.Map                 (Map)
 import qualified Data.Map                 as Map
 import           System.Directory         (createDirectoryIfMissing,
@@ -185,7 +188,7 @@ buildModulesWith mode cacheDir modules k =
       let registry = foldl' (\r m -> fst (registerModule (moduleName m) r))
                             emptyRegistry ordered
           waves = case mode of
-            Sequential -> [[m] | m <- ordered]
+            Sequential -> [m :| [] | m <- ordered]
             _          -> wavesOf ordered
           -- Results are reported in topological order whatever the
           -- schedule, so the three modes are comparable verbatim.
@@ -199,37 +202,35 @@ buildModulesWith mode cacheDir modules k =
           Right <$> k registry env (assemble perModule)
   where
     go :: Foil.Distinct c
-       => Registry -> Env c -> Map Raw.VarIdent ContentHash -> [[Raw.Module]]
+       => Registry -> Env c -> Map Raw.VarIdent ContentHash -> [NonEmpty Raw.Module]
        -> IO (Either String ([(Raw.VarIdent, [CommandResult])], BuiltEnv))
     go _ env _ [] = pure (Right ([], BuiltEnv env))
     go registry env hashes (wave : rest) = do
       units <- produceWave registry env hashes wave
       let hashes' = foldr (\(_, a, _) -> Map.insert (artifactModule a) (artifactHash a))
                           hashes units
-          results = [(artifactModule a, rs) | (_, a, rs) <- units]
-      case foldM1 linkChecked [cm | (cm, _, _) <- units] of
+          results = [(artifactModule a, rs) | (_, a, rs) <- NonEmpty.toList units]
+          first :| more = fmap (\(cm, _, _) -> cm) units
+      case foldM linkChecked first more of
         Left err     -> pure (Left err)
         Right linked ->
           withCheckedModule linked $ \_ env' _ ->
-            fmap (\(more, built) -> (results <> more, built))
+            fmap (\(later, built) -> (results <> later, built))
               <$> go registry env' hashes' rest
-
-    foldM1 f (x : xs) = foldM f x xs
-    foldM1 _ []       = error "impossible: an empty wave"
 
     -- Check (or load) each module of a wave against the same base
     -- environment; under 'Parallel', each on its own thread.
     produceWave
       :: Foil.Distinct c
-      => Registry -> Env c -> Map Raw.VarIdent ContentHash -> [Raw.Module]
-      -> IO [(CheckedModule c, ModuleArtifact, [CommandResult])]
+      => Registry -> Env c -> Map Raw.VarIdent ContentHash -> NonEmpty Raw.Module
+      -> IO (NonEmpty (CheckedModule c, ModuleArtifact, [CommandResult]))
     produceWave registry env hashes wave
       | mode == Parallel = do
           vars <- forM wave $ \m -> do
             var <- newEmptyMVar
             _ <- forkIO $ do
               unit@(_, _, rs) <- produce registry env hashes m
-              _ <- evaluate (length (show rs))   -- do the work on this thread
+              _ <- evaluate (force rs)   -- do the work on this thread
               putMVar var unit
             pure var
           mapM takeMVar vars
@@ -274,8 +275,8 @@ buildModulesWith mode cacheDir modules k =
 -- | Group modules, already in topological order, into dependency waves: a
 -- module's wave is one past the deepest wave among its imports, so the
 -- members of a wave are mutually independent.
-wavesOf :: [Raw.Module] -> [[Raw.Module]]
-wavesOf ordered = map (map snd) (groupBy ((==) `on` fst) (sortOn fst levelled))
+wavesOf :: [Raw.Module] -> [NonEmpty Raw.Module]
+wavesOf ordered = map (fmap snd) (NonEmpty.groupBy ((==) `on` fst) (sortOn fst levelled))
   where
     levelled = [(levelOf m, m) | m <- ordered]
     levels :: Map Raw.VarIdent Int

--- a/haskell/mltt/src/Language/MLTT/Build.hs
+++ b/haskell/mltt/src/Language/MLTT/Build.hs
@@ -42,10 +42,11 @@ module Language.MLTT.Build (
 import           Control.Concurrent       (forkIO, newEmptyMVar, putMVar,
                                            takeMVar)
 import           Control.Exception        (evaluate)
-import           Control.Monad            (foldM, forM, forM_, when)
+import           Control.Monad            (foldM, forM, forM_, unless, when)
 import qualified Control.Monad.Foil       as Foil
 import           Data.Char                (isSpace)
-import           Data.List                (groupBy, isPrefixOf, sortOn,
+import           Data.Function            (on)
+import           Data.List                (foldl', groupBy, isPrefixOf, sortOn,
                                            stripPrefix)
 import           Data.Map                 (Map)
 import qualified Data.Map                 as Map
@@ -86,7 +87,7 @@ buildMain args =
           else pure (succeeded results)
       case result of
         Left err -> putStrLn err >> exitFailure
-        Right ok -> if ok then pure () else exitFailure
+        Right ok -> unless ok exitFailure
 
 parseArgs :: [String] -> Either String (BuildMode, Maybe FilePath, Bool, [FilePath])
 parseArgs = fmap done . foldM step (Sequential, Nothing, False, [])
@@ -181,8 +182,8 @@ buildModulesWith mode cacheDir modules k =
     Left err -> pure (Left err)
     Right ordered -> do
       forM_ cacheDir (createDirectoryIfMissing True)
-      let registry = foldl (\r m -> fst (registerModule (moduleName m) r))
-                           emptyRegistry ordered
+      let registry = foldl' (\r m -> fst (registerModule (moduleName m) r))
+                            emptyRegistry ordered
           waves = case mode of
             Sequential -> [[m] | m <- ordered]
             _          -> wavesOf ordered
@@ -274,11 +275,11 @@ buildModulesWith mode cacheDir modules k =
 -- module's wave is one past the deepest wave among its imports, so the
 -- members of a wave are mutually independent.
 wavesOf :: [Raw.Module] -> [[Raw.Module]]
-wavesOf ordered = map (map snd) (groupBy (\a b -> fst a == fst b) (sortOn fst levelled))
+wavesOf ordered = map (map snd) (groupBy ((==) `on` fst) (sortOn fst levelled))
   where
     levelled = [(levelOf m, m) | m <- ordered]
     levels :: Map Raw.VarIdent Int
-    levels = foldl step Map.empty ordered
+    levels = foldl' step Map.empty ordered
     step acc m = Map.insert (moduleName m) (computeLevel acc m) acc
     computeLevel acc m = 1 + maximum
       (0 : [ Map.findWithDefault 0 x acc | Raw.AnImport _ x <- moduleImports m ])

--- a/haskell/mltt/src/Language/MLTT/Build.hs
+++ b/haskell/mltt/src/Language/MLTT/Build.hs
@@ -25,10 +25,17 @@
 -- declarations came out unchanged does not dirty its dependants (early
 -- cutoff). A cached module's @check@ and @compute@ commands are not re-run:
 -- the cache reconstructs environments, not output.
+--
+-- With @--repl@, the build is followed by an interactive session over its
+-- result: every built module's exports are in scope, and the session
+-- allocates from the first stripe the build left free.
 module Language.MLTT.Build (
   BuildMode (..),
   buildModules,
+  buildModulesWith,
   buildSources,
+  buildSourcesWith,
+  sessionOver,
   buildMain,
 ) where
 
@@ -37,6 +44,7 @@ import           Control.Concurrent       (forkIO, newEmptyMVar, putMVar,
 import           Control.Exception        (evaluate)
 import           Control.Monad            (foldM, forM, forM_, when)
 import qualified Control.Monad.Foil       as Foil
+import           Data.Char                (isSpace)
 import           Data.List                (groupBy, isPrefixOf, sortOn,
                                            stripPrefix)
 import           Data.Map                 (Map)
@@ -45,6 +53,7 @@ import           System.Directory         (createDirectoryIfMissing,
                                            doesFileExist)
 import           System.Exit              (exitFailure)
 import           System.FilePath          ((</>))
+import           System.IO                (hFlush, isEOF, stdout)
 
 import           Language.MLTT.Artifact
 import           Language.MLTT.Impl
@@ -54,36 +63,74 @@ import qualified Language.MLTT.Syntax.Abs as Raw
 import qualified Language.MLTT.Syntax.Print as Raw
 
 -- | The executable's entry point:
--- @mltt [--mode=sequential|linked|parallel] [--cache=DIR] [FILES…]@,
+-- @mltt [--mode=sequential|linked|parallel] [--cache=DIR] [--repl] [FILES…]@,
 -- reading standard input when no files are given.
+--
+-- With @--repl@, the files are built first and a session is started over the
+-- result; standard input then belongs to the session, so no files means an
+-- empty environment rather than a source on standard input. The session is
+-- entered even if some declarations failed — the failures were reported, and
+-- what did check is there to poke at.
 buildMain :: [String] -> IO ()
 buildMain args =
   case parseArgs args of
     Left err -> putStrLn err >> exitFailure
-    Right (mode, cacheDir, paths) -> do
+    Right (mode, cacheDir, interactive, paths) -> do
       sources <- case paths of
-        [] -> (\input -> [("<stdin>", input)]) <$> getContents
+        [] | not interactive -> (\input -> [("<stdin>", input)]) <$> getContents
         _  -> mapM (\path -> (,) path <$> readFile path) paths
-      result <- buildSources mode cacheDir sources
+      result <- buildSourcesWith mode cacheDir sources $ \registry env results -> do
+        mapM_ (putStrLn . renderResult) results
+        if interactive
+          then True <$ runRepl (sessionOver registry env)
+          else pure (succeeded results)
       case result of
         Left err -> putStrLn err >> exitFailure
-        Right results -> do
-          mapM_ (putStrLn . renderResult) results
-          if succeeded results then pure () else exitFailure
+        Right ok -> if ok then pure () else exitFailure
 
-parseArgs :: [String] -> Either String (BuildMode, Maybe FilePath, [FilePath])
-parseArgs = fmap done . foldM step (Sequential, Nothing, [])
+parseArgs :: [String] -> Either String (BuildMode, Maybe FilePath, Bool, [FilePath])
+parseArgs = fmap done . foldM step (Sequential, Nothing, False, [])
   where
-    done (m, c, ps) = (m, c, reverse ps)
-    step (m, c, ps) = \case
-      "--mode=sequential" -> Right (Sequential, c, ps)
-      "--mode=linked"     -> Right (Linked, c, ps)
-      "--mode=parallel"   -> Right (Parallel, c, ps)
+    done (m, c, i, ps) = (m, c, i, reverse ps)
+    step (m, c, i, ps) = \case
+      "--mode=sequential" -> Right (Sequential, c, i, ps)
+      "--mode=linked"     -> Right (Linked, c, i, ps)
+      "--mode=parallel"   -> Right (Parallel, c, i, ps)
+      "--repl"            -> Right (m, c, True, ps)
       arg
-        | Just dir <- stripPrefix "--cache=" arg -> Right (m, Just dir, ps)
+        | Just dir <- stripPrefix "--cache=" arg -> Right (m, Just dir, i, ps)
         | "--" `isPrefixOf` arg -> Left ("unknown option: " <> arg <> usage)
-        | otherwise -> Right (m, c, arg : ps)
-    usage = "\nusage: mltt [--mode=sequential|linked|parallel] [--cache=DIR] [FILES...]"
+        | otherwise -> Right (m, c, i, arg : ps)
+    usage = "\nusage: mltt [--mode=sequential|linked|parallel] [--cache=DIR] [--repl] [FILES...]"
+
+-- | Begin a session over a build. Every built module's exports are in scope,
+-- as if the session's module imported them all, and names are allocated from
+-- the first stripe the build left free — the registry is append-only, so its
+-- size names that stripe.
+sessionOver :: Foil.Distinct c => Registry -> Env c -> Repl c
+sessionOver registry env =
+  beginRepl (stripeRange (StripeIndex (Map.size registry)))
+            env { envDeclared = Map.unions (Map.elems (envModules env)) }
+
+-- | The loop itself: one 'replStep' per line, until end of input. Blank
+-- lines are skipped, and results are rendered exactly like the builder's.
+runRepl :: Repl c -> IO ()
+runRepl = loop
+  where
+    loop s = do
+      putStr "mltt> "
+      hFlush stdout
+      end <- isEOF
+      if end
+        then putStrLn ""
+        else do
+          line <- getLine
+          if all isSpace line
+            then loop s
+            else do
+              let (s', results) = replStep line s
+              mapM_ (putStrLn . renderResult) results
+              loop s'
 
 -- | How to schedule the checking.
 data BuildMode = Sequential | Linked | Parallel
@@ -94,19 +141,42 @@ buildSources
   :: BuildMode -> Maybe FilePath -> [(FilePath, String)]
   -> IO (Either String [CommandResult])
 buildSources mode cacheDir sources =
+  buildSourcesWith mode cacheDir sources (\_ _ results -> pure results)
+
+-- | 'buildSources', handing the continuation the outcome; see
+-- 'buildModulesWith'.
+buildSourcesWith
+  :: BuildMode -> Maybe FilePath -> [(FilePath, String)]
+  -> (forall c. Foil.Distinct c => Registry -> Env c -> [CommandResult] -> IO r)
+  -> IO (Either String r)
+buildSourcesWith mode cacheDir sources k =
   case traverse parseSource sources of
     Left err -> pure (Left err)
-    Right ms -> buildModules mode cacheDir (concat ms)
+    Right ms -> buildModulesWith mode cacheDir (concat ms) k
   where
     parseSource (path, input) = case parseProgram input of
       Left err                    -> Left (path <> ":" <> err)
       Right (Raw.AProgram _ms ms) -> Right ms
+
+-- | The environment a build ends in, its scope index hidden.
+data BuiltEnv where
+  BuiltEnv :: Foil.Distinct c => Env c -> BuiltEnv
 
 -- | Build a set of modules.
 buildModules
   :: BuildMode -> Maybe FilePath -> [Raw.Module]
   -> IO (Either String [CommandResult])
 buildModules mode cacheDir modules =
+  buildModulesWith mode cacheDir modules (\_ _ results -> pure results)
+
+-- | 'buildModules', handing the continuation the environment the build ends
+-- in — at its existential scope index — together with the registry, so a
+-- session can be started over the result ('sessionOver').
+buildModulesWith
+  :: BuildMode -> Maybe FilePath -> [Raw.Module]
+  -> (forall c. Foil.Distinct c => Registry -> Env c -> [CommandResult] -> IO r)
+  -> IO (Either String r)
+buildModulesWith mode cacheDir modules k =
   case buildOrder modules of
     Left err -> pure (Left err)
     Right ordered -> do
@@ -121,12 +191,16 @@ buildModules mode cacheDir modules =
           assemble perModule =
             let table = Map.fromListWith (flip (<>)) perModule
              in concat [Map.findWithDefault [] (moduleName m) table | m <- ordered]
-      fmap assemble <$> go registry emptyEnv Map.empty waves
+      result <- go registry emptyEnv Map.empty waves
+      case result of
+        Left err -> pure (Left err)
+        Right (perModule, BuiltEnv env) ->
+          Right <$> k registry env (assemble perModule)
   where
     go :: Foil.Distinct c
        => Registry -> Env c -> Map Raw.VarIdent ContentHash -> [[Raw.Module]]
-       -> IO (Either String [(Raw.VarIdent, [CommandResult])])
-    go _ _ _ [] = pure (Right [])
+       -> IO (Either String ([(Raw.VarIdent, [CommandResult])], BuiltEnv))
+    go _ env _ [] = pure (Right ([], BuiltEnv env))
     go registry env hashes (wave : rest) = do
       units <- produceWave registry env hashes wave
       let hashes' = foldr (\(_, a, _) -> Map.insert (artifactModule a) (artifactHash a))
@@ -136,7 +210,8 @@ buildModules mode cacheDir modules =
         Left err     -> pure (Left err)
         Right linked ->
           withCheckedModule linked $ \_ env' _ ->
-            fmap (results <>) <$> go registry env' hashes' rest
+            fmap (\(more, built) -> (results <> more, built))
+              <$> go registry env' hashes' rest
 
     foldM1 f (x : xs) = foldM f x xs
     foldM1 _ []       = error "impossible: an empty wave"

--- a/haskell/mltt/src/Language/MLTT/Build.hs
+++ b/haskell/mltt/src/Language/MLTT/Build.hs
@@ -1,0 +1,210 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-- | A builder over the module machinery: collect modules, order them by
+-- imports, and build one of three ways —
+--
+-- * 'Sequential': one module after another in topological order, each
+--   absorbed into a growing environment; the classic driver.
+-- * 'Linked': modules grouped into dependency waves; each wave's modules are
+--   checked separately against the same base and then linked as units.
+-- * 'Parallel': the same waves, with each wave's modules checked on
+--   concurrently forked threads.
+--
+-- All three produce the same results, declaration names included, because
+-- names come from the registry's stripes and elaboration is canonical; the
+-- spec pins the equality. 'Sequential' is 'Linked' with singleton waves, so
+-- one driver serves all three.
+--
+-- With a cache directory, each successfully checked module's artifact is
+-- written beside the build, and a module whose printed source and imports
+-- are unchanged is loaded instead of checked ('LoadedModule' in the
+-- results). Staleness is content-defined, so a rebuilt dependency whose
+-- declarations came out unchanged does not dirty its dependants (early
+-- cutoff). A cached module's @check@ and @compute@ commands are not re-run:
+-- the cache reconstructs environments, not output.
+module Language.MLTT.Build (
+  BuildMode (..),
+  buildModules,
+  buildSources,
+  buildMain,
+) where
+
+import           Control.Concurrent       (forkIO, newEmptyMVar, putMVar,
+                                           takeMVar)
+import           Control.Exception        (evaluate)
+import           Control.Monad            (foldM, forM, forM_, when)
+import qualified Control.Monad.Foil       as Foil
+import           Data.List                (groupBy, isPrefixOf, sortOn,
+                                           stripPrefix)
+import           Data.Map                 (Map)
+import qualified Data.Map                 as Map
+import           System.Directory         (createDirectoryIfMissing,
+                                           doesFileExist)
+import           System.Exit              (exitFailure)
+import           System.FilePath          ((</>))
+
+import           Language.MLTT.Artifact
+import           Language.MLTT.Impl
+import           Language.MLTT.Impl.Generated (parseProgram)
+import           Language.MLTT.Resolve    (prettyVarIdent)
+import qualified Language.MLTT.Syntax.Abs as Raw
+import qualified Language.MLTT.Syntax.Print as Raw
+
+-- | The executable's entry point:
+-- @mltt [--mode=sequential|linked|parallel] [--cache=DIR] [FILES…]@,
+-- reading standard input when no files are given.
+buildMain :: [String] -> IO ()
+buildMain args =
+  case parseArgs args of
+    Left err -> putStrLn err >> exitFailure
+    Right (mode, cacheDir, paths) -> do
+      sources <- case paths of
+        [] -> (\input -> [("<stdin>", input)]) <$> getContents
+        _  -> mapM (\path -> (,) path <$> readFile path) paths
+      result <- buildSources mode cacheDir sources
+      case result of
+        Left err -> putStrLn err >> exitFailure
+        Right results -> do
+          mapM_ (putStrLn . renderResult) results
+          if succeeded results then pure () else exitFailure
+
+parseArgs :: [String] -> Either String (BuildMode, Maybe FilePath, [FilePath])
+parseArgs = fmap done . foldM step (Sequential, Nothing, [])
+  where
+    done (m, c, ps) = (m, c, reverse ps)
+    step (m, c, ps) = \case
+      "--mode=sequential" -> Right (Sequential, c, ps)
+      "--mode=linked"     -> Right (Linked, c, ps)
+      "--mode=parallel"   -> Right (Parallel, c, ps)
+      arg
+        | Just dir <- stripPrefix "--cache=" arg -> Right (m, Just dir, ps)
+        | "--" `isPrefixOf` arg -> Left ("unknown option: " <> arg <> usage)
+        | otherwise -> Right (m, c, arg : ps)
+    usage = "\nusage: mltt [--mode=sequential|linked|parallel] [--cache=DIR] [FILES...]"
+
+-- | How to schedule the checking.
+data BuildMode = Sequential | Linked | Parallel
+  deriving (Eq, Show)
+
+-- | Parse several named sources and build them; see 'buildModules'.
+buildSources
+  :: BuildMode -> Maybe FilePath -> [(FilePath, String)]
+  -> IO (Either String [CommandResult])
+buildSources mode cacheDir sources =
+  case traverse parseSource sources of
+    Left err -> pure (Left err)
+    Right ms -> buildModules mode cacheDir (concat ms)
+  where
+    parseSource (path, input) = case parseProgram input of
+      Left err                    -> Left (path <> ":" <> err)
+      Right (Raw.AProgram _ms ms) -> Right ms
+
+-- | Build a set of modules.
+buildModules
+  :: BuildMode -> Maybe FilePath -> [Raw.Module]
+  -> IO (Either String [CommandResult])
+buildModules mode cacheDir modules =
+  case buildOrder modules of
+    Left err -> pure (Left err)
+    Right ordered -> do
+      forM_ cacheDir (createDirectoryIfMissing True)
+      let registry = foldl (\r m -> fst (registerModule (moduleName m) r))
+                           emptyRegistry ordered
+          waves = case mode of
+            Sequential -> [[m] | m <- ordered]
+            _          -> wavesOf ordered
+          -- Results are reported in topological order whatever the
+          -- schedule, so the three modes are comparable verbatim.
+          assemble perModule =
+            let table = Map.fromListWith (flip (<>)) perModule
+             in concat [Map.findWithDefault [] (moduleName m) table | m <- ordered]
+      fmap assemble <$> go registry emptyEnv Map.empty waves
+  where
+    go :: Foil.Distinct c
+       => Registry -> Env c -> Map Raw.VarIdent ContentHash -> [[Raw.Module]]
+       -> IO (Either String [(Raw.VarIdent, [CommandResult])])
+    go _ _ _ [] = pure (Right [])
+    go registry env hashes (wave : rest) = do
+      units <- produceWave registry env hashes wave
+      let hashes' = foldr (\(_, a, _) -> Map.insert (artifactModule a) (artifactHash a))
+                          hashes units
+          results = [(artifactModule a, rs) | (_, a, rs) <- units]
+      case foldM1 linkChecked [cm | (cm, _, _) <- units] of
+        Left err     -> pure (Left err)
+        Right linked ->
+          withCheckedModule linked $ \_ env' _ ->
+            fmap (results <>) <$> go registry env' hashes' rest
+
+    foldM1 f (x : xs) = foldM f x xs
+    foldM1 _ []       = error "impossible: an empty wave"
+
+    -- Check (or load) each module of a wave against the same base
+    -- environment; under 'Parallel', each on its own thread.
+    produceWave
+      :: Foil.Distinct c
+      => Registry -> Env c -> Map Raw.VarIdent ContentHash -> [Raw.Module]
+      -> IO [(CheckedModule c, ModuleArtifact, [CommandResult])]
+    produceWave registry env hashes wave
+      | mode == Parallel = do
+          vars <- forM wave $ \m -> do
+            var <- newEmptyMVar
+            _ <- forkIO $ do
+              unit@(_, _, rs) <- produce registry env hashes m
+              _ <- evaluate (length (show rs))   -- do the work on this thread
+              putMVar var unit
+            pure var
+          mapM takeMVar vars
+      | otherwise = mapM (produce registry env hashes) wave
+
+    produce
+      :: Foil.Distinct c
+      => Registry -> Env c -> Map Raw.VarIdent ContentHash -> Raw.Module
+      -> IO (CheckedModule c, ModuleArtifact, [CommandResult])
+    produce registry env hashes m = do
+      let name = moduleName m
+          idx = Map.findWithDefault (error "impossible: unregistered module")
+                                    name registry
+          range = stripeRange idx
+          source = contentHash (Raw.printTree m)
+          importHashes =
+            [ (x, h)
+            | Raw.AnImport _ x <- moduleImports m
+            , Just h <- [Map.lookup x hashes] ]
+          path dir = dir </> prettyVarIdent name <> ".mltta"
+      cached <- case cacheDir of
+        Nothing  -> pure Nothing
+        Just dir -> do
+          exists <- doesFileExist (path dir)
+          if exists
+            then either (const Nothing) Just . readArtifact <$> readFile (path dir)
+            else pure Nothing
+      case cached of
+        Just a
+          | artifactSource a == source
+          , Right cm <- loadArtifact hashes range env a
+          -> pure (cm, a, [LoadedModule (prettyVarIdent name)])
+        _ -> do
+          let cm = checkModule range env m
+              a  = makeArtifact name idx source importHashes cm
+              rs = resultsOf cm
+          forM_ cacheDir $ \dir ->
+            when (succeeded rs) $
+              writeFile (path dir) (renderArtifact a)
+          pure (cm, a, rs)
+
+-- | Group modules, already in topological order, into dependency waves: a
+-- module's wave is one past the deepest wave among its imports, so the
+-- members of a wave are mutually independent.
+wavesOf :: [Raw.Module] -> [[Raw.Module]]
+wavesOf ordered = map (map snd) (groupBy (\a b -> fst a == fst b) (sortOn fst levelled))
+  where
+    levelled = [(levelOf m, m) | m <- ordered]
+    levels :: Map Raw.VarIdent Int
+    levels = foldl step Map.empty ordered
+    step acc m = Map.insert (moduleName m) (computeLevel acc m) acc
+    computeLevel acc m = 1 + maximum
+      (0 : [ Map.findWithDefault 0 x acc | Raw.AnImport _ x <- moduleImports m ])
+    levelOf m = Map.findWithDefault 0 (moduleName m) levels

--- a/haskell/mltt/src/Language/MLTT/Impl.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE DeriveFoldable      #-}
 {-# LANGUAGE DeriveFunctor       #-}
+{-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE DeriveTraversable   #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE LambdaCase          #-}
@@ -41,6 +42,7 @@
 -- narrowing belongs above the library rather than inside it.
 module Language.MLTT.Impl where
 
+import           Control.DeepSeq              (NFData)
 import           Control.Monad                (foldM)
 import qualified Control.Monad.Foil           as Foil
 import qualified Control.Monad.Foil.Blocks    as Blocks
@@ -52,6 +54,7 @@ import           Data.Map                     (Map)
 import           Data.Maybe                   (listToMaybe)
 import qualified Data.Map                     as Map
 import qualified Data.Set                     as Set
+import           GHC.Generics                 (Generic)
 import           Language.MLTT.Eval
 import           Language.MLTT.FreeFoilConfig (intToVarIdent)
 import           Language.MLTT.Impl.Generated
@@ -152,7 +155,11 @@ data CommandResult
   | Checked String String     -- ^ @check@ succeeded, for a term and its type.
   | Computed String           -- ^ @compute@ succeeded, with the normal form.
   | Failed String             -- ^ The declaration was rejected.
-  deriving (Eq, Show)
+  deriving (Eq, Generic, Show)
+
+-- | Forcing a result forces the checking that produced it; the parallel
+-- builder relies on this to keep each module's work on its own thread.
+instance NFData CommandResult
 
 -- | Did everything succeed?
 succeeded :: [CommandResult] -> Bool

--- a/haskell/mltt/src/Language/MLTT/Impl.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl.hs
@@ -59,7 +59,6 @@ import           Language.MLTT.Resolve
 import qualified Language.MLTT.Syntax.Abs     as Raw
 import           Language.MLTT.Telescope
 import           Language.MLTT.Typecheck
-import           System.Exit                  (exitFailure)
 
 -- $setup
 -- >>> :set -XOverloadedStrings
@@ -145,6 +144,9 @@ display env = showTermWith intToVarIdent (envDisplay env)
 -- | What interpreting one declaration produced.
 data CommandResult
   = EnteredModule String      -- ^ A module was reached in build order.
+  | LoadedModule String       -- ^ A module was loaded from its cached
+                              -- artifact; its @check@ and @compute@ commands
+                              -- are not re-run.
   | Defined String [String]   -- ^ @def@ succeeded, for the fully qualified name
                               -- and the module parameters it was discharged over.
   | Checked String String     -- ^ @check@ succeeded, for a term and its type.
@@ -162,6 +164,7 @@ succeeded = all $ \case
 renderResult :: CommandResult -> String
 renderResult = \case
   EnteredModule name -> "module " <> name
+  LoadedModule name  -> "module " <> name <> " (cached)"
   Defined name []    -> "  ✓ defined " <> name
   Defined name used  -> "  ✓ defined " <> name
                           <> " over (" <> intercalate ", " used <> ")"
@@ -330,6 +333,10 @@ withCheckedModule
   -> r
 withCheckedModule (CheckedModule ext env results) cont = cont ext env results
 
+-- | The results a checked module reported.
+resultsOf :: CheckedModule c -> [CommandResult]
+resultsOf cm = withCheckedModule cm (\_ _ results -> results)
+
 -- | Check one module against an environment of already checked modules.
 --
 -- Nothing here depends on any sibling: the module sees only what it imports,
@@ -404,27 +411,41 @@ linkModules
   -> CheckedModule c    -- ^ The second unit.
   -> (forall k. Foil.Distinct k => Env k -> r)
   -> Either String r
-linkModules (CheckedModule extA envA _) (CheckedModule extB envB _) cont =
+linkModules a b cont = do
+  linked <- linkChecked a b
+  withCheckedModule linked (\_ env _ -> Right (cont env))
+
+-- | Link two units into one, keeping the evidence, so the result links
+-- further: a whole build folds through this, wave by wave.
+linkChecked :: CheckedModule c -> CheckedModule c -> Either String (CheckedModule c)
+linkChecked (CheckedModule extA envA rsA) (CheckedModule extB envB rsB) =
   case Blocks.withDisjointUnion extA extB (ctxScope (envCtx envA)) (ctxScope (envCtx envB))
-         (\scope union ->
-            cont Env
-              { envCtx      = Ctx scope
-                  (Blocks.unionNameMaps union
-                    (sunkTo scope (ctxTypes (envCtx envA)))
-                    (sunkTo scope (ctxTypes (envCtx envB))))
-                  (Blocks.unionNameMaps union
-                    (sunkTo scope (ctxDefs (envCtx envA)))
-                    (sunkTo scope (ctxDefs (envCtx envB))))
-              , envDeclared = Map.empty
-              , envExports  = Map.empty
-              , envModules  = Map.union
-                  (getCompose (sunkTo scope (Compose (envModules envA))))
-                  (getCompose (sunkTo scope (Compose (envModules envB))))
-              , envDisplay  = Blocks.unionNameMaps union (envDisplay envA) (envDisplay envB)
-              , envClosedOver = Map.empty
-              }) of
+         (\scope union extK ->
+            CheckedModule extK (mergeEnvs union scope envA envB) (rsA <> rsB)) of
     Nothing -> Left "linking: reserved name ranges overlap"
     Just r  -> Right r
+
+-- | Merge the environments of two linked units; see 'linkModules' for why
+-- nothing but the union is needed.
+mergeEnvs
+  :: (Foil.Ext n k, Foil.Ext m k, Foil.Distinct k)
+  => Blocks.ScopeUnion n m k -> Foil.Scope k -> Env n -> Env m -> Env k
+mergeEnvs union scope envA envB = Env
+  { envCtx      = Ctx scope
+      (Blocks.unionNameMaps union
+        (sunkTo scope (ctxTypes (envCtx envA)))
+        (sunkTo scope (ctxTypes (envCtx envB))))
+      (Blocks.unionNameMaps union
+        (sunkTo scope (ctxDefs (envCtx envA)))
+        (sunkTo scope (ctxDefs (envCtx envB))))
+  , envDeclared = Map.empty
+  , envExports  = Map.empty
+  , envModules  = Map.union
+      (getCompose (sunkTo scope (Compose (envModules envA))))
+      (getCompose (sunkTo scope (Compose (envModules envB))))
+  , envDisplay  = Blocks.unionNameMaps union (envDisplay envA) (envDisplay envB)
+  , envClosedOver = Map.empty
+  }
 
 -- | 'Foil.sinkContainer', with the target index determined by a scope the
 -- caller already holds, so that the wanted constraints match the givens of a
@@ -695,17 +716,3 @@ interpretSources sources = interpretModules . concat <$> traverse parseSource so
       Left err                    -> Left (path <> ":" <> err)
       Right (Raw.AProgram _ms ms) -> Right ms
 
--- | Read modules from the given files, or from standard input if none are
--- given, and interpret them.
-defaultMain :: [FilePath] -> IO ()
-defaultMain paths = do
-  sources <- case paths of
-    [] -> (\input -> [("<stdin>", input)]) <$> getContents
-    _  -> mapM (\path -> (,) path <$> readFile path) paths
-  case interpretSources sources of
-    Left err -> do
-      putStrLn err
-      exitFailure
-    Right results -> do
-      mapM_ (putStrLn . renderResult) results
-      if succeeded results then return () else exitFailure

--- a/haskell/mltt/src/Language/MLTT/Impl.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl.hs
@@ -644,6 +644,31 @@ withDecls me params path (decl : decls) cont = case decl of
                               cont me''
                                 (Defined (prettyVarIdent full) (map prettyVarIdent over') : rest)
 
+-- * An interactive session
+
+-- | A read–eval–print session: a module that never ends. The session holds
+-- a 'ModuleEnv' at an existential scope index, so each step picks up exactly
+-- where the previous one stopped, allocating from one interactive stripe.
+data Repl c where
+  Repl :: Foil.DExt c n => ModuleEnv c n -> Repl c
+
+-- | Start a session over an environment of already checked (or loaded)
+-- modules, allocating in the given stripe.
+beginRepl :: Foil.Distinct c => Foil.NameRange -> Env c -> Repl c
+beginRepl range env = Repl (ModuleEnv (Blocks.beginBlock range) env)
+
+-- | Feed one input — any run of declarations, including @check@ and
+-- @compute@ — to the session.
+--
+-- A redefinition allocates a new name and rebinds the spelling, GHCi-style:
+-- a term that already refers to the old binding keeps it, since withholding
+-- a spelling touches no term.
+replStep :: String -> Repl c -> (Repl c, [CommandResult])
+replStep input (Repl me) = case parseDecls input of
+  Left err -> (Repl me, [Failed ("parse error: " <> err)])
+  Right decls ->
+    withDecls me [] [] decls $ \me' results -> (Repl me', results)
+
 -- | Parse and interpret one source.
 --
 -- >>> let report = mapM_ (putStrLn . renderResult) . either error id . interpret

--- a/haskell/mltt/src/Language/MLTT/Impl/Generated.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl/Generated.hs
@@ -98,6 +98,11 @@ unsafeParse parse input =
 parseProgram :: String -> Either String Raw.Program
 parseProgram input = Raw.pProgram (Raw.resolveLayout True (Raw.tokens input))
 
+-- | Parse a run of declarations, laid out as a module body is: what one
+-- interactive input holds.
+parseDecls :: String -> Either String [Raw.Decl]
+parseDecls input = Raw.pListDecl (Raw.resolveLayout True (Raw.tokens input))
+
 -- |
 -- >>> "λ x ⇒ λ y ⇒ x" :: Term' Raw.BNFC'Position Foil.VoidS
 -- λ x0 ⇒ λ x1 ⇒ x0

--- a/haskell/mltt/test/Language/MLTT/ArtifactSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ArtifactSpec.hs
@@ -17,6 +17,7 @@ import           Language.MLTT.Artifact
 import           Language.MLTT.Impl
 import           Language.MLTT.Impl.Generated (parseProgram)
 import qualified Language.MLTT.Syntax.Abs     as Raw
+import qualified Language.MLTT.Syntax.Print   as Raw
 
 srcP, srcQ, srcR, srcS, srcT, srcU :: String
 srcP = unlines ["module P", "def base : 𝟙 := tt"]
@@ -59,7 +60,8 @@ artifactsOf = go (0 :: Int) Map.empty emptyEnv
             [ (x, artifactHash (acc Map.! x))
             | Raw.AnImport _ x <- moduleImports m ]
           cm = checkModule (stripeRange (StripeIndex i)) env m
-          a  = makeArtifact (moduleName m) (StripeIndex i) importHashes cm
+          a  = makeArtifact (moduleName m) (StripeIndex i)
+                 (contentHash (Raw.printTree m)) importHashes cm
        in withCheckedModule cm $ \_ env' results ->
             if succeeded results
               then go (i + 1) (Map.insert (artifactModule a) a acc) env' ms
@@ -79,8 +81,6 @@ declaredIds :: CheckedModule c -> [(Raw.VarIdent, Int)]
 declaredIds cm = withCheckedModule cm $ \_ env _ ->
   Map.toList (fmap Foil.nameId (envDeclared env))
 
-resultsOf :: CheckedModule c -> [CommandResult]
-resultsOf cm = withCheckedModule cm (\_ _ rs -> rs)
 
 spec :: Spec
 spec = do
@@ -137,6 +137,7 @@ spec = do
       -- elsewhere in the module graph.
       withCheckedModule (checkModule (stripeRange (StripeIndex 0)) emptyEnv mP) $ \_ envP _ ->
         makeArtifact (moduleName mS) (StripeIndex 3)
+            (contentHash (Raw.printTree mS))
             [(moduleName mP, artifactHash (art "P"))]
             (checkModule (stripeRange (StripeIndex 3)) envP mS)
           `shouldBe` art "S"
@@ -147,6 +148,7 @@ spec = do
             withCheckedModule cmP $ \_ envP _ -> do
               cmS <- loadArtifact (hashesOf ["P"]) (stripeRange (StripeIndex 3)) envP (art "S")
               Right (makeArtifact (moduleName mS) (StripeIndex 3)
+                       (contentHash (Raw.printTree mS))
                        [(moduleName mP, artifactHash (art "P"))] cmS)
        in roundTrip `shouldBe` Right (art "S")
 

--- a/haskell/mltt/test/Language/MLTT/BuildSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/BuildSpec.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | The builder: three scheduling modes over one driver, and the on-disk
+-- cache with content-defined staleness.
+module Language.MLTT.BuildSpec (spec) where
+
+import           System.Directory             (getTemporaryDirectory,
+                                               removePathForcibly)
+import           System.FilePath              ((</>))
+import           Test.Hspec
+
+import           Language.MLTT.Build
+import           Language.MLTT.Impl
+import           Language.MLTT.Impl.Generated (parseProgram)
+import qualified Language.MLTT.Syntax.Abs     as Raw
+
+srcP, srcQ, srcQ', srcR, srcS, srcT, srcU :: String
+srcP = unlines ["module P", "def base : 𝟙 := tt"]
+srcQ = unlines ["module Q", "import P", "def q : 𝟙 := base"]
+srcQ' = srcQ <> unlines ["def q2 : 𝟙 := tt"]
+srcR = unlines ["module R", "import Q", "def r : 𝟙 := q"]
+srcS = unlines
+  [ "module S (A : 𝕌) (a : A)"
+  , "import P"
+  , "def s : A → A := λ u ⇒ a"
+  , "def sbase : 𝟙 := base"
+  ]
+srcT = unlines ["module T", "import S", "def t : 𝟙 → 𝟙 := s 𝟙 sbase"]
+srcU = unlines ["module U", "import R", "import T", "compute t r"]
+
+oneModule :: String -> Raw.Module
+oneModule src = case parseProgram src of
+  Right (Raw.AProgram _ [m]) -> m
+  Right _                    -> error "expected exactly one module"
+  Left err                   -> error err
+
+ms :: [Raw.Module]
+ms = map oneModule [srcP, srcQ, srcR, srcS, srcT, srcU]
+
+loadedNames :: [CommandResult] -> [String]
+loadedNames results = [name | LoadedModule name <- results]
+
+checkedNames :: [CommandResult] -> [String]
+checkedNames results = [name | EnteredModule name <- results]
+
+spec :: Spec
+spec = do
+  describe "three ways to build" $
+    it "sequential, linked and parallel agree, and match the interpreter" $ do
+      seqR <- buildModules Sequential Nothing ms
+      lnkR <- buildModules Linked Nothing ms
+      parR <- buildModules Parallel Nothing ms
+      seqR `shouldBe` Right (interpretModules ms)
+      lnkR `shouldBe` seqR
+      parR `shouldBe` seqR
+
+  describe "the cache" $
+    it "loads the unchanged, rebuilds the stale, and cuts off early" $ do
+      dir <- (</> "mltt-build-spec-cache") <$> getTemporaryDirectory
+      removePathForcibly dir
+      r1 <- buildModules Linked (Just dir) ms
+      fmap loadedNames r1 `shouldBe` Right []
+      -- A rebuild of the same sources loads everything; note that a cached
+      -- module's compute commands are not re-run.
+      r2 <- buildModules Linked (Just dir) ms
+      fmap loadedNames r2 `shouldBe` Right ["P", "Q", "R", "S", "T", "U"]
+      -- Adding a declaration to Q dirties Q, and R through its recorded
+      -- import hash; but R's own declarations come out unchanged, so its
+      -- content hash is the same and U is loaded: early cutoff.
+      let ms' = [ if moduleName m == moduleName (oneModule srcQ)
+                    then oneModule srcQ' else m
+                | m <- ms ]
+      r3 <- buildModules Linked (Just dir) ms'
+      fmap checkedNames r3 `shouldBe` Right ["Q", "R"]
+      fmap loadedNames r3 `shouldBe` Right ["P", "S", "T", "U"]

--- a/haskell/mltt/test/Language/MLTT/BuildSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/BuildSpec.hs
@@ -73,3 +73,12 @@ spec = do
       r3 <- buildModules Linked (Just dir) ms'
       fmap checkedNames r3 `shouldBe` Right ["Q", "R"]
       fmap loadedNames r3 `shouldBe` Right ["P", "S", "T", "U"]
+
+  describe "a session over a build" $
+    it "sees every built module's exports and continues from there" $ do
+      r <- buildModulesWith Linked Nothing ms $ \registry env results -> do
+        let s0 = sessionOver registry env
+            (s1, r1) = replStep "def mine : 𝟙 := t r" s0
+            (_,  r2) = replStep "compute mine" s1
+        pure (succeeded results, r1, r2)
+      r `shouldBe` Right (True, [Defined "mine" []], [Computed "tt"])

--- a/haskell/mltt/test/Language/MLTT/LinkSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/LinkSpec.hs
@@ -75,10 +75,6 @@ registry = Map.fromList
   [ (moduleName mI, StripeIndex 0), (moduleName mA, StripeIndex 1)
   , (moduleName mB, StripeIndex 2) ]
 
--- | The results a checked module reported.
-resultsOf :: CheckedModule c -> [CommandResult]
-resultsOf cm = withCheckedModule cm (\_ _ rs -> rs)
-
 -- | The raw name of everything a checked module can refer to, by spelling.
 declaredIds :: CheckedModule c -> [(Raw.VarIdent, Int)]
 declaredIds cm = withCheckedModule cm $ \_ env _ ->

--- a/haskell/mltt/test/Language/MLTT/LinkSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/LinkSpec.hs
@@ -9,6 +9,9 @@
 -- with the shared import identified rather than renamed apart.
 module Language.MLTT.LinkSpec (spec) where
 
+import           Control.Concurrent           (forkIO, newEmptyMVar, putMVar,
+                                               takeMVar)
+import           Control.Exception            (evaluate)
 import qualified Control.Monad.Foil           as Foil
 import qualified Control.Monad.Foil.Blocks    as Blocks
 import           Data.Either                  (isLeft)
@@ -136,6 +139,33 @@ spec = do
             linked = linkModules chainQR chainST (\envU -> goModules chainRegistry envU [mU])
          in fmap (\resultsU -> resultsP <> resultsOf chainQR <> resultsOf chainST <> resultsU) linked
               `shouldBe` Right (interpretModules [mP, mQ, mR, mS, mT, mU])
+
+  describe "checking on separate threads" $
+    it "checks the two chains concurrently and matches the sequential run" $
+      withCheckedModule (checkModule (stripeRange (StripeIndex 0)) emptyEnv mP) $ \_ envP resultsP -> do
+        vQR <- newEmptyMVar
+        vST <- newEmptyMVar
+        _ <- forkIO $ do
+          let chain = checkModuleAfter (stripeRange (StripeIndex 3))
+                        (checkModule (stripeRange (StripeIndex 1)) envP mQ) mR
+          _ <- evaluate (length (show (resultsOf chain)))  -- do the work here
+          putMVar vQR chain
+        _ <- forkIO $ do
+          let chain = checkModuleAfter (stripeRange (StripeIndex 4))
+                        (checkModule (stripeRange (StripeIndex 2)) envP mS) mT
+          _ <- evaluate (length (show (resultsOf chain)))
+          putMVar vST chain
+        chainQR <- takeMVar vQR
+        chainST <- takeMVar vST
+        let chainRegistry = Map.fromList
+              [ (moduleName mP, StripeIndex 0), (moduleName mQ, StripeIndex 1)
+              , (moduleName mS, StripeIndex 2), (moduleName mR, StripeIndex 3)
+              , (moduleName mT, StripeIndex 4) ]
+        case linkModules chainQR chainST (\envU -> goModules chainRegistry envU [mU]) of
+          Left err -> expectationFailure err
+          Right resultsU ->
+            (resultsP <> resultsOf chainQR <> resultsOf chainST <> resultsU)
+              `shouldBe` interpretModules [mP, mQ, mR, mS, mT, mU]
 
   describe "linking failures" $
     it "refuses two modules whose stripes overlap" $

--- a/haskell/mltt/test/Language/MLTT/ReplSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ReplSpec.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | The interactive session: one stripe, allocated incrementally, with the
+-- environment carried from step to step.
+module Language.MLTT.ReplSpec (spec) where
+
+import           Test.Hspec
+
+import           Language.MLTT.Impl
+
+spec :: Spec
+spec = describe "an interactive session" $ do
+  it "carries the environment from step to step, in one stripe" $ do
+    let s0 = beginRepl (stripeRange (StripeIndex 0)) emptyEnv
+        (s1, r1) = replStep "def one : 𝟙 := tt" s0
+        (s2, r2) = replStep "compute one" s1
+        (s3, r3) = replStep "def two : 𝟙 := one" s2
+        (s4, r4) = replStep "def one : 𝟙 → 𝟙 := λ x ⇒ x" s3   -- a redefinition
+        (s5, r5) = replStep "compute two" s4
+        (_,  r6) = replStep "compute one tt" s5
+    r1 `shouldBe` [Defined "one" []]
+    r2 `shouldBe` [Computed "tt"]
+    r3 `shouldBe` [Defined "two" []]
+    r4 `shouldBe` [Defined "one" []]
+    -- The old binding survives the rebinding of its spelling: `two` still
+    -- reduces through it, while the spelling now means the new definition.
+    r5 `shouldBe` [Computed "tt"]
+    r6 `shouldBe` [Computed "tt"]
+
+  it "accepts several declarations in one input" $ do
+    let s0 = beginRepl (stripeRange (StripeIndex 0)) emptyEnv
+        (_, rs) = replStep "def a : 𝟙 := tt\ndef b : 𝟙 := a\ncompute b" s0
+    rs `shouldBe` [Defined "a" [], Defined "b" [], Computed "tt"]
+
+  it "reports an input that does not parse, and the session survives" $ do
+    let s0 = beginRepl (stripeRange (StripeIndex 0)) emptyEnv
+        (s1, r1) = replStep "def broken :=" s0
+        (_,  r2) = replStep "def a : 𝟙 := tt" s1
+    map (take 11) [msg | Failed msg <- r1] `shouldBe` ["parse error"]
+    r2 `shouldBe` [Defined "a" []]


### PR DESCRIPTION
Four additions that turn the module machinery into things a user can drive:

1. A `Repl`: a module that never ends. `replStep` feeds one input through the same `withDecls` the driver uses, allocating from one interactive stripe; redefinition rebinds the spelling GHCi-style (terms referring to the old binding keep it), and a parse error leaves the session usable. `mltt --repl FILES…` drives it from the shell: the files are built first, the session starts with every built module's exports in scope, and it allocates from the first stripe the build left free (`buildModulesWith` hands the final environment to a continuation for this).
2. `buildModules`: collect modules, order them by imports, build one of three ways — `Sequential`, `Linked` (dependency waves, checked separately and linked as units), `Parallel` (the same waves, one thread per module). One driver serves all three, results come out in topological order whatever the schedule, and the spec pins all three against the interpreter, checking the chains on actually forked threads.
3. An on-disk cache (`--mode=` and `--cache=` on the executable). Staleness is content-defined — the artifact now records the printed source's hash — so a rebuilt dependency whose declarations come out unchanged does not dirty its dependants: adding a declaration to Q rebuilds Q and R, while P, S, T and U load from cache. A cached module's `compute` commands are not re-run; the cache reconstructs environments, not output.
4. One library change underneath: `withDisjointUnion` also hands out the union's own `ExtWithin` (the union of the two range sets, exact), so a linked unit is itself linkable and a build folds through the one function — and the `Ext c k` given, which a caller cannot derive, since chaining `Ext c n` with `Ext n k` is refused whenever both sides' paths are in scope.

```
$ mltt --mode=parallel --cache=.mltt-cache examples/modules.mltt
module Prelude
  ✓ defined Nat.twice
  …
$ mltt --mode=parallel --cache=.mltt-cache examples/modules.mltt
module Prelude (cached)
module Client (cached)
```