### PR TITLE
Windows: decode files and standard input as UTF-8 too

### DIFF
--- a/haskell/free-foil/test/SpecHook.hs
+++ b/haskell/free-foil/test/SpecHook.hs
@@ -1,15 +1,23 @@
--- | Set Unicode-capable output before any test output is printed; hspec
+-- | Set Unicode-capable input and output before any test runs; hspec
 -- discovers this module and wraps every spec in 'hook'.
 --
--- On Windows, GHC encodes standard output with the local code page, which
--- cannot represent characters such as Π or 𝟙 that appear in the test
--- descriptions, so the reporter dies with @commitBuffer: invalid argument@.
--- Setting the handles to UTF-8 in-process also covers redirected output,
--- which a @chcp@ call in the workflow never reached.
+-- On Windows, GHC encodes handles with the local code page, which cannot
+-- represent characters such as Π or 𝟙: the reporter used to die printing a
+-- test description (@commitBuffer: invalid argument@), and a spec that
+-- 'readFile's a UTF-8 example mis-decoded it and failed to parse. Setting
+-- the standard handles and the locale default (which every newly opened
+-- file inherits) to UTF-8 in-process covers both, including redirected
+-- output that a @chcp@ call in the workflow never reached.
 module SpecHook (hook) where
 
-import           System.IO  (hSetEncoding, stderr, stdout, utf8)
-import           Test.Hspec (Spec, runIO)
+import           GHC.IO.Encoding (setLocaleEncoding)
+import           System.IO       (hSetEncoding, stderr, stdout, utf8)
+import           Test.Hspec      (Spec, runIO)
 
 hook :: Spec -> Spec
-hook spec = runIO (hSetEncoding stdout utf8 >> hSetEncoding stderr utf8) >> spec
+hook spec = runIO setUtf8 >> spec
+  where
+    setUtf8 = do
+      setLocaleEncoding utf8
+      hSetEncoding stdout utf8
+      hSetEncoding stderr utf8

--- a/haskell/lambda-pi/test/SpecHook.hs
+++ b/haskell/lambda-pi/test/SpecHook.hs
@@ -1,15 +1,23 @@
--- | Set Unicode-capable output before any test output is printed; hspec
+-- | Set Unicode-capable input and output before any test runs; hspec
 -- discovers this module and wraps every spec in 'hook'.
 --
--- On Windows, GHC encodes standard output with the local code page, which
--- cannot represent characters such as Π or 𝟙 that appear in the test
--- descriptions, so the reporter dies with @commitBuffer: invalid argument@.
--- Setting the handles to UTF-8 in-process also covers redirected output,
--- which a @chcp@ call in the workflow never reached.
+-- On Windows, GHC encodes handles with the local code page, which cannot
+-- represent characters such as Π or 𝟙: the reporter used to die printing a
+-- test description (@commitBuffer: invalid argument@), and a spec that
+-- 'readFile's a UTF-8 example mis-decoded it and failed to parse. Setting
+-- the standard handles and the locale default (which every newly opened
+-- file inherits) to UTF-8 in-process covers both, including redirected
+-- output that a @chcp@ call in the workflow never reached.
 module SpecHook (hook) where
 
-import           System.IO  (hSetEncoding, stderr, stdout, utf8)
-import           Test.Hspec (Spec, runIO)
+import           GHC.IO.Encoding (setLocaleEncoding)
+import           System.IO       (hSetEncoding, stderr, stdout, utf8)
+import           Test.Hspec      (Spec, runIO)
 
 hook :: Spec -> Spec
-hook spec = runIO (hSetEncoding stdout utf8 >> hSetEncoding stderr utf8) >> spec
+hook spec = runIO setUtf8 >> spec
+  where
+    setUtf8 = do
+      setLocaleEncoding utf8
+      hSetEncoding stdout utf8
+      hSetEncoding stderr utf8

--- a/haskell/mltt/app/MLTT.hs
+++ b/haskell/mltt/app/MLTT.hs
@@ -1,7 +1,17 @@
 module Main where
 
+import GHC.IO.Encoding    (setLocaleEncoding)
 import Language.MLTT.Build (buildMain)
 import System.Environment (getArgs)
+import System.IO          (hSetEncoding, stderr, stdin, stdout, utf8)
 
+-- | MLTT sources are UTF-8 wherever they come from, so fix every channel to
+-- it up front: the locale default covers files the builder reads, and the
+-- standard handles cover piped sources, the session and the output. On
+-- Windows the default is the local code page, which garbles Π and 𝟙 on the
+-- way in and refuses them on the way out.
 main :: IO ()
