### PR TITLE
MLTT: imports from the REPL session

### DIFF
--- a/haskell/free-foil/ChangeLog.md
+++ b/haskell/free-foil/ChangeLog.md
@@ -66,6 +66,8 @@ New:
 
 - `Control.Monad.Foil` exports the `Id` and `RawName` synonyms, so a client can type its raw-name arithmetic (stripe bases, interned identifiers) the way `nameId`'s result already means.
 
+- `Control.Monad.Foil.Blocks.resumeBlock` resumes allocating from a range once the evidence has grown past what a `Block` tracked by itself — after composing in a loaded unit's evidence, say. The invariant `withFreshInBlock` rests on is checked (the allocation range must lie inside the evidence's ranges), and this is what lets an interactive unit keep allocating in its own reservation after an import enlarges its scope.
+
 Changed:
 
 - `convertToAST` and `convertToScopedAST` are deprecated in favour of `unsafeConvertToAST` and `unsafeConvertToScopedAST`, which are the same functions under names that admit they call `error`. The old names still work.

--- a/haskell/free-foil/src/Control/Monad/Foil/Blocks.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/Blocks.hs
@@ -49,6 +49,7 @@ module Control.Monad.Foil.Blocks (
   -- * Blocks in use
   Block,
   beginBlock,
+  resumeBlock,
   blockRange,
   blockExt,
   withFreshInBlock,
@@ -169,6 +170,29 @@ data Block (c :: S) (l :: S) = UnsafeBlock !NameRange (ExtWithin c l)
 -- | Start a unit: no names allocated yet, so the evidence is trivial.
 beginBlock :: NameRange -> Block c c
 beginBlock range = UnsafeBlock range (extWithinRefl range)
+
+-- | Resume allocating from a range once the evidence has grown past what a
+-- 'Block' tracked by itself — after composing in a loaded unit's evidence
+-- with 'composeExtWithin', say, so that an interactive unit can keep
+-- allocating in its own reservation over the enlarged scope.
+--
+-- The invariant 'withFreshInBlock' rests on is checked: the allocation
+-- range must lie inside one of the evidence's ranges (they are normalised,
+-- so covering is containment in a single one), and 'Nothing' says it does
+-- not.
+--
+-- >>> let grown = composeExtWithin (extWithinRefl (NameRange 0 9)) (extWithinRefl (NameRange 10 19))
+-- >>> fmap blockRange (resumeBlock (NameRange 0 9) grown)
+-- Just (NameRange {nameRangeLo = 0, nameRangeHi = 9})
+-- >>> fmap blockRange (resumeBlock (NameRange 30 39) grown)
+-- Nothing
+resumeBlock :: NameRange -> ExtWithin c l -> Maybe (Block c l)
+resumeBlock range@(NameRange lo hi) ext
+  | lo > hi = Nothing
+  | any covers (extWithinRanges ext) = Just (UnsafeBlock range ext)
+  | otherwise = Nothing
+  where
+    covers (NameRange lo' hi') = lo' <= lo && hi <= hi'
 
 -- | The range 'withFreshInBlock' allocates from.
 blockRange :: Block c l -> NameRange

--- a/haskell/mltt/mltt.cabal
+++ b/haskell/mltt/mltt.cabal
@@ -138,6 +138,7 @@ test-suite spec
       Language.MLTT.LinkSpec
       Language.MLTT.ModulesSpec
       Language.MLTT.ParametersSpec
+      Language.MLTT.ReplImportSpec
       Language.MLTT.ReplSpec
       SpecHook
       Paths_mltt

--- a/haskell/mltt/src/Language/MLTT/Build.hs
+++ b/haskell/mltt/src/Language/MLTT/Build.hs
@@ -27,8 +27,10 @@
 -- the cache reconstructs environments, not output.
 --
 -- With @--repl@, the build is followed by an interactive session over its
