### PR TITLE
MLTT: name the vocabulary instead of String, Int and Bool

### DIFF
--- a/haskell/free-foil/ChangeLog.md
+++ b/haskell/free-foil/ChangeLog.md
@@ -58,6 +58,8 @@ New:
 
 - `withDisjointUnion` hands its continuation two more things. The union's own `ExtWithin`: the linked scope extends the common base only within the union of the two range sets, which is exact, so a linked unit is itself linkable and a whole build folds through the one function. And the `Ext c k` constraint, which a caller cannot derive on the spot: obtaining it from `Ext c n` and `Ext n k` is exactly the chain the solver refuses when both sides' paths are in scope, since either given offers a candidate and it commits to neither.
 
+- `Control.Monad.Foil` exports the `Id` and `RawName` synonyms, so a client can type its raw-name arithmetic (stripe bases, interned identifiers) the way `nameId`'s result already means.
+
 Changed:
 
 - `convertToAST` and `convertToScopedAST` are deprecated in favour of `unsafeConvertToAST` and `unsafeConvertToScopedAST`, which are the same functions under names that admit they call `error`. The old names still work.

--- a/haskell/free-foil/src/Control/Monad/Foil.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil.hs
@@ -26,6 +26,8 @@ module Control.Monad.Foil (
   nameOf,
   namesOfPattern,
   nameId,
+  Id,
+  RawName,
   withFreshBinder,
   withFresh,
   NameRange(..),

--- a/haskell/mltt/src/Language/MLTT/Artifact.hs
+++ b/haskell/mltt/src/Language/MLTT/Artifact.hs
@@ -42,6 +42,7 @@ module Language.MLTT.Artifact (
   ArtifactDecl (..),
   ContentHash (..),
   StoredTerm (..),
+  ArtifactError,
   makeArtifact,
   loadArtifact,
   loadArtifactAfter,
@@ -100,12 +101,16 @@ newtype StoredTerm = StoredTerm { storedText :: String }
 newtype ContentHash = ContentHash Integer
   deriving (Eq, Show, Read)
 
+-- | What reading or loading an artifact can report: malformed wire text, a
+-- stale import hash, or a stored term that no longer re-interns.
+type ArtifactError = String
+
 -- | Render an artifact for writing. 'readArtifact' is its inverse.
 renderArtifact :: ModuleArtifact -> String
 renderArtifact = show
 
 -- | Read an artifact back; reports rather than crashes on malformed input.
-readArtifact :: String -> Either String ModuleArtifact
+readArtifact :: String -> Either ArtifactError ModuleArtifact
 readArtifact = readEither
 
 -- | FNV-1a over a string, 64 bits. A build-cache checksum, not a defence.
@@ -159,7 +164,7 @@ makeArtifact name stripe source imports cm = withCheckedModule cm $ \_ env _ ->
         }
 
 -- | The canonical spelling of a bound variable in an artifact.
-boundName :: Int -> Raw.VarIdent
+boundName :: Foil.RawName -> Raw.VarIdent
 boundName i = Raw.VarIdent ("l" <> show i)
 
 -- | What the content hash covers: everything semantically relevant. The
@@ -188,7 +193,7 @@ loadArtifact
   -> Foil.NameRange       -- ^ The module's stripe, from this run's registry.
   -> Env c                -- ^ Environment holding what its imports export.
   -> ModuleArtifact
-  -> Either String (CheckedModule c)
+  -> Either ArtifactError (CheckedModule c)
 loadArtifact hashes range env artifact = do
   mapM_ checkImport (artifactImports artifact)
   go (Blocks.beginBlock range) env' (artifactDecls artifact)
@@ -211,7 +216,7 @@ loadArtifact hashes range env artifact = do
       }
 
     go :: Foil.DExt c n
