### PR TITLE
A binary wire format that carries the AST itself

### DIFF
--- a/haskell/free-foil/ChangeLog.md
+++ b/haskell/free-foil/ChangeLog.md
@@ -66,6 +66,10 @@ New:
 
 - `Control.Monad.Foil` exports the `Id` and `RawName` synonyms, so a client can type its raw-name arithmetic (stripe bases, interned identifiers) the way `nameId`'s result already means.
 
+- `Control.Monad.Free.Foil.Binary`: `Binary` instances for `Name`, `NameBinder`, `AST` and `ScopedAST` — the wire view of a term is the term itself, raw ids and all. The instances are opt-in orphans in a module of their own (importing it is what brings them into scope), and the dependency this costs is `binary`, a GHC boot library. Decoding mints scope evidence — the existential index under a binder is chosen arbitrarily — so the instances are a trust boundary in the sense of `checkExtScope`, and the module documentation says what a serialising layer is expected to validate on the way in; `mltt`'s artifact module is the worked example. `Control.Monad.Free.Foil.Binary.TH.deriveBinaryPattern` writes the one instance a client must supply itself — its pattern type is a GADT, out of `GHC.Generics`' reach — decoding at the scope diagonal, which any chain of binder indices admits, then coercing once.
+
+- The successor allocator never dips below zero: `rawFreshName` over a scope whose maximum is negative now allocates `0`, not the successor of a negative name. This is the local half of the never-cross-zero layout from the design notes — names below zero are reserved for interned constants, allocated by explicit policy (`withFreshIn` at a negative range, which needed no change) — and `mltt` now assigns its module stripes below zero on the strength of it. A spec pins allocation around the sign boundary, since `sink` rests on the allocator.
+
 - `Control.Monad.Foil.Blocks.resumeBlock` resumes allocating from a range once the evidence has grown past what a `Block` tracked by itself — after composing in a loaded unit's evidence, say. The invariant `withFreshInBlock` rests on is checked (the allocation range must lie inside the evidence's ranges), and this is what lets an interactive unit keep allocating in its own reservation after an import enlarges its scope.
 
 Changed:

--- a/haskell/free-foil/free-foil.cabal
+++ b/haskell/free-foil/free-foil.cabal
@@ -42,6 +42,8 @@ library
       Control.Monad.Foil.TH.Util
       Control.Monad.Free.Foil
       Control.Monad.Free.Foil.Annotated
+      Control.Monad.Free.Foil.Binary
+      Control.Monad.Free.Foil.Binary.TH
       Control.Monad.Free.Foil.Example
       Control.Monad.Free.Foil.TH
       Control.Monad.Free.Foil.TH.Convert
@@ -63,6 +65,7 @@ library
       array >=0.5.3.0 && <0.6
     , base >=4.19 && <5
     , bifunctors >=5.5 && <5.7
+    , binary >=0.8
     , containers >=0.6.8 && <0.9
     , deepseq >=1.4 && <1.6
     , kind-generics >=0.5.0 && <0.6
@@ -81,6 +84,7 @@ test-suite doctests
       array >=0.5.3.0 && <0.6
     , base >=4.19 && <5
     , bifunctors >=5.5 && <5.7
+    , binary >=0.8
     , containers >=0.6.8 && <0.9
     , deepseq >=1.4 && <1.6
     , doctest-parallel
@@ -116,6 +120,7 @@ test-suite spec
     , array >=0.5.3.0 && <0.6
     , base >=4.19 && <5
     , bifunctors >=5.5 && <5.7
+    , binary >=0.8
     , containers
     , deepseq >=1.4 && <1.6
     , free-foil
@@ -139,6 +144,7 @@ benchmark normalize
       array >=0.5.3.0 && <0.6
     , base >=4.19 && <5
     , bifunctors >=5.5 && <5.7
+    , binary >=0.8
     , containers >=0.6.8 && <0.9
     , deepseq >=1.4 && <1.6
     , free-foil
@@ -161,6 +167,7 @@ benchmark zipmatchk
       array >=0.5.3.0 && <0.6
     , base >=4.19 && <5
     , bifunctors >=5.5 && <5.7
+    , binary >=0.8
     , containers >=0.6.8 && <0.9
     , deepseq >=1.4 && <1.6
     , free-foil

--- a/haskell/free-foil/package.yaml
+++ b/haskell/free-foil/package.yaml
@@ -24,6 +24,7 @@ dependencies:
   base: ">= 4.19 && < 5"
   text: ">= 1.2.3.1 && < 2.2"
   containers: ">= 0.6.8 && < 0.9"  # >= 0.6.8 for Data.IntSet.fromRange
+  binary: ">= 0.8"  # a GHC boot library; used only by Control.Monad.Free.Foil.Binary
   bifunctors: ">= 5.5 && < 5.7"
   template-haskell: ">= 2.21.0.0 && < 2.24"
   deepseq: ">= 1.4 && < 1.6"

--- a/haskell/free-foil/src/Control/Monad/Foil/Internal.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/Internal.hs
@@ -1434,9 +1434,21 @@ type RawScope = IntSet
 -- | \(O(\min(n, W))\).
 -- Generate a fresh raw name that
 -- does not appear in a given raw scope.
+-- The guard keeps allocation out of the negative range: names below zero
+-- are reserved for interned constants, allocated by an explicit policy
+-- ('withFreshIn' at a negative range) and never by this successor. Without
+-- the guard, a scope holding only negative names would hand out the
+-- successor of its maximum, which is a "fresh" name inside the constants'
+-- region and may collide with a constant not in this scope. A scope that
+-- holds 'maxBound' is reported as exhausted rather than wrapped past,
+-- since the wrapped successor lands on an arbitrary small name that may
+-- well be taken.
 rawFreshName :: RawScope -> RawName
-rawFreshName scope | IntSet.null scope = 0
-                   | otherwise = IntSet.findMax scope + 1
+rawFreshName scope
+  | IntSet.null scope = 0
+  | otherwise = case IntSet.findMax scope of
+      m | m == maxBound -> error "rawFreshName: name space exhausted"
+        | otherwise     -> max 0 (m + 1)
 
 -- | An inclusive reservation of a contiguous range of raw names.
 --

--- a/haskell/free-foil/src/Control/Monad/Free/Foil/Binary.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil/Binary.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE UndecidableInstances  #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+-- | 'Binary' instances for the scope-safe syntax: the wire view of a term
+-- is the term itself, raw ids and all.
+--
+-- The instances are deliberately orphans in a module of their own, so that
+-- they are opt-in: importing this module is what brings them into scope,
+-- and nothing else in the library does. (The dependency this costs is
+-- @binary@, a GHC boot library.)
+--
+-- Note that decoding /mints/ scope evidence: a 'Foil.Name' comes back at
+-- whatever scope index the context asks for, and the existential scope
+-- under a binder is chosen arbitrarily. Thus the instances are a trust
+-- boundary, in the sense of 'Control.Monad.Foil.Blocks.checkExtScope'. The
+-- bytes are meaningful only under the discipline of the layer that wrote
+-- them, and that layer is expected to validate what it can on the way in.
+-- In particular, it should resolve the references it made
+-- world-independent, and check that the names it left verbatim lie where
+-- its allocation policy says. The artifact module of @mltt@ in the
+-- free-foil repository is the worked example.
+module Control.Monad.Free.Foil.Binary () where
+
+import           Data.Binary                 (Binary (..))
+import           Data.Binary.Get             (Get, getWord8)
+import           Data.Binary.Put             (putWord8)
+
+import           Control.Monad.Foil.Internal
+import           Control.Monad.Free.Foil     (AST (..), ScopedAST (..))
+
+-- | The raw id and nothing else; see the module documentation for what
+-- decoding trusts.
+instance Binary (Name n) where
+  put (UnsafeName raw) = put raw
+  get = UnsafeName <$> get
+
+-- | See the 'Binary' instance of 'Name'.
+instance Binary (NameBinder n l) where
+  put (UnsafeNameBinder name) = put name
+  get = UnsafeNameBinder <$> get
+
+-- | The two bounds. A range carries no scope index, so nothing is minted:
+-- this instance is layout metadata for the serialising layer.
+instance Binary NameRange where
+  put (NameRange lo hi) = put lo <> put hi
+  get = NameRange <$> get <*> get
+
+-- | The binder and the body, one after the other. Decoding mints the scope
+-- under the binder; see the module documentation.
+instance (forall x y. Binary (binder x y), forall l. Binary (AST binder sig l))
+    => Binary (ScopedAST binder sig n) where
+  put (ScopedAST binder body) = put binder <> put body
+  get = do
+    binder <- get :: Get (binder n n)
+    body <- get
+    pure (ScopedAST binder body)
+
+-- | A tag byte, then the name or the node.
+instance ( forall x y. Binary (binder x y)
+         , forall scope term. (Binary scope, Binary term) => Binary (sig scope term)
+         ) => Binary (AST binder sig n) where
+  put (Var x)     = putWord8 0 <> put x
+  put (Node node) = putWord8 1 <> put node
+  get = getWord8 >>= \case
+    0   -> Var <$> get
+    1   -> Node <$> get
+    tag -> fail ("unknown AST tag " <> show tag)