--- result: every built module's exports are in scope, and the session
--- allocates from the first stripe the build left free.
+-- result. The session starts seeing nothing, like any module: an @import@
+-- brings a built module's exports into scope, or loads a module (and its
+-- missing imports) from the cache mid-session. The session allocates from
+-- the first stripe the build left free.
 module Language.MLTT.Build (
   BuildMode (..),
   BuildOptions (..),
@@ -38,6 +40,7 @@ module Language.MLTT.Build (
   buildSources,
   buildSourcesWith,
   sessionOver,
+  replImport,
   buildMain,
 ) where
 
@@ -47,8 +50,10 @@ import           Control.DeepSeq          (force)
 import           Control.Exception        (evaluate)
 import           Control.Monad            (foldM, forM, forM_, unless, when)
 import qualified Control.Monad.Foil       as Foil
+import qualified Control.Monad.Foil.Blocks as Blocks
 import           Data.Char                (isSpace)
 import           Data.Function            (on)
+import           Data.Functor.Compose     (Compose (..))
 import           Data.List                (foldl', isPrefixOf, sortOn,
                                            stripPrefix)
 import           Data.List.NonEmpty       (NonEmpty (..))
@@ -63,7 +68,8 @@ import           System.IO                (hFlush, isEOF, stdout)
 
 import           Language.MLTT.Artifact
 import           Language.MLTT.Impl
-import           Language.MLTT.Impl.Generated (SourceText (..), parseProgram)
+import           Language.MLTT.Impl.Generated (SourceText (..), parseImports,
+                                               parseProgram)
 import           Language.MLTT.Resolve    (prettyVarIdent)
 import qualified Language.MLTT.Syntax.Abs as Raw
 import qualified Language.MLTT.Syntax.Print as Raw
@@ -90,7 +96,7 @@ buildMain args =
         \registry env results -> do
           mapM_ (putStrLn . renderResult) results
           case optSession opts of
-            Interactive -> True <$ runRepl (sessionOver registry env)
+            Interactive -> True <$ runRepl (optCache opts) (sessionOver registry env)
             BatchOnly   -> pure (succeeded results)
       case result of
         Left err -> putStrLn err >> exitFailure
@@ -124,19 +130,160 @@ parseArgs = fmap done . foldM step (BuildOptions Sequential Nothing BatchOnly []
         | otherwise -> Right opts { optFiles = arg : optFiles opts }
     usage = "\nusage: mltt [--mode=sequential|linked|parallel] [--cache=DIR] [--repl] [FILES...]"
 
--- | Begin a session over a build. Every built module's exports are in scope,
--- as if the session's module imported them all, and names are allocated from
--- the first stripe the build left free — the registry is append-only, so its
+-- | Begin a session over a build. The session is a module that never ends,
+-- and like any module it starts seeing nothing: an @import@ brings a built
+-- module's exports into scope ('replImport'). Names are allocated from the
+-- first stripe the build left free — the registry is append-only, so its
 -- size names that stripe.
 sessionOver :: Foil.Distinct c => Registry -> Env c -> Repl c
 sessionOver registry env =
   beginRepl (stripeRange (StripeIndex (Map.size registry)))
-            env { envDeclared = Map.unions (Map.elems (envModules env)) }
+            env { envDeclared   = Map.empty
+                , envExports    = Map.empty
+                , envClosedOver = Map.empty
+                }
 
--- | The loop itself: one 'replStep' per line, until end of input. Blank
+-- | One interactive @import@.
+--
+-- A module the session's world already holds — built before the session, or
+-- imported earlier — contributes its exports to what the session can name,
+-- and nothing else: the import is resolution, exactly as in a module
+-- header, except that a later import rebinds a spelling an earlier one
+-- brought in, the way a later @def@ rebinds one.
+--
+-- A module the world does not hold is loaded from the cache: the module and
+-- its missing imports, dependency-first, each artifact loaded over the
+-- session's current scope at its recorded stripe, so the session's evidence
+-- grows by the imports' stripes ('Blocks.composeExtWithin') and the session
+-- keeps allocating in its own stripe over the enlarged scope
+-- ('Blocks.resumeBlock'). Staleness is checked exactly as in the builder:
+-- an artifact's recorded import hashes must agree with the artifacts its
+-- imports load from.
+replImport :: Maybe FilePath -> Raw.VarIdent -> Repl c -> IO (Repl c, [CommandResult])
+replImport cacheDir name repl@(Repl me)
+  | Map.member name (envModules (moduleEnv me)) = pure (resolutionImport name repl)
+  | otherwise = case cacheDir of
+      Nothing ->
+        pure (repl, [Failed ("unknown module " <> prettyVarIdent name
+                              <> ", and no cache directory to load it from")])
+      Just dir -> do
+        gathered <- gatherArtifacts dir (moduleEnv me) name
+        pure $ case gathered of
+          Left err                  -> (repl, [Failed err])
+          Right (artifacts, hashes) -> loadImports hashes artifacts name repl
+
+-- | Bring an already-checked module's exports into the session's view.
+resolutionImport :: Raw.VarIdent -> Repl c -> (Repl c, [CommandResult])
+resolutionImport name (Repl (ModuleEnv block env)) =
+  case Map.lookup name (envModules env) of
+    Nothing ->
+      ( Repl (ModuleEnv block env)
+      , [Failed ("unknown module " <> prettyVarIdent name)] )
+    Just exports ->
+      ( Repl (ModuleEnv block env { envDeclared = exports <> envDeclared env })
+      , [Imported (renderVarIdent name)] )
+
+-- | Collect, dependency-first, the artifacts an import has to load: the
+-- module itself and every import of it the session's world does not hold.
+-- For an import the world does hold, only its artifact's content hash is
+-- read, which is what a dependant's staleness check compares against.
+gatherArtifacts
+  :: FilePath -> Env n -> Raw.VarIdent
+  -> IO (Either ErrorMessage ([ModuleArtifact], Map Raw.VarIdent ContentHash))
+gatherArtifacts dir env = go [] ([], Map.empty)
+  where
+    artifactPath name = dir </> prettyVarIdent name <> ".mltta"
+
+    readArtifactFor name = do
+      exists <- doesFileExist (artifactPath name)
+      if not exists
+        then pure (Left ("unknown module " <> prettyVarIdent name
+                          <> ": not in this session's world, and no artifact at "
+                          <> artifactPath name))
+        else either (\e -> Left ("artifact for " <> prettyVarIdent name <> ": " <> e)) Right
+               . readArtifact <$> readFile (artifactPath name)
+
+    go trail acc@(loads, hashes) name
+      | name `elem` trail =
+          pure (Left ("import cycle in cached artifacts through " <> prettyVarIdent name))
+      | Map.member name hashes = pure (Right acc)
+      | Map.member name (envModules env) = fmap recordHash <$> readArtifactFor name
+      | otherwise = do
+          ea <- readArtifactFor name
+          case ea of
+            Left err -> pure (Left err)
+            Right a -> do
+              deeper <- foldM (visit (name : trail)) (Right acc)
+                              [x | (x, _) <- artifactImports a]
+              pure $ case deeper of
+                Left err -> Left err
+                Right (loads', hashes') ->
+                  Right ( loads' <> [a]
+                        , Map.insert (artifactModule a) (artifactHash a) hashes' )
+      where
+        recordHash a = (loads, Map.insert name (artifactHash a) hashes)
+
+    visit trail acc name = case acc of
+      Left err   -> pure (Left err)
+      Right acc' -> go trail acc' name
+
+-- | The session's own view of the world: what it can name, what it has
+-- defined, and what those definitions were closed over. Loading an artifact
+-- rewires exactly these three tables to the loaded module's view, so an
+-- import saves them, sinks them along each load, and puts them back.
+data SessionView n = SessionView
+  { viewDeclared   :: Map Raw.VarIdent (Foil.Name n)
+  , viewExports    :: Map Raw.VarIdent (Foil.Name n)
+  , viewClosedOver :: Map Raw.VarIdent ([Raw.VarIdent], Foil.Name n)
+  }
+
+sessionView :: Env n -> SessionView n
+sessionView env = SessionView (envDeclared env) (envExports env) (envClosedOver env)
+
+sinkView :: Foil.DExt n l => SessionView n -> SessionView l
+sinkView (SessionView decls exports closed) =
+  SessionView (Foil.sink1 decls) (Foil.sink1 exports)
+              (getCompose (Foil.sink1 (Compose closed)))
+
+-- | The importing fold's carrier: the session's block over its base, the
+-- environment after the loads so far, and the session's view sunk along.
+data Importing c where
+  Importing
+    :: Foil.DExt c n
+    => Blocks.Block c n -> Env n -> SessionView n -> Importing c
+
+-- | Load the gathered artifacts over the session, dependency-first, and
+-- bring the imported module's exports into the session's view.
+loadImports
+  :: Map Raw.VarIdent ContentHash -> [ModuleArtifact] -> Raw.VarIdent
+  -> Repl c -> (Repl c, [CommandResult])
+loadImports hashes artifacts name (Repl me) =
+  case foldM step (Importing (moduleBlock me) (moduleEnv me) (sessionView (moduleEnv me))) artifacts of
+    Left err -> (Repl me, [Failed err])
+    Right (Importing block env view) ->
+      let exports = Map.findWithDefault Map.empty name (envModules env)
+          env' = env
+            { envDeclared   = exports <> viewDeclared view
+            , envExports    = viewExports view
+            , envClosedOver = viewClosedOver view
+            }
+       in ( Repl (ModuleEnv block env')
+          , [LoadedModule (renderVarIdent (artifactModule a)) | a <- artifacts]
+              <> [Imported (renderVarIdent name)] )
+  where
+    step (Importing block env view) a = do
+      cm <- loadArtifact hashes (stripeRange (artifactStripe a)) env a
+      withCheckedModule cm $ \ext env' _ ->
+        case Blocks.resumeBlock (Blocks.blockRange block)
+               (Blocks.composeExtWithin (Blocks.blockExt block) ext) of
+          Nothing     -> error "impossible: composition dropped the session's own range"
+          Just block' -> Right (Importing block' env' (sinkView view))
+
+-- | The loop itself: one step per line, until end of input. A line of
+-- imports goes through 'replImport'; anything else is a 'replStep'. Blank
 -- lines are skipped, and results are rendered exactly like the builder's.
-runRepl :: Repl c -> IO ()
-runRepl = loop
+runRepl :: Maybe FilePath -> Repl c -> IO ()
+runRepl cacheDir = loop
   where
     loop s = do
       putStr "mltt> "
@@ -148,10 +295,19 @@ runRepl = loop
           line <- getLine
           if all isSpace line
             then loop s
-            else do
-              let (s', results) = replStep (SourceText line) s
-              mapM_ (putStrLn . renderResult) results
-              loop s'
+            else case parseImports (SourceText line) of
+              Right imports@(_ : _) -> do
+                (s', results) <- foldM importOne (s, []) imports
+                mapM_ (putStrLn . renderResult) results
+                loop s'
+              _ -> do
+                let (s', results) = replStep (SourceText line) s
+                mapM_ (putStrLn . renderResult) results
+                loop s'
+
+    importOne (s, results) (Raw.AnImport _ name) = do
+      (s', more) <- replImport cacheDir name s
+      pure (s', results <> more)
 
 -- | How to schedule the checking.
 data BuildMode = Sequential | Linked | Parallel

--- a/haskell/mltt/src/Language/MLTT/Impl.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl.hs
@@ -182,6 +182,8 @@ data CommandResult
   | Checked RenderedTerm RenderedTerm
                                 -- ^ @check@ succeeded, for a term and its type.
   | Computed RenderedTerm       -- ^ @compute@ succeeded, with the normal form.
+  | Imported RenderedName       -- ^ An interactive @import@ brought a
+                                -- module's exports into the session.
   | Failed ErrorMessage         -- ^ The declaration was rejected.
   deriving (Eq, Generic, Show)
 
@@ -205,6 +207,7 @@ renderResult = \case
                           <> " over (" <> intercalate ", " (map renderedName used) <> ")"
   Checked term ty    -> "  ✓ " <> renderedTerm term <> " : " <> renderedTerm ty
   Computed term      -> "  ↦ " <> renderedTerm term
+  Imported name      -> "  ✓ imported " <> renderedName name
   Failed err         -> "  ✗ " <> err
 
 -- * Build order

--- a/haskell/mltt/src/Language/MLTT/Impl/Generated.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl/Generated.hs
@@ -118,6 +118,11 @@ parseProgram (SourceText input) = Raw.pProgram (Raw.resolveLayout True (Raw.toke
 parseDecls :: SourceText -> Either ParseError [Raw.Decl]
 parseDecls (SourceText input) = Raw.pListDecl (Raw.resolveLayout True (Raw.tokens input))
 
+-- | Parse a run of imports, laid out as a module header is: what an
+-- interactive @import@ line holds.
+parseImports :: SourceText -> Either ParseError [Raw.Import]
+parseImports (SourceText input) = Raw.pListImport (Raw.resolveLayout True (Raw.tokens input))
+
 -- |
 -- >>> "λ x ⇒ λ y ⇒ x" :: Term' Raw.BNFC'Position Foil.VoidS
 -- λ x0 ⇒ λ x1 ⇒ x0

--- a/haskell/mltt/test/Language/MLTT/BuildSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/BuildSpec.hs
@@ -76,10 +76,16 @@ spec = do
       fmap loadedNames r3 `shouldBe` Right ["P", "S", "T", "U"]
 
   describe "a session over a build" $
-    it "sees every built module's exports and continues from there" $ do
+    it "starts seeing nothing; imports bring built modules' exports in" $ do
       r <- buildModulesWith Linked Nothing ms $ \registry env results -> do
         let s0 = sessionOver registry env
-            (s1, r1) = replStep "def mine : 𝟙 := t r" s0
-            (_,  r2) = replStep "compute mine" s1
-        pure (succeeded results, r1, r2)
-      r `shouldBe` Right (True, [Defined "mine" []], [Computed "tt"])
+            (_, r0) = replStep "def nope : 𝟙 := t r" s0
+        (s1, r1) <- replImport Nothing (Raw.VarIdent "T") s0
+        (s2, r2) <- replImport Nothing (Raw.VarIdent "R") s1
+        let (s3, r3) = replStep "def mine : 𝟙 := t r" s2
+            (_,  r4) = replStep "compute mine" s3
+        pure ( succeeded results, null [msg | Failed msg <- r0]
+             , r1, r2, r3, r4 )
+      r `shouldBe` Right ( True, False
+                         , [Imported "T"], [Imported "R"]
+                         , [Defined "mine" []], [Computed "tt"] )

--- a/haskell/mltt/test/Language/MLTT/ReplImportSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ReplImportSpec.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Imports into an interactive session: resolution for modules the world
+-- holds, artifact-chain loading for modules it does not, and the failure
+-- modes (unknown module, missing artifact, stale chain).
+module Language.MLTT.ReplImportSpec (spec) where
+
+import qualified Control.Monad.Foil           as Foil
+import           Data.List                    (isInfixOf)
+import           System.Directory             (getTemporaryDirectory,
+                                               removePathForcibly)
+import           System.FilePath              ((</>))
+import           Test.Hspec
+
+import           Language.MLTT.Build
+import           Language.MLTT.Impl
+import           Language.MLTT.Impl.Generated (SourceText, parseProgram,
+                                               sourceLines)
+import qualified Language.MLTT.Syntax.Abs     as Raw
+
+srcP, srcP', srcQ, srcR :: SourceText
+srcP  = sourceLines ["module P", "def base : 𝟙 := tt"]
+srcP' = sourceLines ["module P", "def base : 𝟙 → 𝟙 := λ x ⇒ x"]
+srcQ  = sourceLines ["module Q", "import P", "def q : 𝟙 := base"]
+srcR  = sourceLines ["module R", "import Q", "def r : 𝟙 := q"]
+
+modsOf :: [SourceText] -> [Raw.Module]
+modsOf srcs = concat [ms | Right (Raw.AProgram _ ms) <- map parseProgram srcs]
+
+-- | A session over an empty world, on a stripe clear of the cached ones.
+bareSession :: Repl Foil.VoidS
+bareSession = beginRepl (stripeRange (StripeIndex 9)) emptyEnv
+
+failures :: [CommandResult] -> [ErrorMessage]
+failures results = [msg | Failed msg <- results]
+
+spec :: Spec
+spec = describe "importing into a session" $ do
+  it "loads a cached chain, and brings only the imported module's exports in" $ do
+    dir <- (</> "mltt-repl-import-cache") <$> getTemporaryDirectory
+    removePathForcibly dir
+    _ <- buildModules Sequential (Just dir) (modsOf [srcP, srcQ, srcR])
+    (s1, r1) <- replImport (Just dir) (Raw.VarIdent "R") bareSession
+    r1 `shouldBe` [ LoadedModule "P", LoadedModule "Q", LoadedModule "R"
+                  , Imported "R" ]
+    let (s2, r2) = replStep "compute r" s1
+    r2 `shouldBe` [Computed "tt"]
+    -- Q's q reduces through r, but only R's exports can be named.
+    let (s3, r3) = replStep "compute q" s2
+    failures r3 `shouldSatisfy` (not . null)
+    -- A further import is resolution only: Q is in the world now.
+    (s4, r4) <- replImport (Just dir) (Raw.VarIdent "Q") s3
+    r4 `shouldBe` [Imported "Q"]
+    let (_, r5) = replStep "compute q" s4
+    r5 `shouldBe` [Computed "tt"]
+
+  it "refuses an unknown module, naming the artifact it looked for" $ do
+    (_, r1) <- replImport Nothing (Raw.VarIdent "M") bareSession
+    failures r1 `shouldSatisfy` (not . null)
+    dir <- (</> "mltt-repl-import-empty") <$> getTemporaryDirectory
+    removePathForcibly dir
+    (_, r2) <- replImport (Just dir) (Raw.VarIdent "M") bareSession
+    concat (failures r2) `shouldSatisfy` ("M.mltta" `isInfixOf`)
+
+  it "rejects a stale chain instead of loading it" $ do
+    dir <- (</> "mltt-repl-import-stale") <$> getTemporaryDirectory
+    removePathForcibly dir
+    _ <- buildModules Sequential (Just dir) (modsOf [srcP, srcQ])
+    -- P changes and is rebuilt alone, so Q's artifact records a hash the
+    -- cache no longer agrees with.
+    _ <- buildModules Sequential (Just dir) (modsOf [srcP'])
+    (_, r) <- replImport (Just dir) (Raw.VarIdent "Q") bareSession
+    concat (failures r) `shouldSatisfy` ("stale" `isInfixOf`)


### PR DESCRIPTION
The session is a module that never ends, and like any module it now starts seeing nothing: `import` brings exports into scope.

1. Importing a module the world already holds is resolution alone, as in a module header; a later import rebinds a spelling, the way a later `def` does.
2. Importing anything else loads its artifact chain from the cache, dependency-first, over the session's current scope; the session's evidence grows by the imports' stripes, staleness is checked as in the builder, and the session's own view is sunk along and put back.
3. New in the library: `Blocks.resumeBlock`, so the session keeps allocating in its own reservation over the enlarged scope.
4. Deviation from the earlier sketch: the import composes over the current scope (the `checkModuleAfter` shape) instead of `linkChecked` over a retained base — observationally the same for a sequential session, and the view stays sinkable stepwise.

```
$ mltt --cache=.mltt-cache examples/modules.mltt     # build once
$ mltt --repl --cache=.mltt-cache                    # a bare session
mltt> compute q
  ✗ not in scope: q
mltt> import Q
module P (cached)
module Q (cached)
  ✓ imported Q
mltt> compute q
  ↦ tt
```