-       => Blocks.Block c n -> Env n -> [ArtifactDecl] -> Either String (CheckedModule c)
+       => Blocks.Block c n -> Env n -> [ArtifactDecl] -> Either ArtifactError (CheckedModule c)
     go block envN [] =
       Right (CheckedModule (Blocks.blockExt block)
                            (finishModule (artifactModule artifact) envN)
@@ -226,7 +231,7 @@ loadArtifact hashes range env artifact = do
 
     -- Parse a stored term and convert it against the environment assembled
     -- so far: this is the re-interning the wire format promises.
-    reintern :: Foil.Distinct n => Env n -> StoredTerm -> Either String (Term n)
+    reintern :: Foil.Distinct n => Env n -> StoredTerm -> Either ArtifactError (Term n)
     reintern envN (StoredTerm input) = do
       raw <- Raw.pTerm (Raw.tokens input)
       case tryToTerm'In localRegion (ctxScope (envCtx envN)) (envDeclared envN) raw of
@@ -244,7 +249,7 @@ loadArtifactAfter
   -> Foil.NameRange       -- ^ The next module's stripe, from this run's registry.
   -> CheckedModule c      -- ^ The chain so far.
   -> ModuleArtifact
-  -> Either String (CheckedModule c)
+  -> Either ArtifactError (CheckedModule c)
 loadArtifactAfter hashes range (CheckedModule ext env results) artifact = do
   cm <- loadArtifact hashes range env artifact
   case cm of

--- a/haskell/mltt/src/Language/MLTT/Build.hs
+++ b/haskell/mltt/src/Language/MLTT/Build.hs
@@ -31,6 +31,8 @@
 -- allocates from the first stripe the build left free.
 module Language.MLTT.Build (
   BuildMode (..),
+  BuildOptions (..),
+  SessionMode (..),
   buildModules,
   buildModulesWith,
   buildSources,
@@ -61,7 +63,7 @@ import           System.IO                (hFlush, isEOF, stdout)
 
 import           Language.MLTT.Artifact
 import           Language.MLTT.Impl
-import           Language.MLTT.Impl.Generated (parseProgram)
+import           Language.MLTT.Impl.Generated (SourceText (..), parseProgram)
 import           Language.MLTT.Resolve    (prettyVarIdent)
 import qualified Language.MLTT.Syntax.Abs as Raw
 import qualified Language.MLTT.Syntax.Print as Raw
@@ -79,32 +81,47 @@ buildMain :: [String] -> IO ()
 buildMain args =
   case parseArgs args of
     Left err -> putStrLn err >> exitFailure
-    Right (mode, cacheDir, interactive, paths) -> do
-      sources <- case paths of
-        [] | not interactive -> (\input -> [("<stdin>", input)]) <$> getContents
-        _  -> mapM (\path -> (,) path <$> readFile path) paths
-      result <- buildSourcesWith mode cacheDir sources $ \registry env results -> do
-        mapM_ (putStrLn . renderResult) results
-        if interactive
-          then True <$ runRepl (sessionOver registry env)
-          else pure (succeeded results)
+    Right opts -> do
+      sources <- case optFiles opts of
+        [] | optSession opts == BatchOnly ->
+          (\input -> [("<stdin>", SourceText input)]) <$> getContents
+        paths -> mapM (\path -> (,) path . SourceText <$> readFile path) paths
+      result <- buildSourcesWith (optMode opts) (optCache opts) sources $
+        \registry env results -> do
+          mapM_ (putStrLn . renderResult) results
+          case optSession opts of
+            Interactive -> True <$ runRepl (sessionOver registry env)
+            BatchOnly   -> pure (succeeded results)
       case result of
         Left err -> putStrLn err >> exitFailure
         Right ok -> unless ok exitFailure
 
-parseArgs :: [String] -> Either String (BuildMode, Maybe FilePath, Bool, [FilePath])
-parseArgs = fmap done . foldM step (Sequential, Nothing, False, [])
+-- | Whether the build is followed by an interactive session (@--repl@).
+data SessionMode = BatchOnly | Interactive
+  deriving (Eq, Show)
+
+-- | What the command line asked for.
+data BuildOptions = BuildOptions
+  { optMode    :: BuildMode
+  , optCache   :: Maybe FilePath
+  , optSession :: SessionMode
+  , optFiles   :: [FilePath]
+  }
+  deriving (Eq, Show)
+
+parseArgs :: [String] -> Either ErrorMessage BuildOptions
+parseArgs = fmap done . foldM step (BuildOptions Sequential Nothing BatchOnly [])
   where
-    done (m, c, i, ps) = (m, c, i, reverse ps)
-    step (m, c, i, ps) = \case
-      "--mode=sequential" -> Right (Sequential, c, i, ps)
-      "--mode=linked"     -> Right (Linked, c, i, ps)
-      "--mode=parallel"   -> Right (Parallel, c, i, ps)
-      "--repl"            -> Right (m, c, True, ps)
+    done opts = opts { optFiles = reverse (optFiles opts) }
+    step opts = \case
+      "--mode=sequential" -> Right opts { optMode = Sequential }
+      "--mode=linked"     -> Right opts { optMode = Linked }
+      "--mode=parallel"   -> Right opts { optMode = Parallel }
+      "--repl"            -> Right opts { optSession = Interactive }
       arg
-        | Just dir <- stripPrefix "--cache=" arg -> Right (m, Just dir, i, ps)
+        | Just dir <- stripPrefix "--cache=" arg -> Right opts { optCache = Just dir }
         | "--" `isPrefixOf` arg -> Left ("unknown option: " <> arg <> usage)
-        | otherwise -> Right (m, c, i, arg : ps)
+        | otherwise -> Right opts { optFiles = arg : optFiles opts }
     usage = "\nusage: mltt [--mode=sequential|linked|parallel] [--cache=DIR] [--repl] [FILES...]"
 
 -- | Begin a session over a build. Every built module's exports are in scope,
@@ -132,7 +149,7 @@ runRepl = loop
           if all isSpace line
             then loop s
             else do
-              let (s', results) = replStep line s
+              let (s', results) = replStep (SourceText line) s
               mapM_ (putStrLn . renderResult) results
               loop s'
 
@@ -142,17 +159,17 @@ data BuildMode = Sequential | Linked | Parallel
 
 -- | Parse several named sources and build them; see 'buildModules'.
 buildSources
-  :: BuildMode -> Maybe FilePath -> [(FilePath, String)]
-  -> IO (Either String [CommandResult])
+  :: BuildMode -> Maybe FilePath -> [(FilePath, SourceText)]
+  -> IO (Either BuildError [CommandResult])
 buildSources mode cacheDir sources =
   buildSourcesWith mode cacheDir sources (\_ _ results -> pure results)
 
 -- | 'buildSources', handing the continuation the outcome; see
 -- 'buildModulesWith'.
 buildSourcesWith
-  :: BuildMode -> Maybe FilePath -> [(FilePath, String)]
+  :: BuildMode -> Maybe FilePath -> [(FilePath, SourceText)]
   -> (forall c. Foil.Distinct c => Registry -> Env c -> [CommandResult] -> IO r)
-  -> IO (Either String r)
+  -> IO (Either BuildError r)
 buildSourcesWith mode cacheDir sources k =
   case traverse parseSource sources of
     Left err -> pure (Left err)
@@ -169,7 +186,7 @@ data BuiltEnv where
 -- | Build a set of modules.
 buildModules
   :: BuildMode -> Maybe FilePath -> [Raw.Module]
-  -> IO (Either String [CommandResult])
+  -> IO (Either BuildError [CommandResult])
 buildModules mode cacheDir modules =
   buildModulesWith mode cacheDir modules (\_ _ results -> pure results)
 
@@ -179,7 +196,7 @@ buildModules mode cacheDir modules =
 buildModulesWith
   :: BuildMode -> Maybe FilePath -> [Raw.Module]
   -> (forall c. Foil.Distinct c => Registry -> Env c -> [CommandResult] -> IO r)
-  -> IO (Either String r)
+  -> IO (Either BuildError r)
 buildModulesWith mode cacheDir modules k =
   case buildOrder modules of
     Left err -> pure (Left err)
@@ -203,7 +220,7 @@ buildModulesWith mode cacheDir modules k =
   where
     go :: Foil.Distinct c
        => Registry -> Env c -> Map Raw.VarIdent ContentHash -> [NonEmpty Raw.Module]
-       -> IO (Either String ([(Raw.VarIdent, [CommandResult])], BuiltEnv))
+       -> IO (Either BuildError ([(Raw.VarIdent, [CommandResult])], BuiltEnv))
     go _ env _ [] = pure (Right ([], BuiltEnv env))
     go registry env hashes (wave : rest) = do
       units <- produceWave registry env hashes wave
@@ -262,7 +279,7 @@ buildModulesWith mode cacheDir modules k =
         Just a
           | artifactSource a == source
           , Right cm <- loadArtifact hashes range env a
-          -> pure (cm, a, [LoadedModule (prettyVarIdent name)])
+          -> pure (cm, a, [LoadedModule (renderVarIdent name)])
         _ -> do
           let cm = checkModule range env m
               a  = makeArtifact name idx source importHashes cm

--- a/haskell/mltt/src/Language/MLTT/FreeFoilConfig.hs
+++ b/haskell/mltt/src/Language/MLTT/FreeFoilConfig.hs
@@ -8,10 +8,11 @@
 module Language.MLTT.FreeFoilConfig where
 
 import           Control.Monad.Free.Foil.TH.MkFreeFoil
+import qualified Control.Monad.Foil                    as Foil
 import qualified Language.MLTT.Syntax.Abs              as Raw
 
--- | Name a bound variable after its underlying integer identifier.
-intToVarIdent :: Int -> Raw.VarIdent
+-- | Name a bound variable after its underlying raw name.
+intToVarIdent :: Foil.RawName -> Raw.VarIdent
 intToVarIdent i = Raw.VarIdent ("x" <> show i)
 
 -- | The variable constructor, with the annotation erased.

--- a/haskell/mltt/src/Language/MLTT/Impl.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl.hs
@@ -1,12 +1,14 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE DeriveFoldable      #-}
-{-# LANGUAGE DeriveFunctor       #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE DeriveTraversable   #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveFoldable             #-}
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DeriveTraversable          #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
 -- | The MLTT interpreter: the generated syntax, the evaluator, the type checker
 -- and the resolver glued into a program that reads modules.
 --
@@ -51,6 +53,7 @@ import           Data.Functor.Identity        (Identity (..))
 import           Control.Monad.Free.Foil      (AST (Var), UnresolvedName (..))
 import           Data.List                    (foldl', intercalate)
 import           Data.Map                     (Map)
+import           Data.String                  (IsString)
 import           Data.Maybe                   (listToMaybe)
 import qualified Data.Map                     as Map
 import qualified Data.Set                     as Set
@@ -66,6 +69,7 @@ import           Language.MLTT.Typecheck
 -- $setup
 -- >>> :set -XOverloadedStrings
 -- >>> :set -XDataKinds
+-- >>> import Language.MLTT.Impl.Generated (sourceLines)
 
 -- * The elaboration environment
 
@@ -139,22 +143,46 @@ extendEnv ctx binder full visibility env = Env
 
 -- | Print a term, showing top-level definitions by name and bound variables by
 -- their index.
-display :: Foil.Distinct n => Env n -> Term n -> String
-display env = showTermWith intToVarIdent (envDisplay env)
+display :: Foil.Distinct n => Env n -> Term n -> RenderedTerm
+display env = RenderedTerm . showTermWith intToVarIdent (envDisplay env)
 
 -- * Results
 
+-- | A name as shown to the user: a fully qualified spelling, not a
+-- 'Foil.Name'. Distinct from 'RenderedTerm' so that the two cannot be mixed
+-- up in a 'CommandResult'.
+newtype RenderedName = RenderedName { renderedName :: String }
+  deriving newtype (Eq, Show, IsString, NFData)
+
+-- | A term as shown to the user, printed by 'display'. Distinct from
+-- 'StoredTerm' in "Language.MLTT.Artifact", which is printed for reading
+-- back rather than for the user.
+newtype RenderedTerm = RenderedTerm { renderedTerm :: String }
+  deriving newtype (Eq, Show, IsString, NFData)
+
+-- | The prose of a failure, whatever layer it came from: a 'ParseError', a
+-- 'TypeError', a 'LinkError' — by the time it reaches a result, it is only
+-- shown.
+type ErrorMessage = String
+
+-- | Render a fully qualified name the way results show it.
+renderVarIdent :: Raw.VarIdent -> RenderedName
+renderVarIdent = RenderedName . prettyVarIdent
+
 -- | What interpreting one declaration produced.
 data CommandResult
-  = EnteredModule String      -- ^ A module was reached in build order.
-  | LoadedModule String       -- ^ A module was loaded from its cached
-                              -- artifact; its @check@ and @compute@ commands
-                              -- are not re-run.
-  | Defined String [String]   -- ^ @def@ succeeded, for the fully qualified name
-                              -- and the module parameters it was discharged over.
-  | Checked String String     -- ^ @check@ succeeded, for a term and its type.
-  | Computed String           -- ^ @compute@ succeeded, with the normal form.
-  | Failed String             -- ^ The declaration was rejected.
+  = EnteredModule RenderedName  -- ^ A module was reached in build order.
+  | LoadedModule RenderedName   -- ^ A module was loaded from its cached
+                                -- artifact; its @check@ and @compute@
+                                -- commands are not re-run.
+  | Defined RenderedName [RenderedName]
+                                -- ^ @def@ succeeded, for the fully qualified
+                                -- name and the module parameters it was
+                                -- discharged over.
+  | Checked RenderedTerm RenderedTerm
+                                -- ^ @check@ succeeded, for a term and its type.
+  | Computed RenderedTerm       -- ^ @compute@ succeeded, with the normal form.
+  | Failed ErrorMessage         -- ^ The declaration was rejected.
   deriving (Eq, Generic, Show)
 
 -- | Forcing a result forces the checking that produced it; the parallel
@@ -170,22 +198,26 @@ succeeded = all $ \case
 -- | Render a result the way the executable prints it.
 renderResult :: CommandResult -> String
 renderResult = \case
-  EnteredModule name -> "module " <> name
-  LoadedModule name  -> "module " <> name <> " (cached)"
-  Defined name []    -> "  ✓ defined " <> name
-  Defined name used  -> "  ✓ defined " <> name
-                          <> " over (" <> intercalate ", " used <> ")"
-  Checked term ty    -> "  ✓ " <> term <> " : " <> ty
-  Computed term      -> "  ↦ " <> term
+  EnteredModule name -> "module " <> renderedName name
+  LoadedModule name  -> "module " <> renderedName name <> " (cached)"
+  Defined name []    -> "  ✓ defined " <> renderedName name
+  Defined name used  -> "  ✓ defined " <> renderedName name
+                          <> " over (" <> intercalate ", " (map renderedName used) <> ")"
+  Checked term ty    -> "  ✓ " <> renderedTerm term <> " : " <> renderedTerm ty
+  Computed term      -> "  ↦ " <> renderedTerm term
   Failed err         -> "  ✗ " <> err
 
 -- * Build order
+
+-- | What ordering or linking a set of modules can report: a missing or
+-- cyclic import, or overlapping reservations.
+type BuildError = String
 
 -- | Order the modules so that every module comes after the ones it imports.
 --
 -- Reports an import of a module that is not present, and an import cycle,
 -- rather than looping or crashing.
-buildOrder :: [Raw.Module] -> Either String [Raw.Module]
+buildOrder :: [Raw.Module] -> Either BuildError [Raw.Module]
 buildOrder modules
   | not (null missing) = Left ("imported module not found: " <> intercalate ", " missing)
   | otherwise = reverse <$> foldM (visit Set.empty) [] (map moduleName modules)
@@ -229,7 +261,7 @@ stripeSize :: Int
 stripeSize = 0x100000
 
 -- | Where the first stripe starts. Below it lies 'localRegion'.
-firstStripeBase :: Int
+firstStripeBase :: Foil.RawName
 firstStripeBase = stripeSize
 
 -- | The region module parameters and elaboration-time binders live in.
@@ -370,7 +402,7 @@ checkModule range env m =
                         (finishModule (moduleName m) (moduleEnv me))
                         (entered : results)
   where
-    entered = EnteredModule (prettyVarIdent (moduleName m))
+    entered = EnteredModule (renderVarIdent (moduleName m))
     -- An import contributes the exporting module's public names, under the
     -- spellings it exported them with. Nothing else crosses a module boundary.
     env' = env
@@ -417,14 +449,14 @@ linkModules
    . CheckedModule c    -- ^ The first unit.
   -> CheckedModule c    -- ^ The second unit.
   -> (forall k. Foil.Distinct k => Env k -> r)
-  -> Either String r
+  -> Either BuildError r
 linkModules a b cont = do
   linked <- linkChecked a b
   withCheckedModule linked (\_ env _ -> Right (cont env))
 
 -- | Link two units into one, keeping the evidence, so the result links
 -- further: a whole build folds through this, wave by wave.
-linkChecked :: CheckedModule c -> CheckedModule c -> Either String (CheckedModule c)
+linkChecked :: CheckedModule c -> CheckedModule c -> Either BuildError (CheckedModule c)
 linkChecked (CheckedModule extA envA rsA) (CheckedModule extB envB rsB) =
   case Blocks.withDisjointUnion extA extB (ctxScope (envCtx envA)) (ctxScope (envCtx envB))
          (\scope union extK ->
@@ -507,7 +539,7 @@ withParams env (Raw.AParam _loc name rawTy : rest) onErr cont =
     ctx = envCtx env
 
 -- | Elaborate a module's parameter types, reporting the first that fails.
-validateParams :: Foil.Distinct n => Env n -> [Raw.Param] -> Maybe String
+validateParams :: Foil.Distinct n => Env n -> [Raw.Param] -> Maybe TypeError
 validateParams env params = withParams env params Just (\_tele _envP -> Nothing)
 
 -- | Split the visible spellings into a table of names and a table of terms,
@@ -548,13 +580,13 @@ splitVisible envP visible =
 --
 -- With the computed set this cannot arise, since that set is closed. It is the
 -- answer for a caller that supplies a set of its own.
-needsParameters :: [Raw.VarIdent] -> String
+needsParameters :: [Raw.VarIdent] -> TypeError
 needsParameters names =
   "declaration needs module parameters it is not closed over: "
     <> intercalate ", " (map prettyVarIdent names)
 
 -- | Report an identifier that did not resolve, with any near spellings.
-notInScope :: UnresolvedName Raw.VarIdent -> String
+notInScope :: UnresolvedName Raw.VarIdent -> TypeError
 notInScope (UnresolvedName x inScope) =
   case suggestions x inScope of
     []    -> "not in scope: " <> prettyVarIdent x
@@ -670,7 +702,7 @@ withDecls me params path (decl : decls) cont = case decl of
                                   (envClosedOver extended) }
                          in withDecls (ModuleEnv block' env') params path decls $ \me'' rest ->
                               cont me''
-                                (Defined (prettyVarIdent full) (map prettyVarIdent over') : rest)
+                                (Defined (renderVarIdent full) (map renderVarIdent over') : rest)
 
 -- * An interactive session
 
@@ -691,7 +723,7 @@ beginRepl range env = Repl (ModuleEnv (Blocks.beginBlock range) env)
 -- A redefinition allocates a new name and rebinds the spelling, GHCi-style:
 -- a term that already refers to the old binding keeps it, since withholding
 -- a spelling touches no term.
-replStep :: String -> Repl c -> (Repl c, [CommandResult])
+replStep :: SourceText -> Repl c -> (Repl c, [CommandResult])
 replStep input (Repl me) = case parseDecls input of
   Left err -> (Repl me, [Failed ("parse error: " <> err)])
   Right decls ->
@@ -700,14 +732,14 @@ replStep input (Repl me) = case parseDecls input of
 -- | Parse and interpret one source.
 --
 -- >>> let report = mapM_ (putStrLn . renderResult) . either error id . interpret
--- >>> report (unlines ["module M (A : 𝕌) (x : A)", "def k : A → A := λ y ⇒ y", "def one : A := x"])
+-- >>> report (sourceLines ["module M (A : 𝕌) (x : A)", "def k : A → A := λ y ⇒ y", "def one : A := x"])
 -- module M
 --   ✓ defined k over (A)
 --   ✓ defined one over (A, x)
 --
 -- Each declaration is discharged over the parameters it uses and no others, so
 -- what a client sees is a closed definition it applies for itself.
-interpret :: String -> Either String [CommandResult]
+interpret :: SourceText -> Either ParseError [CommandResult]
 interpret input = interpretProgram <$> parseProgram input
 
 -- | Parse and interpret several named sources.
@@ -716,7 +748,7 @@ interpret input = interpretProgram <$> parseProgram input
 -- line of the file it is in rather than against a concatenation of them all.
 -- The modules are pooled afterwards, which is what lets one file import
 -- another.
-interpretSources :: [(FilePath, String)] -> Either String [CommandResult]
+interpretSources :: [(FilePath, SourceText)] -> Either ParseError [CommandResult]
 interpretSources sources = interpretModules . concat <$> traverse parseSource sources
   where
     parseSource (path, input) = case parseProgram input of

--- a/haskell/mltt/src/Language/MLTT/Impl/Generated.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl/Generated.hs
@@ -1,18 +1,20 @@
 {-# OPTIONS_GHC -Wno-orphans -Wno-redundant-constraints #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE DeriveTraversable   #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE PatternSynonyms     #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving  #-}
-{-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DeriveTraversable          #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE PatternSynonyms            #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeFamilies               #-}
 -- | Everything about MLTT that is /generated/ rather than written.
 --
 -- The scope-safe term type, the signature bifunctor, the pattern synonyms and
@@ -87,21 +89,34 @@ instance Foil.UnifiableInPattern Raw.BNFC'Position where
 
 -- * Parsing and printing
 
+-- | Source text as the parser receives it: the contents of a file, of
+-- standard input, or of one interactive step. The 'IsString' instance lets
+-- tests and doctests write literals.
+newtype SourceText = SourceText { sourceText :: String }
+  deriving newtype (Eq, Show, IsString, Semigroup, Monoid)
+
+-- | Assemble a source from its lines, 'unlines'-style.
+sourceLines :: [String] -> SourceText
+sourceLines = SourceText . unlines
+
+-- | What the parser reports when the input is not MLTT.
+type ParseError = String
+
 -- | Parse a raw term, calling 'error' if it does not parse.
-unsafeParse :: ([Raw.Token] -> Either String a) -> String -> a
-unsafeParse parse input =
+unsafeParse :: ([Raw.Token] -> Either ParseError a) -> SourceText -> a
+unsafeParse parse (SourceText input) =
   case parse (Raw.tokens input) of
     Left err -> error ("could not parse an MLTT term: " <> input <> "\n  " <> err)
     Right x  -> x
 
 -- | Parse a raw program: a sequence of modules, laid out.
-parseProgram :: String -> Either String Raw.Program
-parseProgram input = Raw.pProgram (Raw.resolveLayout True (Raw.tokens input))
+parseProgram :: SourceText -> Either ParseError Raw.Program
+parseProgram (SourceText input) = Raw.pProgram (Raw.resolveLayout True (Raw.tokens input))
 
 -- | Parse a run of declarations, laid out as a module body is: what one
 -- interactive input holds.
-parseDecls :: String -> Either String [Raw.Decl]
-parseDecls input = Raw.pListDecl (Raw.resolveLayout True (Raw.tokens input))
+parseDecls :: SourceText -> Either ParseError [Raw.Decl]
+parseDecls (SourceText input) = Raw.pListDecl (Raw.resolveLayout True (Raw.tokens input))
 
 -- |
 -- >>> "λ x ⇒ λ y ⇒ x" :: Term' Raw.BNFC'Position Foil.VoidS
@@ -122,7 +137,7 @@ parseDecls input = Raw.pListDecl (Raw.resolveLayout True (Raw.tokens input))
 -- >>> toTerm'In (Foil.NameRange 50 59) Foil.emptyScope Map.empty (unsafeParse Par.pTerm "λ x ⇒ λ y ⇒ x")
 -- λ x50 ⇒ λ x51 ⇒ x50
 instance IsString (Term' Raw.BNFC'Position Foil.VoidS) where
-  fromString = toTerm' Foil.emptyScope Map.empty . unsafeParse Raw.pTerm
+  fromString = toTerm' Foil.emptyScope Map.empty . unsafeParse Raw.pTerm . SourceText
 
 instance Show (Term' a n) where show = Raw.printTree . fromTerm'
 

--- a/haskell/mltt/test/Language/MLTT/ArtifactSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ArtifactSpec.hs
@@ -15,24 +15,25 @@ import           Test.Hspec
 
 import           Language.MLTT.Artifact
 import           Language.MLTT.Impl
-import           Language.MLTT.Impl.Generated (parseProgram)
+import           Language.MLTT.Impl.Generated (SourceText,
+                                               parseProgram, sourceLines)
 import qualified Language.MLTT.Syntax.Abs     as Raw
 import qualified Language.MLTT.Syntax.Print   as Raw
 
-srcP, srcQ, srcR, srcS, srcT, srcU :: String
-srcP = unlines ["module P", "def base : 𝟙 := tt"]
-srcQ = unlines ["module Q", "import P", "def q : 𝟙 := base"]
-srcR = unlines ["module R", "import Q", "def r : 𝟙 := q"]
-srcS = unlines
+srcP, srcQ, srcR, srcS, srcT, srcU :: SourceText
+srcP = sourceLines ["module P", "def base : 𝟙 := tt"]
+srcQ = sourceLines ["module Q", "import P", "def q : 𝟙 := base"]
+srcR = sourceLines ["module R", "import Q", "def r : 𝟙 := q"]
+srcS = sourceLines
   [ "module S (A : 𝕌) (a : A)"
   , "import P"
   , "def s : A → A := λ u ⇒ a"
   , "def sbase : 𝟙 := base"
   ]
-srcT = unlines ["module T", "import S", "def t : 𝟙 → 𝟙 := s 𝟙 sbase"]
-srcU = unlines ["module U", "import R", "import T", "compute t r"]
+srcT = sourceLines ["module T", "import S", "def t : 𝟙 → 𝟙 := s 𝟙 sbase"]
+srcU = sourceLines ["module U", "import R", "import T", "compute t r"]
 
-oneModule :: String -> Raw.Module
+oneModule :: SourceText -> Raw.Module
 oneModule src = case parseProgram src of
   Right (Raw.AProgram _ [m]) -> m
   Right _                    -> error "expected exactly one module"

--- a/haskell/mltt/test/Language/MLTT/BuildSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/BuildSpec.hs
@@ -11,24 +11,25 @@ import           Test.Hspec
 
 import           Language.MLTT.Build
 import           Language.MLTT.Impl
-import           Language.MLTT.Impl.Generated (parseProgram)
+import           Language.MLTT.Impl.Generated (SourceText,
+                                               parseProgram, sourceLines)
 import qualified Language.MLTT.Syntax.Abs     as Raw
 
-srcP, srcQ, srcQ', srcR, srcS, srcT, srcU :: String
-srcP = unlines ["module P", "def base : 𝟙 := tt"]
-srcQ = unlines ["module Q", "import P", "def q : 𝟙 := base"]
-srcQ' = srcQ <> unlines ["def q2 : 𝟙 := tt"]
-srcR = unlines ["module R", "import Q", "def r : 𝟙 := q"]
-srcS = unlines
+srcP, srcQ, srcQ', srcR, srcS, srcT, srcU :: SourceText
+srcP = sourceLines ["module P", "def base : 𝟙 := tt"]
+srcQ = sourceLines ["module Q", "import P", "def q : 𝟙 := base"]
+srcQ' = srcQ <> sourceLines ["def q2 : 𝟙 := tt"]
+srcR = sourceLines ["module R", "import Q", "def r : 𝟙 := q"]
+srcS = sourceLines
   [ "module S (A : 𝕌) (a : A)"
   , "import P"
   , "def s : A → A := λ u ⇒ a"
   , "def sbase : 𝟙 := base"
   ]
-srcT = unlines ["module T", "import S", "def t : 𝟙 → 𝟙 := s 𝟙 sbase"]
-srcU = unlines ["module U", "import R", "import T", "compute t r"]
+srcT = sourceLines ["module T", "import S", "def t : 𝟙 → 𝟙 := s 𝟙 sbase"]
+srcU = sourceLines ["module U", "import R", "import T", "compute t r"]
 
-oneModule :: String -> Raw.Module
+oneModule :: SourceText -> Raw.Module
 oneModule src = case parseProgram src of
   Right (Raw.AProgram _ [m]) -> m
   Right _                    -> error "expected exactly one module"
@@ -37,10 +38,10 @@ oneModule src = case parseProgram src of
 ms :: [Raw.Module]
 ms = map oneModule [srcP, srcQ, srcR, srcS, srcT, srcU]
 
-loadedNames :: [CommandResult] -> [String]
+loadedNames :: [CommandResult] -> [RenderedName]
 loadedNames results = [name | LoadedModule name <- results]
 
-checkedNames :: [CommandResult] -> [String]
+checkedNames :: [CommandResult] -> [RenderedName]
 checkedNames results = [name | EnteredModule name <- results]
 
 spec :: Spec

--- a/haskell/mltt/test/Language/MLTT/LinkSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/LinkSpec.hs
@@ -20,18 +20,19 @@ import           Data.Maybe                   (isJust, isNothing)
 import           Test.Hspec
 
 import           Language.MLTT.Impl
-import           Language.MLTT.Impl.Generated (parseProgram)
+import           Language.MLTT.Impl.Generated (SourceText,
+                                               parseProgram, sourceLines)
 import qualified Language.MLTT.Syntax.Abs     as Raw
 import           Language.MLTT.Typecheck      (ctxScope)
 
-srcI, srcA, srcB, srcC, srcX :: String
-srcI = unlines ["module I", "def base : 𝟙 := tt"]
-srcA = unlines ["module A", "import I", "def a : 𝟙 := base"]
-srcB = unlines ["module B", "import I", "def b : 𝟙 → 𝟙 := λ x ⇒ base"]
-srcC = unlines ["module C", "import A", "import B", "compute b a"]
-srcX = unlines ["module X", "def unrelated : 𝟙 := tt"]
+srcI, srcA, srcB, srcC, srcX :: SourceText
+srcI = sourceLines ["module I", "def base : 𝟙 := tt"]
+srcA = sourceLines ["module A", "import I", "def a : 𝟙 := base"]
+srcB = sourceLines ["module B", "import I", "def b : 𝟙 → 𝟙 := λ x ⇒ base"]
+srcC = sourceLines ["module C", "import A", "import B", "compute b a"]
+srcX = sourceLines ["module X", "def unrelated : 𝟙 := tt"]
 
-oneModule :: String -> Raw.Module
+oneModule :: SourceText -> Raw.Module
 oneModule src = case parseProgram src of
   Right (Raw.AProgram _ [m]) -> m
   Right _                    -> error "expected exactly one module"
@@ -47,18 +48,18 @@ mX = oneModule srcX
 
 -- Two chains over a shared base: P; Q imports P; R imports Q; S imports P;
 -- T imports S; U imports both chain ends.
-srcP, srcQ, srcR, srcS, srcT, srcU :: String
-srcP = unlines ["module P", "def base : \120793 := tt"]
-srcQ = unlines ["module Q", "import P", "def q : \120793 := base"]
-srcR = unlines ["module R", "import Q", "def r : \120793 := q"]
-srcS = unlines
+srcP, srcQ, srcR, srcS, srcT, srcU :: SourceText
+srcP = sourceLines ["module P", "def base : \120793 := tt"]
+srcQ = sourceLines ["module Q", "import P", "def q : \120793 := base"]
+srcR = sourceLines ["module R", "import Q", "def r : \120793 := q"]
+srcS = sourceLines
   [ "module S (A : \120140) (a : A)"
   , "import P"
   , "def s : A \8594 A := \955 u \8658 a"
   , "def sbase : \120793 := base"
   ]
-srcT = unlines ["module T", "import S", "def t : \120793 \8594 \120793 := s \120793 sbase"]
-srcU = unlines ["module U", "import R", "import T", "compute t r"]
+srcT = sourceLines ["module T", "import S", "def t : \120793 \8594 \120793 := s \120793 sbase"]
+srcU = sourceLines ["module U", "import R", "import T", "compute t r"]
 
 mP, mQ, mR, mS, mT, mU :: Raw.Module
 mP = oneModule srcP

--- a/haskell/mltt/test/Language/MLTT/ModulesSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ModulesSpec.hs
@@ -6,12 +6,13 @@ module Language.MLTT.ModulesSpec (spec) where
 import           Control.Monad     (forM_)
 import           Data.List         (isInfixOf)
 import           Language.MLTT.Impl
+import           Language.MLTT.Impl.Generated (SourceText (..))
 import           Test.Hspec
 
 -- | Interpret a program, reporting a parse error as a failed command so that
 -- every assertion below can be made about the same list.
 run :: String -> [CommandResult]
-run input = case interpret input of
+run input = case interpret (SourceText input) of
   Left err      -> [Failed ("parse error: " <> err)]
   Right results -> results
 
@@ -20,7 +21,7 @@ failures :: [CommandResult] -> [String]
 failures results = [err | Failed err <- results]
 
 -- | The normal forms every @compute@ produced.
-computed :: [CommandResult] -> [String]
+computed :: [CommandResult] -> [RenderedTerm]
 computed results = [term | Computed term <- results]
 
 -- | Two modules: a Prelude with a private helper used by a public definition,

--- a/haskell/mltt/test/Language/MLTT/ParametersSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ParametersSpec.hs
@@ -9,11 +9,12 @@ module Language.MLTT.ParametersSpec (spec) where
 
 import           Data.List          (isInfixOf)
 import           Language.MLTT.Impl
+import           Language.MLTT.Impl.Generated (SourceText (..))
 import           Test.Hspec
 
 -- | Interpret a program, reporting a parse error as a failed command.
 run :: String -> [CommandResult]
-run input = case interpret input of
+run input = case interpret (SourceText input) of
   Left err      -> [Failed ("parse error: " <> err)]
   Right results -> results
 
@@ -22,7 +23,7 @@ failures :: [CommandResult] -> [String]
 failures results = [err | Failed err <- results]
 
 -- | The normal forms every @compute@ produced.
-computed :: [CommandResult] -> [String]
+computed :: [CommandResult] -> [RenderedTerm]
 computed results = [term | Computed term <- results]
 
 -- | A monoid-shaped parameter block, and whatever declarations are given.


### PR DESCRIPTION
Newtypes where mixing two strings up is a real bug:
- `SourceText` is what the parser receives (with `IsString` for tests and `sourceLines` for multi-line sources),
- `RenderedName` and `RenderedTerm` are what a `CommandResult` shows the user, next to the existing `StoredTerm`.

Error prose stays `String` under per-layer synonyms (`ParseError`, `TypeError`, `BuildError`, `ArtifactError`, `ErrorMessage`) so signatures say which layer reports without touching the plumbing.

The executable's argument tuple becomes a `BuildOptions` record, with the `--repl` `Bool` replaced by `SessionMode`.

Raw-name arithmetic is typed via free-foil, which now exports the `Id` and `RawName` synonyms (`nameId`'s result already meant them): `firstStripeBase`, `boundName` and `intToVarIdent` say `RawName` instead of `Int`.