-main = buildMain =<< getArgs
+main = do
+  setLocaleEncoding utf8
+  mapM_ (`hSetEncoding` utf8) [stdin, stdout, stderr]
+  buildMain =<< getArgs

--- a/haskell/mltt/test/SpecHook.hs
+++ b/haskell/mltt/test/SpecHook.hs
@@ -1,15 +1,23 @@
--- | Set Unicode-capable output before any test output is printed; hspec
+-- | Set Unicode-capable input and output before any test runs; hspec
 -- discovers this module and wraps every spec in 'hook'.
 --
--- On Windows, GHC encodes standard output with the local code page, which
--- cannot represent characters such as Π or 𝟙 that appear in the test
--- descriptions, so the reporter dies with @commitBuffer: invalid argument@.
--- Setting the handles to UTF-8 in-process also covers redirected output,
--- which a @chcp@ call in the workflow never reached.
+-- On Windows, GHC encodes handles with the local code page, which cannot
+-- represent characters such as Π or 𝟙: the reporter used to die printing a
+-- test description (@commitBuffer: invalid argument@), and a spec that
+-- 'readFile's a UTF-8 example mis-decoded it and failed to parse. Setting
+-- the standard handles and the locale default (which every newly opened
+-- file inherits) to UTF-8 in-process covers both, including redirected
+-- output that a @chcp@ call in the workflow never reached.
 module SpecHook (hook) where
 
-import           System.IO  (hSetEncoding, stderr, stdout, utf8)
-import           Test.Hspec (Spec, runIO)
+import           GHC.IO.Encoding (setLocaleEncoding)
+import           System.IO       (hSetEncoding, stderr, stdout, utf8)
+import           Test.Hspec      (Spec, runIO)
 
 hook :: Spec -> Spec
-hook spec = runIO (hSetEncoding stdout utf8 >> hSetEncoding stderr utf8) >> spec
+hook spec = runIO setUtf8 >> spec
+  where
+    setUtf8 = do
+      setLocaleEncoding utf8
+      hSetEncoding stdout utf8
+      hSetEncoding stderr utf8

--- a/haskell/soas/test/SpecHook.hs
+++ b/haskell/soas/test/SpecHook.hs
@@ -1,15 +1,23 @@
--- | Set Unicode-capable output before any test output is printed; hspec
+-- | Set Unicode-capable input and output before any test runs; hspec
 -- discovers this module and wraps every spec in 'hook'.
 --
--- On Windows, GHC encodes standard output with the local code page, which
--- cannot represent characters such as Π or 𝟙 that appear in the test
--- descriptions, so the reporter dies with @commitBuffer: invalid argument@.
--- Setting the handles to UTF-8 in-process also covers redirected output,
--- which a @chcp@ call in the workflow never reached.
+-- On Windows, GHC encodes handles with the local code page, which cannot
+-- represent characters such as Π or 𝟙: the reporter used to die printing a
+-- test description (@commitBuffer: invalid argument@), and a spec that
+-- 'readFile's a UTF-8 example mis-decoded it and failed to parse. Setting
+-- the standard handles and the locale default (which every newly opened
+-- file inherits) to UTF-8 in-process covers both, including redirected
+-- output that a @chcp@ call in the workflow never reached.
 module SpecHook (hook) where
 
-import           System.IO  (hSetEncoding, stderr, stdout, utf8)
-import           Test.Hspec (Spec, runIO)
+import           GHC.IO.Encoding (setLocaleEncoding)
+import           System.IO       (hSetEncoding, stderr, stdout, utf8)
+import           Test.Hspec      (Spec, runIO)
 
 hook :: Spec -> Spec
-hook spec = runIO (hSetEncoding stdout utf8 >> hSetEncoding stderr utf8) >> spec
+hook spec = runIO setUtf8 >> spec
+  where
+    setUtf8 = do
+      setLocaleEncoding utf8
+      hSetEncoding stdout utf8
+      hSetEncoding stderr utf8


### PR DESCRIPTION
The SpecHook from #63 fixed the output handles, and the Windows job got as far as running every example — three then failed differently: the spec that `readFile`s the UTF-8 example programs decoded them with the local code page, garbling 𝟙 and Π into something the parser rejects (`syntax error … before '#error'`).

The hook now also calls `setLocaleEncoding utf8`, which every newly opened file inherits. The mltt executable had the same bug for the sources it reads, so its `main` fixes the locale default and the standard handles the same way (stdin included — the interactive session reads from it).