### PR TITLE
CI: set test output to UTF-8 in-process (fix Windows)

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -29,9 +29,9 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set codepage on Windows
-        if: ${{ runner.os == 'Windows' }}
-        run: chcp 65001
+      # No code-page juggling for Windows here: the test suites set their
+      # output handles to UTF-8 themselves (test/SpecHook.hs in each package),
+      # which also covers redirected output that `chcp` never affected.
 
       - name: Restore Syntax files
         id: restore-syntax-files

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ haskell/mltt/src/Language/MLTT/Syntax/Par.y
 # (no trailing slash, so the entry matches the symlink as well as a directory)
 /notes
 
+# An on-disk cache written by `mltt --cache=.mltt-cache`
+.mltt-cache/
+
 scala/free-foil/src/main/scala/.scala-build/
 
 dist

--- a/haskell/free-foil/free-foil.cabal
+++ b/haskell/free-foil/free-foil.cabal
@@ -105,6 +105,7 @@ test-suite spec
       Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Config
       Control.Monad.Free.Foil.TH.MkFreeFoilSpec.Syntax
       Data.ZipMatchK.THSpec
+      SpecHook
       Paths_free_foil
   hs-source-dirs:
       test

--- a/haskell/free-foil/test/SpecHook.hs
+++ b/haskell/free-foil/test/SpecHook.hs
@@ -1,0 +1,15 @@
+-- | Set Unicode-capable output before any test output is printed; hspec
+-- discovers this module and wraps every spec in 'hook'.
+--
+-- On Windows, GHC encodes standard output with the local code page, which
+-- cannot represent characters such as Π or 𝟙 that appear in the test
+-- descriptions, so the reporter dies with @commitBuffer: invalid argument@.
+-- Setting the handles to UTF-8 in-process also covers redirected output,
+-- which a @chcp@ call in the workflow never reached.
+module SpecHook (hook) where
+
+import           System.IO  (hSetEncoding, stderr, stdout, utf8)
+import           Test.Hspec (Spec, runIO)
+
+hook :: Spec -> Spec
+hook spec = runIO (hSetEncoding stdout utf8 >> hSetEncoding stderr utf8) >> spec

--- a/haskell/lambda-pi/lambda-pi.cabal
+++ b/haskell/lambda-pi/lambda-pi.cabal
@@ -123,6 +123,7 @@ test-suite spec
   other-modules:
       Language.LambdaPi.Impl.FoilSpec
       Language.LambdaPi.Impl.FreeFoilSpec
+      SpecHook
       Paths_lambda_pi
   hs-source-dirs:
       test

--- a/haskell/lambda-pi/test/SpecHook.hs
+++ b/haskell/lambda-pi/test/SpecHook.hs
@@ -1,0 +1,15 @@
+-- | Set Unicode-capable output before any test output is printed; hspec
+-- discovers this module and wraps every spec in 'hook'.
+--
+-- On Windows, GHC encodes standard output with the local code page, which
+-- cannot represent characters such as Π or 𝟙 that appear in the test
+-- descriptions, so the reporter dies with @commitBuffer: invalid argument@.
+-- Setting the handles to UTF-8 in-process also covers redirected output,
+-- which a @chcp@ call in the workflow never reached.
+module SpecHook (hook) where
+
+import           System.IO  (hSetEncoding, stderr, stdout, utf8)
+import           Test.Hspec (Spec, runIO)
+
+hook :: Spec -> Spec
+hook spec = runIO (hSetEncoding stdout utf8 >> hSetEncoding stderr utf8) >> spec

--- a/haskell/mltt/mltt.cabal
+++ b/haskell/mltt/mltt.cabal
@@ -139,6 +139,7 @@ test-suite spec
       Language.MLTT.ModulesSpec
       Language.MLTT.ParametersSpec
       Language.MLTT.ReplSpec
+      SpecHook
       Paths_mltt
   hs-source-dirs:
       test

--- a/haskell/mltt/test/SpecHook.hs
+++ b/haskell/mltt/test/SpecHook.hs
@@ -1,0 +1,15 @@
+-- | Set Unicode-capable output before any test output is printed; hspec
+-- discovers this module and wraps every spec in 'hook'.
+--
+-- On Windows, GHC encodes standard output with the local code page, which
+-- cannot represent characters such as Π or 𝟙 that appear in the test
+-- descriptions, so the reporter dies with @commitBuffer: invalid argument@.
+-- Setting the handles to UTF-8 in-process also covers redirected output,
+-- which a @chcp@ call in the workflow never reached.
+module SpecHook (hook) where
+
+import           System.IO  (hSetEncoding, stderr, stdout, utf8)
+import           Test.Hspec (Spec, runIO)
+
+hook :: Spec -> Spec
+hook spec = runIO (hSetEncoding stdout utf8 >> hSetEncoding stderr utf8) >> spec

--- a/haskell/soas/soas.cabal
+++ b/haskell/soas/soas.cabal
@@ -119,6 +119,7 @@ test-suite spec
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      SpecHook
       Paths_soas
   hs-source-dirs:
       test

--- a/haskell/soas/test/SpecHook.hs
+++ b/haskell/soas/test/SpecHook.hs
@@ -1,0 +1,15 @@
+-- | Set Unicode-capable output before any test output is printed; hspec
+-- discovers this module and wraps every spec in 'hook'.
+--
+-- On Windows, GHC encodes standard output with the local code page, which
+-- cannot represent characters such as Π or 𝟙 that appear in the test
+-- descriptions, so the reporter dies with @commitBuffer: invalid argument@.
+-- Setting the handles to UTF-8 in-process also covers redirected output,
+-- which a @chcp@ call in the workflow never reached.
+module SpecHook (hook) where
+
+import           System.IO  (hSetEncoding, stderr, stdout, utf8)
+import           Test.Hspec (Spec, runIO)
+
+hook :: Spec -> Spec
+hook spec = runIO (hSetEncoding stdout utf8 >> hSetEncoding stderr utf8) >> spec


### PR DESCRIPTION
Every push to main has failed for weeks: on Windows, GHC encodes standard output with the local code page, which cannot represent the Π and 𝟙 in the mltt test descriptions, so the hspec reporter dies with `commitBuffer: invalid argument` — and the docs job, gated on the tests, never runs. The α in lambda-pi's descriptions survived only because the OEM code page happens to contain it.

Each package now has a `test/SpecHook.hs`, picked up by hspec-discover, that sets stdout and stderr to UTF-8 before any output. The `chcp` step in the workflow goes away: it ran in its own console, and redirected output never consulted the console code page in the first place.