--- a/haskell/free-foil/src/Control/Monad/Free/Foil/Binary/TH.hs
+++ b/haskell/free-foil/src/Control/Monad/Free/Foil/Binary/TH.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE TemplateHaskell #-}
+-- | Derive the 'Binary' instance a client's pattern (binder) type needs,
+-- alongside the hand-written instances of "Control.Monad.Free.Foil.Binary".
+--
+-- A pattern type is a GADT over two scope indices, so its instance cannot
+-- come from "GHC.Generics". What the deriver writes is the shape one would
+-- write by hand: one tag byte per constructor in declaration order, then
+-- the fields in order. Decoding happens /at the diagonal/, with every
+-- scope index of a constructor instantiated to the same variable, which
+-- any chain of binder indices admits; a single coercion then moves the
+-- result to the requested indices. The coercion mints scope evidence, so a
+-- derived instance is part of the same trust boundary as the library's
+-- own; see the module documentation of "Control.Monad.Free.Foil.Binary".
+module Control.Monad.Free.Foil.Binary.TH (deriveBinaryPattern) where
+
+import           Control.Monad       (unless, zipWithM)
+import           Data.Binary         (Binary (..))
+import           Data.Binary.Get     (Get, getWord8)
+import           Data.Binary.Put     (putWord8)
+import qualified Data.Map            as Map
+import           Language.Haskell.TH
+import           Unsafe.Coerce       (unsafeCoerce)
+
+-- | @'deriveBinaryPattern' ''Pattern@ writes
+-- @instance (Binary p1, …) => Binary (Pattern p1 … n l)@ for a pattern
+-- type of kind @… -> S -> S -> Type@ whose fields are parameters, name
+-- binders, or nested patterns.
+deriveBinaryPattern :: Name -> Q [Dec]
+deriveBinaryPattern tyName = do
+  info <- reify tyName
+  (tvs, cons) <- case info of
+    TyConI (DataD _ _ tvs _ cons _)    -> pure (tvs, cons)
+    TyConI (NewtypeD _ _ tvs _ con _)  -> pure (tvs, [con])
+    _ -> fail ("deriveBinaryPattern: " <> show tyName <> " is not a data type")
+  unless (length tvs >= 2) $
+    fail "deriveBinaryPattern: expected a type of kind ... -> S -> S -> Type"
+  params <- mapM (\i -> newName ("p" <> show (i :: Int))) [1 .. length tvs - 2]
+  nVar <- newName "n"
+  lVar <- newName "l"
+  ctors <- concat <$> mapM flatten cons
+  unless (length ctors <= 256) $
+    fail "deriveBinaryPattern: more than 256 constructors"
+  putClauses <- zipWithM (putClause) [0 ..] ctors
+  getMatches <- zipWithM (getMatch params nVar) [0 ..] ctors
+  tagName <- newName "tag"
+  let headTy = foldl AppT (ConT tyName) (map VarT (params <> [nVar, lVar]))
+      context = [AppT (ConT ''Binary) (VarT p) | p <- params]
+      failMatch = Match WildP
+        (NormalB (AppE (VarE 'fail) (LitE (StringL "unknown pattern tag")))) []
+      getBody = InfixE (Just (VarE 'getWord8)) (VarE '(>>=))
+        (Just (LamE [VarP tagName]
+          (CaseE (VarE tagName) (getMatches <> [failMatch]))))
+  pure
+    [ InstanceD Nothing context (AppT (ConT ''Binary) headTy)
+        [ FunD 'put putClauses
+        , ValD (VarP 'get) (NormalB getBody) []
+        ]
+    ]
+  where
+    flatten (ForallC _ _ con)   = flatten con
+    flatten (GadtC names bts t) = pure [(c, map snd bts, t) | c <- names]
+    flatten _ =
+      fail "deriveBinaryPattern: expected GADT constructors (a pattern's indices vary per constructor)"
+
+    putClause tag (cname, fields, _) = do
+      args <- mapM (\i -> newName ("x" <> show (i :: Int))) [1 .. length fields]
+      let puts = AppE (VarE 'putWord8) (LitE (IntegerL tag))
+                   : [AppE (VarE 'put) (VarE a) | a <- args]
+      pure (Clause [ConP cname [] (map VarP args)]
+                   (NormalB (AppE (VarE 'mconcat) (ListE puts))) [])
+
+    -- Decode at the diagonal: the constructor's own scope variables (the
+    -- result indices and any intermediates) all become @n@, and its
+    -- parameter variables become the instance's parameters. The chain of a
+    -- pattern's indices always admits the diagonal. Each field's 'get' is
+    -- annotated with the substituted type, pinning the intermediates.
+    getMatch params nVar tag (cname, fields, result) = do
+      let (_, resultArgs) = unfoldApps result
+          paramPairs =
+            [ (v, VarT p)
+            | (VarT v, p) <- zip (take (length params) resultArgs) params ]
+          subst = Map.fromList paramPairs
+          substTy t = case t of
+            VarT v    -> Map.findWithDefault (VarT nVar) v subst
+            AppT f x  -> AppT (substTy f) (substTy x)
+            SigT x k  -> SigT (substTy x) k
+            ParensT x -> ParensT (substTy x)
+            _         -> t
+          getField ft = SigE (VarE 'get) (AppT (ConT ''Get) (substTy ft))
+          chain = case fields of
+            [] -> AppE (VarE 'pure) (ConE cname)
+            (f : fs) -> foldl
+              (\acc ft -> InfixE (Just acc) (VarE '(<*>)) (Just (getField ft)))
+              (InfixE (Just (ConE cname)) (VarE '(<$>)) (Just (getField f)))
+              fs
+          diagTy = AppT (ConT ''Get) (substTy result)
+          body = AppE (AppE (VarE 'fmap) (VarE 'unsafeCoerce)) (SigE chain diagTy)
+      pure (Match (LitP (IntegerL tag)) (NormalB body) [])
+
+    unfoldApps = go []
+      where
+        go args (AppT f x) = go (x : args) f
+        go args t          = (t, args)

--- a/haskell/free-foil/test/Control/Monad/Foil/NameRangeSpec.hs
+++ b/haskell/free-foil/test/Control/Monad/Foil/NameRangeSpec.hs
@@ -89,6 +89,21 @@ spec = do
     it "reports an empty range as exhausted" $
       rawFreshNameIn (NameRange 5 4) IntSet.empty `shouldBe` Nothing
 
+  describe "rawFreshName" $ do
+    it "allocates 0 over a scope of negative names only" $
+      Foil.withFreshIn (NameRange (-10) (-1)) Foil.emptyScope $ \bneg ->
+        let scope = Foil.extendScope bneg Foil.emptyScope
+         in Foil.withFresh scope $ \b ->
+              Foil.nameId (Foil.nameOf b) `shouldBe` 0
+
+    prop "stays non-negative and fresh" $
+      forAll (IntSet.filter (/= maxBound) <$> genRawScope) $ \scope ->
+        let x = rawFreshName scope
+         in conjoin
+              [ counterexample "dipped below zero" (x >= 0)
+              , counterexample "not fresh" (not (IntSet.member x scope))
+              ]
+
   describe "withFreshIn" $ do
     it "allocates the low end of an untouched range" $
       Foil.withFreshIn (NameRange 100 199) Foil.emptyScope $ \binder ->

--- a/haskell/mltt/mltt.cabal
+++ b/haskell/mltt/mltt.cabal
@@ -63,6 +63,8 @@ library
       array >=0.5.3.0
     , base >=4.19 && <5
     , bifunctors
+    , binary
+    , bytestring
     , containers
     , deepseq
     , directory
@@ -89,6 +91,8 @@ executable mltt
       array >=0.5.3.0
     , base >=4.19 && <5
     , bifunctors
+    , binary
+    , bytestring
     , containers
     , deepseq
     , directory
@@ -116,6 +120,8 @@ test-suite doctests
       array >=0.5.3.0
     , base >=4.19 && <5
     , bifunctors
+    , binary
+    , bytestring
     , containers
     , deepseq
     , directory
@@ -154,6 +160,8 @@ test-suite spec
       array >=0.5.3.0
     , base >=4.19 && <5
     , bifunctors
+    , binary
+    , bytestring
     , containers
     , deepseq
     , directory

--- a/haskell/mltt/package.yaml
+++ b/haskell/mltt/package.yaml
@@ -36,6 +36,8 @@ dependencies:
   base: ">= 4.19 && < 5"
   text: ">= 1.2.3.1"
   containers:
+  binary:
+  bytestring:
   bifunctors:
   directory:
   filepath:

--- a/haskell/mltt/src/Language/MLTT/Artifact.hs
+++ b/haskell/mltt/src/Language/MLTT/Artifact.hs
@@ -1,42 +1,47 @@
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE GADTs               #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 -- | Serialisation of checked modules.
 --
--- A 'Foil.Name' is an allocation artefact and cannot be written to disk, so a
--- serialised declaration records /qualified spellings/ and is re-interned on
--- load: the artifact stores each declaration's type and value as raw syntax
--- in which every free variable is printed fully qualified (from 'envDisplay')
--- and every bound variable canonically (@l0@, @l1@, …). Loading parses the
--- terms back and converts them against the environment being assembled, so a
--- loaded module is an ordinary 'CheckedModule': it links, and further modules
--- check against it, exactly as if it had just been checked.
+-- A raw name of a /constant/ is a registry artefact. The artifact therefore
+-- records the constants' qualified spellings, and loading judges them once,
+-- at the artifact level ('constantRelocation'). In the usual case every
+-- constant already means here what it meant at check time, and the terms
+-- are used exactly as decoded; no term is walked at all. Where the registry
+-- moved, one total relocation pass touches the references. A loaded module
+-- is an ordinary 'CheckedModule': it links, and further modules check
+-- against it, exactly as if it had just been checked.
 --
 -- What makes the cache valid is recorded alongside the terms:
 --
--- * the module's stripe index at check time, so a run whose registry agrees
---   reconstructs the very same raw names (and one whose registry moved the
---   stripe still loads, with the names landing where the new stripe says);
+-- * the name ranges at check time: the actual names of the module's own
+--   constants, and of its locals. These are ranges rather than a stripe
+--   index, so the artifact does not depend on the loading build's stripe
+--   policy. A run whose registry agrees reconstructs the very same raw
+--   names, and one whose registry moved the reservation still loads, with
+--   the names landing where the new range says. Moreover, the no-overlap
+--   assumption the verbatim terms rest on is checked from the recorded
+--   ranges, never from the terms;
 -- * the content hash of each import at check time, so a changed dependency
 --   is detected and the artifact rejected rather than linked stale.
 --
--- __Loading trusts the artifact's terms__: nothing is re-checked, which is
--- the point of a cache. Integrity comes from the hash chain, and the hash is
--- 'contentHash', a plain FNV-1a over the rendered content — collision
--- resistance enough for a build cache, not for an adversary.
+-- __Loading trusts the artifact's terms__: nothing is re-checked. This
+-- covers the typing, and equally the locals and their scoping. What is
+-- judged is the constants' boundary, and it is judged from the spelling
+-- table alone, not from the terms. Integrity comes from the hash chain,
+-- and the hash is 'contentHash', a plain FNV-1a over the stored content:
+-- collision resistance enough for a build cache, not for an adversary.
 --
--- Two wire-format notes:
---
--- * Bound variables are printed @l\<i\>@ from their raw ids; a program whose
---   fully qualified spelling matches that pattern would need escaping,
---   which this demo does not implement. The ids themselves are canonical:
---   elaboration allocates its binders in 'localRegion', whose content does
---   not depend on what else is in scope, so the same module produces a
---   byte-identical artifact — and hash — whatever world it is checked in.
---
--- * Source positions inside a loaded term point into the artifact text, not
---   the original source.
+-- Terms are stored verbatim ('encodeTerm'). The name layout's sign
+-- invariant is what makes the raw ids meaningful: a negative name is an
+-- interned constant, resolved by spelling on load, and a non-negative one
+-- is a local, canonical by elaboration. Nothing is parsed on load, no
+-- spelling ever needs escaping, and the bytes do not depend on what else
+-- was in scope at check time. Thus the same module produces an identical
+-- artifact, and an identical hash, whatever world it is checked in.
 module Language.MLTT.Artifact (
   ModuleArtifact (..),
   ArtifactDecl (..),
@@ -46,26 +51,40 @@ module Language.MLTT.Artifact (
   makeArtifact,
   loadArtifact,
   loadArtifactAfter,
-  renderArtifact,
-  readArtifact,
+  encodeArtifact,
+  decodeArtifact,
   contentHash,
 ) where
 
+import           Control.Monad             (unless)
 import qualified Control.Monad.Foil        as Foil
+import qualified Control.Monad.Foil.Internal as Foil.Internal
+import           Control.Monad.Free.Foil   (AST (..), ScopedAST (..),
+                                            supportOf)
+import           Control.Monad.Free.Foil.Binary ()
 import qualified Control.Monad.Foil.Blocks as Blocks
+import           Data.Binary               (Binary (..))
+import           Data.Binary.Get           (runGetOrFail)
+import qualified Data.Binary.Get           as Get
+import           Data.Binary.Put           (runPut)
+import qualified Data.Binary.Put           as Put
+import           Data.Bifoldable           (bifoldMap)
+import           Data.Bifunctor            (bimap)
+import           Unsafe.Coerce             (unsafeCoerce)
 import           Data.Bits                 (xor, (.&.))
+import qualified Data.ByteString.Lazy       as BSL
+import qualified Data.ByteString.Lazy.Char8 as BSL8
 import           Data.List                 (foldl')
+import qualified Data.IntMap               as IntMap
 import           Data.Map                  (Map)
+import           GHC.Generics              (Generic)
 import qualified Data.Map                  as Map
-import           Text.Read                 (readEither)
 
-import           Language.MLTT.Eval        (Def (..), desugar)
+import           Language.MLTT.Eval        (Def (..))
 import           Language.MLTT.Impl
 import           Language.MLTT.Impl.Generated
 import           Language.MLTT.Resolve     (Visibility (..), prettyVarIdent)
 import qualified Language.MLTT.Syntax.Abs  as Raw
-import qualified Language.MLTT.Syntax.Lex  as Raw
-import qualified Language.MLTT.Syntax.Par  as Raw
 import           Language.MLTT.Typecheck   (Ctx (..), extend)
 
 -- * The artifact
@@ -73,15 +92,35 @@ import           Language.MLTT.Typecheck   (Ctx (..), extend)
 -- | A checked module, as written to disk.
 data ModuleArtifact = ModuleArtifact
   { artifactModule  :: Raw.VarIdent  -- ^ The module's qualified name.
-  , artifactStripe  :: StripeIndex   -- ^ From the registry, at check time.
+  , artifactConstants :: Foil.NameRange
+      -- ^ The actual names of the module's own constants: the used prefix
+      -- of its reservation, recorded as the range itself. Thus the
+      -- artifact depends neither on the loading build's stripe policy nor
+      -- on the writer's reservation size, and it loads anywhere its names
+      -- actually fit. Note that the range is exactly its declarations,
+      -- which decoding checks.
+  , artifactLocals  :: Foil.NameRange
+      -- ^ The actual range of the stored terms' locals: the names their
+      -- binders bind, not the writer's whole local region. It is recorded
+      -- so that the no-overlap assumption the verbatim terms rest on is a
+      -- checkable fact of the artifact, not a convention shared with the
+      -- writer. It is the actual range so that the check is tight.
   , artifactSource  :: ContentHash   -- ^ Of the module's printed source:
                                      -- what an incremental rebuild compares.
   , artifactImports :: [(Raw.VarIdent, ContentHash)]
       -- ^ Each import, with its content hash at check time.
-  , artifactHash    :: ContentHash   -- ^ Over the declarations below.
+  , artifactHash    :: ContentHash   -- ^ Over the spellings and declarations below.
+  , artifactSpellings :: Map Foil.RawName Raw.VarIdent
+      -- ^ The fully qualified spelling of every constant the stored terms
+      -- reference. There is one table for the whole artifact, since the
+      -- module's declarations largely reference the same imports.
   , artifactDecls   :: [ArtifactDecl] -- ^ In declaration (= allocation) order.
   }
-  deriving (Eq, Show, Read)
+  deriving (Eq, Show, Generic)
+
+-- | Field order from the 'Generic' shape; 'encodeArtifact' adds the
+-- envelope.
+instance Binary ModuleArtifact
 
 -- | One declaration: everything the environment needs to hold for it.
 data ArtifactDecl = ArtifactDecl
@@ -90,34 +129,206 @@ data ArtifactDecl = ArtifactDecl
   , adType       :: StoredTerm
   , adValue      :: StoredTerm
   }
-  deriving (Eq, Show, Read)
+  deriving (Eq, Show, Generic)
 
--- | A term as stored: raw syntax with fully qualified free variables and
--- canonically named bound ones.
-newtype StoredTerm = StoredTerm { storedText :: String }
-  deriving (Eq, Show, Read)
+instance Binary ArtifactDecl
+
+-- | A term as stored: the canonical bytes of the pair of its spelling table
+-- and the term itself ('encodeTerm'). Equality of stored terms is byte
+-- equality, which is what the canonical-artifact property tests.
+newtype StoredTerm = StoredTerm { storedBytes :: BSL.ByteString }
+  deriving (Eq, Show, Generic)
+
+instance Binary StoredTerm
+
+-- | Encode a checked term, verbatim, through the @free-foil-binary@
+-- instances.
+--
+-- The name layout's sign invariant is what makes verbatim enough. A name
+-- below zero is an interned constant, whose spelling the artifact's table
+-- records; note that a term's free variables are exactly its constants,
+-- since a stored declaration is discharged. A non-negative name is a
+-- local, and needs no table: it is canonical already, since elaboration
+-- allocates locals in a region of their own.
+encodeTerm :: Term n -> BSL.ByteString
+encodeTerm t = runPut (put t)
+
+-- | Decode a stored term's bytes: the instances alone, no meaning yet.
+-- Meaning is given per artifact, not per term — see 'constantRelocation'.
+decodeStored :: StoredTerm -> Either ArtifactError (Term n)
+decodeStored (StoredTerm bytes) =
+  case runGetOrFail get bytes of
+    Left (_, _, err) -> Left ("malformed stored term: " <> err)
+    Right (rest, _, term)
+      | not (BSL.null rest) -> Left "malformed stored term: trailing bytes"
+      | otherwise -> Right term
+
+-- | What an artifact's constants need in the loading world, judged once,
+-- from the spelling table alone. 'Nothing' says every constant already has
+-- the id its spelling means here; this is the fast path, on which no term
+-- is walked at all. Otherwise the result is the renaming to apply. Its
+-- domain is a scope of the artifact's world, which no longer exists, so
+-- its index is the caller's phantom.
+--
+-- The module's own constants (table entries inside the recorded range) do
+-- not consult the world: they are being loaded right now, in the same
+-- order they were allocated, so their relocation is the affine shift
+-- between the recorded range and the one this run assigned. Their new
+-- names are thereby minted ahead of their allocation, which loading's
+-- trust covers. An imported constant resolves by its spelling; one this
+-- world does not know is reported.
+constantRelocation
+  :: Foil.NameRange                 -- ^ The recorded range of its own constants.
+  -> Foil.NameRange                 -- ^ The range this run assigned.
+  -> Foil.NameRange                 -- ^ The artifact's recorded locals region.
+  -> Map Foil.RawName Raw.VarIdent  -- ^ The artifact's spelling table.
+  -> Map Raw.VarIdent (Foil.Name n') -- ^ What each spelling means here.
+  -> Either ArtifactError (Maybe (Foil.NameMap old (Foil.Name n')))
+constantRelocation old@(Foil.NameRange oldLo _) (Foil.NameRange newLo _) locals table globals = do
+  entries <- Map.foldrWithKey step (Right []) table
+  pure $
+    if any (\(i, name) -> Foil.nameId name /= i) entries
+      then Just (Foil.Internal.NameMap (IntMap.fromList entries))
+      else Nothing
+  where
+    shift = newLo - oldLo
+    -- Every relocation target must stay out of the locals region: the
+    -- verbatim locals rest on the two never meeting, and this is where the
+    -- assumption is checked — per constant, at the artifact level, never
+    -- per term.
+    step i spelling acc = do
+      rest <- acc
+      name <-
+        if withinRange old i
+          then Right (Foil.Internal.UnsafeName (i + shift))
+          else case Map.lookup spelling globals of
+            Nothing   -> Left ("not in scope: " <> prettyVarIdent spelling)
+            Just name -> Right name
+      if withinRange locals (Foil.nameId name)
+        then Left ("constant " <> prettyVarIdent spelling
+                     <> " would land in the locals region")
+        else pure ((i, name) : rest)
+
+-- | Whether a raw name lies in a range.
+withinRange :: Foil.NameRange -> Foil.RawName -> Bool
+withinRange (Foil.NameRange lo hi) i = lo <= i && i <= hi
+
+-- | Rename every constant reference through the map, moving the term from
+-- the artifact's world into the loading one. This is the restriction to
+-- constants of a general renaming @'Foil.Name' n -> 'Foil.Name' n'@.
+-- 'Foil.sinkabilityProof' embodies the general renaming, but its efficient
+-- implementations degenerate the renaming to a coercion under binders,
+-- which is sound only for inclusions; this walk carries an arbitrary map
+-- through.
+--
+-- The invariant that lets the walk ignore the binders is the sign layout.
+-- Constants live below zero, and a binder binds locals, at or above zero.
+-- Thus no binder can shadow a name in the map's domain, and no local can
+-- be in it, so the map never needs extending under a binder, and locals
+-- and patterns cross by coercion. A constant outside the map (bytes
+-- referencing something the spelling table does not cover) is re-minted
+-- unchanged, trusted like everything else about the term. Note that a map
+-- that is the identity on raw ids would make the whole walk a coercion,
+-- which is why the caller skips it entirely then.
+relocateConstants :: Foil.NameMap n (Foil.Name n') -> Term n -> Term n'
+relocateConstants (Foil.Internal.NameMap moved) = walk
+  where
+    walk :: forall o o'. Term o -> Term o'
+    walk = \case
+      Var x -> case IntMap.lookup (Foil.nameId x) moved of
+        Just new -> Var (Foil.Internal.UnsafeName (Foil.nameId new))
+        Nothing  -> Var (Foil.Internal.UnsafeName (Foil.nameId x))
+      Node sig -> Node (bimap walkScoped walk sig)
+
+    walkScoped :: forall o o'. ScopedTerm o -> ScopedTerm o'
+    walkScoped (ScopedAST pat body) = ScopedAST (unsafeCoerce pat) (walk body)
 
 -- | The 64-bit FNV-1a of some rendered content; see 'contentHash'.
 newtype ContentHash = ContentHash Integer
-  deriving (Eq, Show, Read)
+  deriving (Eq, Show, Generic)
 
--- | What reading or loading an artifact can report: malformed wire text, a
--- stale import hash, or a stored term that no longer re-interns.
+instance Binary ContentHash
+
+-- | What reading or loading an artifact can report: malformed wire bytes, a
+-- stale import hash, or a stored term that no longer resolves.
 type ArtifactError = String
-
--- | Render an artifact for writing. 'readArtifact' is its inverse.
-renderArtifact :: ModuleArtifact -> String
-renderArtifact = show
-
--- | Read an artifact back; reports rather than crashes on malformed input.
-readArtifact :: String -> Either ArtifactError ModuleArtifact
-readArtifact = readEither
 
 -- | FNV-1a over a string, 64 bits. A build-cache checksum, not a defence.
 contentHash :: String -> ContentHash
-contentHash = ContentHash . foldl' step 0xcbf29ce484222325
+contentHash = ContentHash . foldl' step fnvBasis . map fromEnum
   where
-    step h c = ((h `xor` fromIntegral (fromEnum c)) * 0x100000001b3) .&. 0xffffffffffffffff
+    step h c = fnvStep h (fromIntegral c)
+
+-- | The same FNV-1a, over bytes: what the artifact hash uses, so that the
+-- hash covers exactly the stored representation.
+contentHashBytes :: BSL.ByteString -> ContentHash
+contentHashBytes = ContentHash . BSL.foldl' step fnvBasis
+  where
+    step h w = fnvStep h (fromIntegral w)
+
+fnvBasis :: Integer
+fnvBasis = 0xcbf29ce484222325
+
+fnvStep :: Integer -> Integer -> Integer
+fnvStep h x = ((h `xor` x) * 0x100000001b3) .&. 0xffffffffffffffff
+
+-- * The envelope
+
+-- | The first bytes of an artifact file: decoding /is/ the check, so a file
+-- that is not an artifact is reported rather than misread.
+data WireMagic = WireMagic
+
+instance Binary WireMagic where
+  put WireMagic = Put.putLazyByteString magicBytes
+  get = do
+    bytes <- Get.getLazyByteString (BSL.length magicBytes)
+    unless (bytes == magicBytes) (fail "not an MLTT artifact")
+    pure WireMagic
+
+magicBytes :: BSL.ByteString
+magicBytes = BSL8.pack "MLTTA"
+
+-- | Bumped when the format changes shape; decoding any other version fails,
+-- and the cache treats the artifact as absent, so it is rebuilt.
+data WireVersion = WireVersion
+
+instance Binary WireVersion where
+  put WireVersion = put wireVersion
+  get = do
+    version <- get
+    unless (version == wireVersion) $
+      fail ("format version " <> show version
+              <> ", but this build reads version " <> show wireVersion)
+    pure WireVersion
+
+wireVersion :: Word
+wireVersion = 1
+
+-- | Encode an artifact for writing: the envelope, then the derived
+-- instances. 'decodeArtifact' is its inverse.
+encodeArtifact :: ModuleArtifact -> BSL.ByteString
+encodeArtifact a = runPut (put (WireMagic, WireVersion, a))
+
+-- | Decode an artifact; reports rather than crashes on anything that is not
+-- a current-version artifact. Beyond the envelope, the one shape check the
+-- instances cannot express: a spelling-table entry for a non-negative name
+-- would spell a non-constant.
+decodeArtifact :: BSL.ByteString -> Either ArtifactError ModuleArtifact
+decodeArtifact input = case runGetOrFail get input of
+  Left (_, _, err) -> Left ("malformed artifact: " <> err)
+  Right (rest, _, (WireMagic, WireVersion, a))
+    | not (BSL.null rest) -> Left "malformed artifact: trailing bytes"
+    | overlapping (artifactConstants a) (artifactLocals a) ->
+        Left "malformed artifact: the constants and locals regions overlap"
+    | any (withinRange (artifactLocals a)) (Map.keys (artifactSpellings a)) ->
+        Left "malformed artifact: a spelling for a local"
+    | rangeSize (artifactConstants a) /= length (artifactDecls a) ->
+        Left "malformed artifact: the constants range does not match the declarations"
+    | otherwise -> Right a
+  where
+    overlapping (Foil.NameRange lo1 hi1) (Foil.NameRange lo2 hi2) =
+      lo1 <= hi1 && lo2 <= hi2 && lo1 <= hi2 && lo2 <= hi1
+    rangeSize (Foil.NameRange lo hi) = max 0 (hi - lo + 1)
 
 -- * Writing
 
@@ -129,57 +340,82 @@ contentHash = ContentHash . foldl' step 0xcbf29ce484222325
 -- what was visible under which shorter spelling at check time.
 makeArtifact
   :: Raw.VarIdent               -- ^ The module's name.
-  -> StripeIndex                -- ^ From the registry.
+  -> Foil.NameRange             -- ^ Its reservation, from the registry.
   -> ContentHash                -- ^ Of the module's printed source.
   -> [(Raw.VarIdent, ContentHash)] -- ^ Its imports, with their content hashes.
   -> CheckedModule c
   -> ModuleArtifact
-makeArtifact name stripe source imports cm = withCheckedModule cm $ \_ env _ ->
-  let Foil.NameRange lo hi = stripeRange stripe
+makeArtifact name reservation source imports cm = withCheckedModule cm $ \_ env _ ->
+  let Foil.NameRange lo hi = reservation
+      constants = case map Foil.nameId own of
+        [] -> Foil.NameRange lo (lo - 1)   -- empty, by the lo > hi convention
+        ids -> Foil.NameRange (minimum ids) (maximum ids)
+      locals = case concat localIds of
+        [] -> Foil.NameRange 0 (-1)        -- empty likewise
+        ids -> Foil.NameRange (minimum ids) (maximum ids)
       ctx = envCtx env
       own =
         [ x
         | x <- Foil.nameSetToList (Foil.scopeToNameSet (ctxScope ctx))
         , lo <= Foil.nameId x, Foil.nameId x <= hi
         ]
-      decls = map declOf own
-      declOf x = ArtifactDecl
-        { adSpelling   = spelling
-        , adVisibility = if Map.member spelling (envExports env) then Public else Private
-        , adType       = put (Foil.lookupName x (ctxTypes ctx))
-        , adValue      = case getDef (Foil.lookupName x (ctxDefs ctx)) of
-            Just value -> put value
-            Nothing    -> error "impossible: a top-level name with no definition"
-        }
-        where
-          spelling = Foil.lookupName x (envDisplay env)
-      put = StoredTerm . showTermNamed boundName (envDisplay env)
+      (decls, supports, localIds) = unzip3 (map declOf own)
+      -- The module's support: every constant its stored terms reference,
+      -- and only those. Only those, because the spelling table is hashed:
+      -- an unused import must not change the artifact, or content-defined
+      -- early cutoff dies — and a table of everything in scope would also
+      -- differ between build schedules, breaking canonicity.
+      spellings = Map.fromList
+        [ (Foil.nameId x, Foil.lookupName x (envDisplay env))
+        | x <- Foil.nameSetToList (mconcat supports)
+        ]
+      declOf x =
+        let ty = Foil.lookupName x (ctxTypes ctx)
+            value = case getDef (Foil.lookupName x (ctxDefs ctx)) of
+              Just v  -> v
+              Nothing -> error "impossible: a top-level name with no definition"
+            spelling = Foil.lookupName x (envDisplay env)
+         in ( ArtifactDecl
+                { adSpelling   = spelling
+                , adVisibility =
+                    if Map.member spelling (envExports env) then Public else Private
+                , adType       = StoredTerm (encodeTerm ty)
+                , adValue      = StoredTerm (encodeTerm value)
+                }
+            , supportOf ty <> supportOf value
+            , localsOf ty <> localsOf value )
    in ModuleArtifact
         { artifactModule  = name
-        , artifactStripe  = stripe
+        , artifactConstants = constants
+        , artifactLocals  = locals
         , artifactSource  = source
         , artifactImports = imports
-        , artifactHash    = contentHash (concatMap renderDecl decls)
+        , artifactHash    =
+            contentHashBytes (runPut (put spellings <> put decls))
+        , artifactSpellings = spellings
         , artifactDecls   = decls
         }
 
--- | The canonical spelling of a bound variable in an artifact.
-boundName :: Foil.RawName -> Raw.VarIdent
-boundName i = Raw.VarIdent ("l" <> show i)
+-- | The names a term's binders bind: what 'artifactLocals' ranges over.
+-- Note that 'supportOf' cannot see them: they are bound, not free.
+localsOf :: Term n -> [Foil.RawName]
+localsOf = \case
+  Var _    -> []
+  Node sig -> bifoldMap scopedLocals localsOf sig
+  where
+    scopedLocals :: forall m. ScopedTerm m -> [Foil.RawName]
+    scopedLocals (ScopedAST pat body) = patternIds pat <> localsOf body
 
--- | What the content hash covers: everything semantically relevant. The
--- values are included, not only the types, because conversion unfolds
--- definitions, so a changed body changes what dependants compute.
-renderDecl :: ArtifactDecl -> String
-renderDecl d = unwords
-  [ prettyVarIdent (adSpelling d), show (adVisibility d)
-  , storedText (adType d), storedText (adValue d), ";"
-  ]
+    patternIds :: forall m l. Pattern' Raw.BNFC'Position m l -> [Foil.RawName]
+    patternIds = \case
+      PatternWildcard _ -> []
+      PatternVar _ b    -> [Foil.nameId (Foil.nameOf b)]
+      PatternPair _ a b -> patternIds a <> patternIds b
 
 -- * Loading
 
 -- | Load a checked module from its artifact, into an environment holding
--- what its imports export — the same starting point 'checkModule' has.
+-- what its imports export: the same starting point 'checkModule' has.
 --
 -- The load fails if an import's recorded content hash disagrees with the one
 -- supplied, which is how a stale artifact is detected. It does not compare
@@ -196,7 +432,10 @@ loadArtifact
   -> Either ArtifactError (CheckedModule c)
 loadArtifact hashes range env artifact = do
   mapM_ checkImport (artifactImports artifact)
-  go (Blocks.beginBlock range) env' (artifactDecls artifact)
+  relocation <- constantRelocation (artifactConstants artifact) range
+                                   (artifactLocals artifact)
+                                   (artifactSpellings artifact) (envDeclared env')
+  go relocation (Blocks.beginBlock range) env' (artifactDecls artifact)
   where
     checkImport (m, h) = case Map.lookup m hashes of
       Just h' | h' == h -> Right ()
@@ -215,29 +454,40 @@ loadArtifact hashes range env artifact = do
       , envClosedOver = Map.empty
       }
 
-    go :: Foil.DExt c n
-       => Blocks.Block c n -> Env n -> [ArtifactDecl] -> Either ArtifactError (CheckedModule c)
-    go block envN [] =
+    go :: forall old n. Foil.DExt c n
+       => Maybe (Foil.NameMap old (Foil.Name c))
+       -> Blocks.Block c n -> Env n -> [ArtifactDecl] -> Either ArtifactError (CheckedModule c)
+    go _ block envN [] =
       Right (CheckedModule (Blocks.blockExt block)
                            (finishModule (artifactModule artifact) envN)
                            [])
-    go block envN (d : ds) = do
-      ty    <- reintern envN (adType d)
-      value <- reintern envN (adValue d)
+    go relocation block envN (d : ds) = do
+      ty    <- loadTerm relocation (adType d)
+      value <- loadTerm relocation (adValue d)
       Blocks.withFreshInBlock block (ctxScope (envCtx envN)) $ \binder block' ->
         let ctx' = extend (envCtx envN) binder ty (Just value)
             envN' = extendEnv ctx' binder (adSpelling d) (adVisibility d) envN
-         in go block' envN' ds
+         in go relocation block' envN' ds
 
-    -- Parse a stored term and convert it against the environment assembled
-    -- so far: this is the re-interning the wire format promises.
-    reintern :: Foil.Distinct n => Env n -> StoredTerm -> Either ArtifactError (Term n)
-    reintern envN (StoredTerm input) = do
-      raw <- Raw.pTerm (Raw.tokens input)
-      case tryToTerm'In localRegion (ctxScope (envCtx envN)) (envDeclared envN) raw of
-        Left err -> Left ("artifact for " <> prettyVarIdent (artifactModule artifact)
-                            <> ": " <> notInScope err)
-        Right t  -> Right (desugar t)
+    -- The stored term is the checked (hence desugared) one. On the fast
+    -- path it is used exactly as decoded — the phantom index is simply
+    -- taken to be the caller's. Where the registry moved, the term decodes
+    -- at the map's own phantom, relocates into the base world, and sinks to
+    -- the scope at hand.
+    loadTerm :: forall old m. Foil.DExt c m
+             => Maybe (Foil.NameMap old (Foil.Name c)) -> StoredTerm
+             -> Either ArtifactError (Term m)
+    loadTerm relocation stored = case relocation of
+      Nothing -> context (decodeStored stored)
+      Just moved -> do
+        t <- context (decodeStored stored)
+        pure (Foil.sink (relocateConstants moved t))
+      where
+        context :: Either ArtifactError a -> Either ArtifactError a
+        context = either
+          (\err -> Left ("artifact for " <> prettyVarIdent (artifactModule artifact)
+                            <> ": " <> err))
+          Right
 
 -- | Load a module from its artifact into the environment of an already
 -- loaded (or checked) unit, composing the evidence: the load-side mirror of

--- a/haskell/mltt/src/Language/MLTT/Build.hs
+++ b/haskell/mltt/src/Language/MLTT/Build.hs
@@ -51,6 +51,8 @@ import           Control.Exception        (evaluate)
 import           Control.Monad            (foldM, forM, forM_, unless, when)
 import qualified Control.Monad.Foil       as Foil
 import qualified Control.Monad.Foil.Blocks as Blocks
+import qualified Data.ByteString          as BS
+import qualified Data.ByteString.Lazy     as BSL
 import           Data.Char                (isSpace)
 import           Data.Function            (on)
 import           Data.Functor.Compose     (Compose (..))
@@ -201,7 +203,7 @@ gatherArtifacts dir env = go [] ([], Map.empty)
                           <> ": not in this session's world, and no artifact at "
                           <> artifactPath name))
         else either (\e -> Left ("artifact for " <> prettyVarIdent name <> ": " <> e)) Right
-               . readArtifact <$> readFile (artifactPath name)
+               . decodeArtifact . BSL.fromStrict <$> BS.readFile (artifactPath name)
 
     go trail acc@(loads, hashes) name
       | name `elem` trail =
@@ -272,7 +274,7 @@ loadImports hashes artifacts name (Repl me) =
               <> [Imported (renderVarIdent name)] )
   where
     step (Importing block env view) a = do
-      cm <- loadArtifact hashes (stripeRange (artifactStripe a)) env a
+      cm <- loadArtifact hashes (artifactConstants a) env a
       withCheckedModule cm $ \ext env' _ ->
         case Blocks.resumeBlock (Blocks.blockRange block)
                (Blocks.composeExtWithin (Blocks.blockExt block) ext) of
@@ -429,7 +431,8 @@ buildModulesWith mode cacheDir modules k =
         Just dir -> do
           exists <- doesFileExist (path dir)
           if exists
-            then either (const Nothing) Just . readArtifact <$> readFile (path dir)
+            then either (const Nothing) Just . decodeArtifact . BSL.fromStrict
+                   <$> BS.readFile (path dir)
             else pure Nothing
       case cached of
         Just a
@@ -438,11 +441,11 @@ buildModulesWith mode cacheDir modules k =
           -> pure (cm, a, [LoadedModule (renderVarIdent name)])
         _ -> do
           let cm = checkModule range env m
-              a  = makeArtifact name idx source importHashes cm
+              a  = makeArtifact name range source importHashes cm
               rs = resultsOf cm
           forM_ cacheDir $ \dir ->
             when (succeeded rs) $
-              writeFile (path dir) (renderArtifact a)
+              BSL.writeFile (path dir) (encodeArtifact a)
           pure (cm, a, rs)
 
 -- | Group modules, already in topological order, into dependency waves: a

--- a/haskell/mltt/src/Language/MLTT/Impl.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl.hs
@@ -45,6 +45,7 @@
 module Language.MLTT.Impl where
 
 import           Control.DeepSeq              (NFData)
+import           Data.Binary                  (Binary)
 import           Control.Monad                (foldM)
 import qualified Control.Monad.Foil           as Foil
 import qualified Control.Monad.Foil.Blocks    as Blocks
@@ -155,8 +156,8 @@ newtype RenderedName = RenderedName { renderedName :: String }
   deriving newtype (Eq, Show, IsString, NFData)
 
 -- | A term as shown to the user, printed by 'display'. Distinct from
--- 'StoredTerm' in "Language.MLTT.Artifact", which is printed for reading
--- back rather than for the user.
+-- 'StoredTerm' in "Language.MLTT.Artifact", which keeps the term's bytes
+-- for loading rather than prose for the user.
 newtype RenderedTerm = RenderedTerm { renderedTerm :: String }
   deriving newtype (Eq, Show, IsString, NFData)
 
@@ -258,44 +259,46 @@ moduleDecls :: Raw.Module -> [Raw.Decl]
 moduleDecls (Raw.AModule _ _ _ _ decls) = decls
 
 -- * Name layout
+--
+-- $namelayout
+-- The allocators never cross zero. Module declarations, the interned
+-- constants, live in stripes /below/ zero; everything term-internal lives
+-- at or above it; and a constant is recognised by its sign. Thus the two
+-- halves can never collide, by construction, which is what the wire
+-- format's verbatim locals and the linker's disjointness both rest on.
+-- On the other side, free-foil's successor allocator is guarded to never
+-- dip below zero, so a transient name minted against a scope of constants
+-- stays out of their region.
 
 -- | How many top-level names a module may declare.
 stripeSize :: Int
 stripeSize = 0x100000
 
--- | Where the first stripe starts. Below it lies 'localRegion'.
-firstStripeBase :: Foil.RawName
-firstStripeBase = stripeSize
-
--- | The region module parameters and elaboration-time binders live in.
+-- | The region module parameters and elaboration-time binders live in: every
+-- non-negative name, now that the stripes lie below zero.
 --
--- It lies below every stripe, so nothing here can collide with a
--- declaration's name, and the indices stay small — a discharged type prints
--- as @Π (x0 : 𝕌) → …@ however many declarations precede it. More
--- importantly, allocation inside the region depends only on the region's own
--- content, so elaborating a declaration produces the same term whatever else
--- the ambient scope holds: elaborated terms, and hence artifacts and their
--- hashes, are canonical across worlds.
+-- Nothing here can collide with a declaration's name, and the indices stay
+-- small: a discharged type prints as @Π (x0 : 𝕌) → …@ however many
+-- declarations precede it. More importantly, allocation inside the region
+-- depends only on the region's own content, so elaborating a declaration
+-- produces the same term whatever else the ambient scope holds. Thus
+-- elaborated terms, and hence artifacts and their hashes, are canonical
+-- across worlds.
 --
--- The region's budget is spent on syntax, not on computation. Evaluation and
--- type checking allocate their transient names at the whole scope's
--- successor, above every stripe, and nothing rests on those; what lands here
--- is one name per binder /written/ in the declaration being elaborated, plus
--- the parameters, and the region resets between declarations, since
--- elaboration binders live inside terms and never enter the module's scope.
--- So the occupancy bound is the source size of one declaration against a
--- budget of \(2^{20}\). Were it ever exhausted, 'Foil.withFreshIn' fails
--- loudly rather than colliding: the size is a liveness constant, not a
--- soundness assumption, and widening the region relative to the stripes is a
--- policy change confined to these constants.
+-- What lands here is one name per binder /written/ in the declaration being
+-- elaborated, plus the parameters, and the region resets between
+-- declarations, since elaboration binders live inside terms and never enter
+-- the module's scope. Evaluation and type checking also mint their
+-- transient names here (the guarded successor allocates at the region's
+-- occupied top), and nothing rests on those.
 localRegion :: Foil.NameRange
-localRegion = Foil.NameRange 0 (firstStripeBase - 1)
+localRegion = Foil.NameRange 0 maxBound
 
 -- | A stripe's position in the registry: which run of 'stripeSize' names a
 -- module draws from. Its own type, so that a stripe index cannot be confused
 -- with a name, a count, or an offset.
 newtype StripeIndex = StripeIndex Int
-  deriving (Eq, Ord, Show, Read)
+  deriving newtype (Eq, Ord, Show, Read, Binary)
 
 -- | Which stripe each module's declarations live in.
 --
@@ -320,11 +323,13 @@ registerModule name registry = case Map.lookup name registry of
   Nothing -> let i = StripeIndex (Map.size registry)
               in (Map.insert name i registry, stripeRange i)
 
--- | Stripe @i@ is the @i@-th run of 'stripeSize' names above 'firstStripeBase'.
+-- | Stripe @i@ is the @i@-th run of 'stripeSize' names below zero, counting
+-- downwards, so stripe 0 is @[-stripeSize .. -1]@. Within a stripe,
+-- allocation still ascends, so declaration order is ascending name order.
 stripeRange :: StripeIndex -> Foil.NameRange
-stripeRange (StripeIndex i) = Foil.NameRange lo (lo + stripeSize - 1)
+stripeRange (StripeIndex i) = Foil.NameRange (hi - stripeSize + 1) hi
   where
-    lo = firstStripeBase + i * stripeSize
+    hi = negate (i * stripeSize) - 1
 
 -- * Interpreting a program
 

--- a/haskell/mltt/src/Language/MLTT/Impl/Generated.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl/Generated.hs
@@ -26,10 +26,13 @@
 module Language.MLTT.Impl.Generated where
 
 import           Control.Monad.Free.Foil                 (convertFromASTWith)
+import           Control.Monad.Free.Foil.Binary          ()
+import           Control.Monad.Free.Foil.Binary.TH       (deriveBinaryPattern)
 import           Control.Monad.Free.Foil.TH.MkFreeFoil
 import qualified Control.Monad.Foil                    as Foil
 import           Data.Bifunctor.TH
 import qualified Data.Map                              as Map
+import           Data.Binary                           (Binary (..))
 import           Data.String                           (IsString (..))
 import           Data.ZipMatchK
 import           Data.ZipMatchK.TH                     (deriveZipMatchK2)
@@ -57,6 +60,7 @@ mkFreeFoil mlttConfig
 deriveGenericK ''Term'Sig
 deriveGenericK ''Pattern'
 
+
 deriveBifunctor ''Term'Sig
 deriveBifoldable ''Term'Sig
 deriveBitraversable ''Term'Sig
@@ -74,6 +78,19 @@ instance ZipMatchK Raw.BNFC'Position where zipMatchWithK = zipMatchViaChooseLeft
 -- matching terms is most of what a type checker does, and the generic instance
 -- reflects a node into its "Generics.Kind" representation on every comparison.
 deriveZipMatchK2 ''Term'Sig
+
+-- | A spelling on the wire is its string.
+instance Binary Raw.VarIdent
+
+-- | The signature's own 'Binary': tags and field order from 'GHC.Generics.Generic',
+-- which 'mkFreeFoil' derives for every signature.
+instance (Binary a, Binary s, Binary t) => Binary (Term'Sig a s t)
+
+-- | Tags, positions, binders. The scope indices are fabricated on
+-- decoding, which is why this is derived by the library's own deriver
+-- rather than by "GHC.Generics"; the artifact layer checks the ranges the
+-- names lie in on the way in.
+deriveBinaryPattern ''Pattern'
 
 -- | Two patterns are unified by their binders, in order.
 --

--- a/haskell/mltt/src/Language/MLTT/Resolve.hs
+++ b/haskell/mltt/src/Language/MLTT/Resolve.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 -- | Name resolution: which surface spellings denote which declarations.
 --
 -- Nothing in this module mentions a scope, a 'Control.Monad.Foil.Name', or the
@@ -33,10 +34,12 @@
 --   where @NarrowToUnit@ runs before @ElaborateUnit@.
 module Language.MLTT.Resolve where
 
+import           Data.Binary              (Binary)
 import           Data.List                (inits, intercalate, stripPrefix)
 import           Data.Map                 (Map)
 import qualified Data.Map                 as Map
 import           Data.Maybe               (mapMaybe)
+import           GHC.Generics             (Generic)
 import qualified Language.MLTT.Syntax.Abs as Raw
 
 -- $setup
@@ -154,7 +157,10 @@ data Visibility
   | Private
     -- ^ Not exported. An importing module cannot /name/ it — and can still
     -- /reduce/ through it, since withholding a spelling touches no term.
-  deriving (Eq, Show, Read)
+  deriving (Eq, Show, Read, Generic)
+
+-- | One tag byte, from the 'Generic' shape.
+instance Binary Visibility
 
 -- | Add a declaration to what a module exports, if it is public.
 --

--- a/haskell/mltt/test/Language/MLTT/ArtifactSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ArtifactSpec.hs
@@ -13,6 +13,8 @@ import           Data.Map                     (Map)
 import qualified Data.Map                     as Map
 import           Test.Hspec
 
+import qualified Data.ByteString.Lazy.Char8   as BSL8
+
 import           Language.MLTT.Artifact
 import           Language.MLTT.Impl
 import           Language.MLTT.Impl.Generated (SourceText,
@@ -61,7 +63,7 @@ artifactsOf = go (0 :: Int) Map.empty emptyEnv
             [ (x, artifactHash (acc Map.! x))
             | Raw.AnImport _ x <- moduleImports m ]
           cm = checkModule (stripeRange (StripeIndex i)) env m
-          a  = makeArtifact (moduleName m) (StripeIndex i)
+          a  = makeArtifact (moduleName m) (stripeRange (StripeIndex i))
                  (contentHash (Raw.printTree m)) importHashes cm
        in withCheckedModule cm $ \_ env' results ->
             if succeeded results
@@ -86,11 +88,25 @@ declaredIds cm = withCheckedModule cm $ \_ env _ ->
 spec :: Spec
 spec = do
   describe "the wire format" $ do
-    it "round-trips through render and read" $
-      readArtifact (renderArtifact (art "S")) `shouldBe` Right (art "S")
+    it "round-trips through encode and decode" $
+      decodeArtifact (encodeArtifact (art "S")) `shouldBe` Right (art "S")
 
     it "stores fully qualified spellings, not names" $
       map adSpelling (artifactDecls (art "S")) `shouldBe` ["s", "sbase"]
+
+    it "rejects bytes that are not an artifact" $
+      case decodeArtifact (BSL8.pack "garbage, not an artifact") of
+        Left err -> err `shouldContain` "not an MLTT artifact"
+        Right _  -> expectationFailure "decoded garbage"
+
+    it "rejects an artifact from another format version" $
+      -- The version is the 8-byte word after the 5-byte magic; bump its
+      -- last byte.
+      let bytes = encodeArtifact (art "P")
+          bumped = BSL8.concat [BSL8.take 12 bytes, "\STX", BSL8.drop 13 bytes]
+       in case decodeArtifact bumped of
+            Left err -> err `shouldContain` "version 2"
+            Right _  -> expectationFailure "decoded a mislabelled version" 
 
   describe "loading" $ do
     it "reconstructs the very names the check allocated" $
@@ -137,7 +153,7 @@ spec = do
       -- artifacts, and hence hashes, are what let a cache survive changes
       -- elsewhere in the module graph.
       withCheckedModule (checkModule (stripeRange (StripeIndex 0)) emptyEnv mP) $ \_ envP _ ->
-        makeArtifact (moduleName mS) (StripeIndex 3)
+        makeArtifact (moduleName mS) (stripeRange (StripeIndex 3))
             (contentHash (Raw.printTree mS))
             [(moduleName mP, artifactHash (art "P"))]
             (checkModule (stripeRange (StripeIndex 3)) envP mS)
@@ -148,7 +164,7 @@ spec = do
             cmP <- loadArtifact Map.empty (stripeRange (StripeIndex 0)) emptyEnv (art "P")
             withCheckedModule cmP $ \_ envP _ -> do
               cmS <- loadArtifact (hashesOf ["P"]) (stripeRange (StripeIndex 3)) envP (art "S")
-              Right (makeArtifact (moduleName mS) (StripeIndex 3)
+              Right (makeArtifact (moduleName mS) (stripeRange (StripeIndex 3))
                        (contentHash (Raw.printTree mS))
                        [(moduleName mP, artifactHash (art "P"))] cmS)
        in roundTrip `shouldBe` Right (art "S")

--- a/haskell/mltt/test/Language/MLTT/LinkSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/LinkSpec.hs
@@ -110,8 +110,8 @@ spec = do
     it "numbers a stripe's declarations from its base, in order" $
       withCheckedModule (checkModule (stripeRange (StripeIndex 0)) emptyEnv mI) $ \_ envI _ ->
         declaredIds (checkModule (stripeRange (StripeIndex 1)) envI mA) `shouldBe`
-          [ (Raw.VarIdent "a", firstStripeBase + stripeSize)
-          , (Raw.VarIdent "base", firstStripeBase)
+          [ (Raw.VarIdent "a", Foil.nameRangeLo (stripeRange (StripeIndex 1)))
+          , (Raw.VarIdent "base", Foil.nameRangeLo (stripeRange (StripeIndex 0)))
           ]
 
     it "gives a module the same names whatever else was checked before" $


### PR DESCRIPTION
Artifacts are now binary, and what is stored is the checked term itself, not a print of it. Getting there made the name layout adopt the never-cross-zero invariant. Four commits:

1. free-foil: `Control.Monad.Free.Foil.Binary`, opt-in `Binary` instances for `Name`, `NameBinder`, `AST` and `ScopedAST` (the cost is `binary`, a GHC boot library), plus a TH deriver for the client's pattern GADT, which generics cannot reach. Decoding mints scope evidence, so the module documents itself as a trust boundary, like `checkExtScope`.
2. free-foil: `rawFreshName` never dips below zero (names there are reserved for interned constants) and reports exhaustion instead of wrapping past `maxBound`; new properties pin the sign boundary, since `sink` rests on the allocator.
3. mltt: module stripes live below zero and locals at or above, so a constant is recognised by its sign and the two can never collide.
4. mltt: an artifact stores its terms verbatim, one spelling table for the constants they reference, and its actual name ranges. Loading has a fast path — registry agrees, terms used exactly as decoded, nothing walked — and otherwise one total relocation pass: own constants by the affine stripe shift, imports by spelling. All checks are artifact-level: overlapping ranges, a spelling for a local, a range/declaration-count mismatch, a constant relocated into the locals.

Note that a large part of `Artifact.hs` mentions nothing mltt-specific: the spelling table, the range metadata and its checks, `constantRelocation`, `relocateConstants` and `localsOf` are generic over an `AST binder sig` up to a handful of concrete pattern matches. A next PR moves that part into free-foil, so any client's terms serialise this way, not just mltt's.

```
$ mltt --cache=.mltt-cache examples/modules.mltt
$ head -c 5 .mltt-cache/Prelude.mltta
MLTTA
```