### PR TITLE
MLTT: named telescopes, declared once and included by several modules

### DIFF
--- a/haskell/mltt/README.md
+++ b/haskell/mltt/README.md
@@ -195,13 +195,56 @@ definition rather than the parameters of its module.
 **Discharge is where the demo needs scope restriction rather than extension.**
 Checking happens in the scope the parameters extend the module's scope to, and
 the result has to come back, because the module's scope is where its exports
-live and where the next module starts. `Language.MLTT.Telescope` walks the
-parameters from the inside out and, at each one, asks free-foil's `unsinkAST`
-whether the term can do without it: if it can, the parameter is dropped; if it
-cannot, it is abstracted over with `Π` for the type and `λ` for the value. So
-the used set is not declared and believed, and not computed by a separate
-analysis either — it is whatever restriction turns out to reject, and the
-upward closure follows from asking about one parameter at a time.
+live and where the next module starts. `Language.MLTT.Telescope` takes the
+support of the type and of the value, once each, and closes that set under the
+parameter types: keeping `(x : A)` puts `A` into it, and one pass from the
+inside out settles that, since a parameter's type mentions only the parameters
+before it. Free-foil's `withThinnedNameBinderList` then cuts the chain of
+binders down to the closed set in one step, and the abstractions are rebuilt
+along the thinned chain, restricting each kept parameter type and the body into
+it with `unsinkAST`. So the used set is not declared and believed, and the term
+is walked a fixed number of times rather than once per parameter, which asking
+`unsinkAST` at every parameter in turn would do.
+
+## Named telescopes and `include`
+
+A parameter block can be declared once and reused. A `telescope` declaration is
+a unit of its own, beside the modules, and it binds nothing: what it names is a
+module header and not a term.
+
+```
+telescope Monoid (A : 𝕌) (unit : A) (mul : A → A → A)
+
+module CommMonoid include Monoid
+def square : A → A := λ x ⇒ mul x x
+
+module Group include Monoid (inv : A → A)
+def undo : A → A := λ x ⇒ mul x (inv x)
+```
+
+The included fields come first in the including module's telescope, before the
+parameters it declares itself, and one of its own may mention them: `inv : A →
+A` above resolves only because `A` came from `Monoid`. Everything downstream is
+unchanged, so `undo` is discharged over `(A, mul, inv)` exactly as if the three
+had been written out.
+
+An include is resolved before the module is checked, so what reaches the checker
+is an ordinary parametrised module. That is also what makes an include behave
+like an import for the cache: a module's content hash is taken over its resolved
+header, so changing a telescope rebuilds every module that includes it.
+
+A telescope is elaborated afresh in each including module, so two includers share
+nothing but the source they were written in. Instantiation is application: what
+leaves an including module is a closed constant, and there is no `interpretation`
+command because there is nothing for one to do.
+
+Internally the parameters of a module are a labelled telescope, which is a
+free-foil *pattern* with a label and a payload per binder. It is written out in
+`Language.MLTT.Telescope`, with `CoSinkable` and `UnifiablePattern` by hand, so
+that scope extension, the names of a block and α-equivalence of two blocks all
+come from the library rather than from the demo. Its Haddock records what those
+instances need that the pattern interface does not offer — a payload has to be
+carried into the ambient scope, and `withPattern` exposes no renaming for it.
 
 ## Running it
 
@@ -230,7 +273,7 @@ compute id 𝟙 tt
 | `Language.MLTT.Eval` | Reduction: pattern matching as a substitution, `whnf`, `nf`, `conv`, and the desugaring of `→` and `×`. |
 | `Language.MLTT.Typecheck` | A bidirectional type checker. |
 | `Language.MLTT.Resolve` | Name resolution: paths, name tables, `open`, and the free identifiers of a raw term. Deliberately free of any dependency on the foil. |
-| `Language.MLTT.Telescope` | Module parameters: the telescope they form, discharge over the ones a declaration uses, and the check of an `over` clause against that set. |
+| `Language.MLTT.Telescope` | The labelled telescope, a foil pattern with a label and a payload per binder; module parameters as an instance of it, discharge over the fields a declaration uses, and the check of an `over` clause against that set. |
 | `Language.MLTT.Impl` | The interpreter: build order, modules, declarations, the growing top-level scope, and printing. |
 
 Two things are worth reading for the design rather than for the type theory.

--- a/haskell/mltt/README.md
+++ b/haskell/mltt/README.md
@@ -67,9 +67,9 @@ waiting to be filled here.
   never printed; `let` substitutes rather than sharing; `conv` normalises both
   sides in full. Nothing here has been measured.
 
-Named telescopes, interned qualified names, separate checking with linking, and
-serialisation are not in this list. They are not out of scope — they are what
-comes next, and what is here was built to carry them.
+Refinement of a telescope and interned qualified names are not in this list.
+They are not out of scope: they are what comes next, and what is here was built
+to carry them.
 
 ## The module layer
 
@@ -245,6 +245,17 @@ that scope extension, the names of a block and α-equivalence of two blocks all
 come from the library rather than from the demo. Its Haddock records what those
 instances need that the pattern interface does not offer — a payload has to be
 carried into the ambient scope, and `withPattern` exposes no renaming for it.
+
+The idea is not new here. The framing followed is Jon Sterling's, in the
+[Pterodactyl worklog](https://www.jonmsterling.com/01HC/), where a theory
+expression denotes a telescope and refining a field leaves the remaining fields
+as a telescope again, and that framing inherits in turn. Telescopes are
+[de Bruijn's](<https://doi.org/10.1016/0890-5401(91)90066-B>), and labelling
+their fields, so that a block can be declared once and projected from, is what
+[dependent record types](https://doi.org/10.1007/s001650200018) are, with
+[manifest fields](https://doi.org/10.1007/978-3-642-02444-3_15) for the refined
+case, which is not implemented here. What is new is only that the telescope is a
+scope-safe pattern rather than a construction on raw syntax.
 
 ## Running it
 

--- a/haskell/mltt/README.md
+++ b/haskell/mltt/README.md
@@ -246,6 +246,15 @@ come from the library rather than from the demo. Its Haddock records what those
 instances need that the pattern interface does not offer — a payload has to be
 carried into the ambient scope, and `withPattern` exposes no renaming for it.
 
+`examples/theories.mltt` puts the layer to work: a `Monoid` telescope carrying
+its associativity law, a lemma proved once from that law, and the Church
+numerals under addition as an instance that discharges the law by `refl`, since
+both sides of associativity normalise to the same term. Using the lemma at the
+instance is then application, and no command registers anything anywhere. The
+unit laws are left out of the telescope deliberately: `plus zero n` normalises
+to `λ A ⇒ λ f ⇒ λ x ⇒ n A f x` and stops one η-contraction short of `n`, and
+conversion here has no η, so no instance could prove one.
+
 The idea is not new here. The framing followed is Jon Sterling's, in the
 [Pterodactyl worklog](https://www.jonmsterling.com/01HC/), where a theory
 expression denotes a telescope and refining a field leaves the remaining fields

--- a/haskell/mltt/examples/telescopes.mltt
+++ b/haskell/mltt/examples/telescopes.mltt
@@ -1,0 +1,47 @@
+-- Named telescopes: a block of module parameters declared once and included
+-- by several modules.
+--
+-- A `telescope` declaration names a parameter block. It is a unit of its own,
+-- beside the modules, and it binds nothing: what it names is a module header
+-- and not a term. A module `include`s it, and the included fields come first
+-- in that module's parameter telescope, before the parameters it declares
+-- itself. Nothing downstream changes, and in particular discharge does not:
+-- every declaration still leaves its module abstracted over exactly the fields
+-- it uses, included or own.
+
+telescope Monoid (A : 𝕌) (unit : A) (mul : A → A → A)
+
+-- The same three fields, without writing them again. An `over` clause names
+-- included fields exactly as it names a module's own.
+module CommMonoid include Monoid
+def square over (A, mul) : A → A := λ x ⇒ mul x x
+def neutral over (A, unit) : A := unit
+
+-- A module may declare parameters of its own after the ones it includes, and
+-- their types may mention the included fields: an include is a prefix of one
+-- telescope and not a block beside it. Here `inv`'s type mentions `A`, which
+-- came from `Monoid`.
+module Group include Monoid (inv : A → A)
+def undo over (A, mul, inv) : A → A := λ x ⇒ mul x (inv x)
+def unitInverse over (A, unit, inv) : A := inv unit
+
+-- The two modules include the same telescope and are otherwise unrelated: the
+-- telescope is elaborated afresh in each, so nothing is shared between them
+-- but the source it was written in.
+module Client
+import CommMonoid
+import Group
+
+-- Instantiation is application. A declaration that left an including module is
+-- an ordinary closed constant, so there is nothing to interpret and no command
+-- for interpreting it.
+compute square 𝟙 (λ x ⇒ λ y ⇒ x) tt
+compute neutral 𝟙 tt
+compute undo 𝟙 (λ x ⇒ λ y ⇒ x) (λ x ⇒ x) tt
+compute unitInverse 𝟙 tt (λ x ⇒ x)
+
+-- The discharged types say which fields each declaration took, in telescope
+-- order, with the included ones first.
+check square : Π (A : 𝕌) → Π (mul : A → A → A) → A → A
+check undo : Π (A : 𝕌) → Π (mul : A → A → A) → Π (inv : A → A) → A → A
+check unitInverse : Π (A : 𝕌) → Π (unit : A) → Π (inv : A → A) → A

--- a/haskell/mltt/examples/theories.mltt
+++ b/haskell/mltt/examples/theories.mltt
@@ -1,0 +1,87 @@
+-- A small library of theories, one instance, and a lemma applied at it.
+--
+-- This is the demo the module layer was built for. A theory is a named
+-- telescope: its fields are a carrier, the operations on it, and the laws they
+-- satisfy, all in one dependent block. A module includes the theory to work in
+-- it, and every declaration leaves that module discharged over the fields it
+-- used. An instance is then nothing but a module that supplies values for those
+-- fields, and using a theory's lemma at an instance is application. There is no
+-- `interpretation` command here, and nothing for one to do.
+
+telescope Monoid
+  (A : 𝕌)
+  (unit : A)
+  (mul : A → A → A)
+  (assoc : Π (x : A) → Π (y : A) → Π (z : A) → Id(A, mul (mul x y) z, mul x (mul y z)))
+
+-- The unit laws are missing on purpose, and it is worth saying why. Stating
+-- `Π (x : A) → Id(A, mul unit x, x)` is fine; what no instance below could then
+-- do is prove it. Conversion here normalises both sides and compares them, with
+-- no η, so `plus zero n` reduces to `λ A ⇒ λ f ⇒ λ x ⇒ n A f x` and stops one
+-- η-contraction short of `n`. Associativity needs no η and holds on the nose,
+-- which is why it is the law the demo carries. This is a limitation of the demo
+-- language's conversion, not of telescopes.
+
+-- Two theories over the same block, declared once. `Group` adds a field of its
+-- own, and its type may mention the included ones.
+module CommMonoid include Monoid
+def swapped : A → A → A := λ x ⇒ λ y ⇒ mul y x
+
+module Group include Monoid (inv : A → A)
+def undo : A → A := λ x ⇒ mul x (inv x)
+
+-- * A lemma, proved once in the theory
+
+-- Everything here is checked with the fields in scope, so it reads as ordinary
+-- mathematics, and leaves the module closed over what it used and no more.
+module MonoidTheory include Monoid
+
+-- Uses `A` and `mul`. Not `assoc`, and not `unit`.
+def square over (A, mul) : A → A := λ x ⇒ mul x x
+
+-- Uses the law, so it is discharged over `assoc` as well. Note that the
+-- statement is about `square`, and the proof is the law at one argument
+-- repeated: `square x` unfolds to `mul x x`, so `assoc x x x` already has the
+-- type wanted.
+def squareAssoc over (A, mul, assoc)
+  : Π (x : A) → Id(A, mul (square x) x, mul x (square x))
+  := λ x ⇒ assoc x x x
+
+-- * An instance
+
+-- The naturals as Church numerals, which is as much data as a type theory with
+-- no data declarations can offer.
+module Church
+def Nat : 𝕌 := Π (A : 𝕌) → (A → A) → A → A
+def zero : Nat := λ A ⇒ λ f ⇒ λ x ⇒ x
+def succ : Nat → Nat := λ n ⇒ λ A ⇒ λ f ⇒ λ x ⇒ f (n A f x)
+def plus : Nat → Nat → Nat := λ m ⇒ λ n ⇒ λ A ⇒ λ f ⇒ λ x ⇒ m A f (n A f x)
+
+def one : Nat := succ zero
+def two : Nat := succ one
+def three : Nat := succ two
+
+-- Both sides of associativity normalise to the same term, for variables and
+-- not merely for closed numerals, so the instance discharges the law by `refl`.
+def plusAssoc
+  : Π (a : Nat) → Π (b : Nat) → Π (c : Nat) → Id(Nat, plus (plus a b) c, plus a (plus b c))
+  := λ a ⇒ λ b ⇒ λ c ⇒ refl (plus (plus a b) c)
+
+-- * Using the theory at the instance
+
+module Client
+import MonoidTheory
+import Church
+
+-- Instantiation is application: `square` was closed over `(A, mul)`, so it is
+-- applied to a carrier and an operation, and nothing had to be registered
+-- anywhere for this to be allowed.
+compute square Nat plus two
+
+-- `squareAssoc` was closed over `(A, mul, assoc)`, so the instance's own proof
+-- is the third argument. What comes back is the lemma at the naturals.
+check squareAssoc Nat plus plusAssoc
+  : Π (x : Nat) → Id(Nat, plus (plus x x) x, plus x (plus x x))
+
+-- A theory's lemma is a term like any other, so it applies at an element.
+compute squareAssoc Nat plus plusAssoc three

--- a/haskell/mltt/grammar/MLTT/Syntax.cf
+++ b/haskell/mltt/grammar/MLTT/Syntax.cf
@@ -24,18 +24,34 @@ layout "where" ;
 -- "Language.MLTT.Resolve".
 token VarIdent letter (letter | digit | '_' | '\'' | '.')* ;
 
--- * Modules
+-- * Units
 
--- A program is a sequence of modules. Normally each one is its own file, but
--- putting several in one file is convenient for tests and for a one-file demo.
-AProgram. Program ::= [Module] ;
-terminator Module "" ;
+-- A program is a sequence of units: modules, and the telescopes they include.
+-- Normally each unit is its own file, but putting several in one file is
+-- convenient for tests and for a one-file demo.
+AProgram. Program ::= [Unit] ;
+terminator Unit "" ;
+
+UnitModule.    Unit ::= Module ;
+UnitTelescope. Unit ::= TelescopeDecl ;
 
 -- A module may take parameters. Every declaration inside it is checked with
 -- the parameters in scope, and is then discharged over exactly the ones it
 -- turns out to use, so a client applies it to those and to no others. See
 -- "Language.MLTT.Telescope".
-AModule.  Module ::= "module" VarIdent [Param] ";" [Import] [Decl] ;
+--
+-- An `include` clause takes the parameters of a named telescope, so that a
+-- block of parameters can be declared once and reused. The includes come
+-- first, in order, and the module's own parameters follow them.
+AModule.  Module ::= "module" VarIdent [Include] [Param] ";" [Import] [Decl] ;
+
+AnInclude. Include ::= "include" VarIdent ;
+terminator Include "" ;
+
+-- A telescope declaration names a block of parameters and binds nothing else.
+-- It is a unit of its own rather than a declaration inside a module, since
+-- what it names is a module header and not a term.
+ATelescope. TelescopeDecl ::= "telescope" VarIdent [Param] ";" ;
 
 AParam.   Param ::= "(" VarIdent ":" Term ")" ;
 terminator Param "" ;

--- a/haskell/mltt/mltt.cabal
+++ b/haskell/mltt/mltt.cabal
@@ -146,6 +146,7 @@ test-suite spec
       Language.MLTT.ParametersSpec
       Language.MLTT.ReplImportSpec
       Language.MLTT.ReplSpec
+      Language.MLTT.TelescopeSpec
       SpecHook
       Paths_mltt
   hs-source-dirs:

--- a/haskell/mltt/mltt.cabal
+++ b/haskell/mltt/mltt.cabal
@@ -141,6 +141,7 @@ test-suite spec
       Language.MLTT.ArtifactSpec
       Language.MLTT.BuildSpec
       Language.MLTT.ImplSpec
+      Language.MLTT.IncludeSpec
       Language.MLTT.LinkSpec
       Language.MLTT.ModulesSpec
       Language.MLTT.ParametersSpec

--- a/haskell/mltt/src/Language/MLTT/Build.hs
+++ b/haskell/mltt/src/Language/MLTT/Build.hs
@@ -330,13 +330,13 @@ buildSourcesWith
   -> (forall c. Foil.Distinct c => Registry -> Env c -> [CommandResult] -> IO r)
   -> IO (Either BuildError r)
 buildSourcesWith mode cacheDir sources k =
-  case traverse parseSource sources of
-    Left err -> pure (Left err)
-    Right ms -> buildModulesWith mode cacheDir (concat ms) k
+  case resolveUnits . concat =<< traverse parseSource sources of
+    Left err      -> pure (Left err)
+    Right modules -> buildModulesWith mode cacheDir modules k
   where
     parseSource (path, input) = case parseProgram input of
-      Left err                    -> Left (path <> ":" <> err)
-      Right (Raw.AProgram _ms ms) -> Right ms
+      Left err                        -> Left (path <> ":" <> err)
+      Right (Raw.AProgram _loc units) -> Right units
 
 -- | The environment a build ends in, its scope index hidden.
 data BuiltEnv where

--- a/haskell/mltt/src/Language/MLTT/Impl.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl.hs
@@ -52,7 +52,7 @@ import qualified Control.Monad.Foil.Blocks    as Blocks
 import           Data.Functor.Compose         (Compose (..))
 import           Data.Functor.Identity        (Identity (..))
 import           Control.Monad.Free.Foil      (AST (Var), UnresolvedName (..))
-import           Data.List                    (foldl', intercalate)
+import           Data.List                    (foldl', group, intercalate, sort)
 import           Data.Map                     (Map)
 import           Data.String                  (IsString)
 import           Data.Maybe                   (listToMaybe)
@@ -244,19 +244,62 @@ buildOrder modules
 
 -- | The name of a module.
 moduleName :: Raw.Module -> Raw.VarIdent
-moduleName (Raw.AModule _ name _ _ _) = name
+moduleName (Raw.AModule _ name _ _ _ _) = name
 
 -- | The parameters of a module.
+--
+-- Note that this is the block after 'resolveUnits' has put the included fields
+-- in front of it, since that is the only shape a module reaches the checker in.
 moduleParams :: Raw.Module -> [Raw.Param]
-moduleParams (Raw.AModule _ _ params _ _) = params
+moduleParams (Raw.AModule _ _ _ params _ _) = params
 
 -- | The imports of a module.
 moduleImports :: Raw.Module -> [Raw.Import]
-moduleImports (Raw.AModule _ _ _ imports _) = imports
+moduleImports (Raw.AModule _ _ _ _ imports _) = imports
 
 -- | The declarations of a module.
 moduleDecls :: Raw.Module -> [Raw.Decl]
-moduleDecls (Raw.AModule _ _ _ _ decls) = decls
+moduleDecls (Raw.AModule _ _ _ _ _ decls) = decls
+
+-- * Telescopes and includes
+
+-- | The telescopes a program declares, by name.
+type Telescopes = Map Raw.VarIdent [Raw.Param]
+
+-- | Split a program's units and resolve every @include@ clause.
+--
+-- An include is expanded into the module's parameter block, so that nothing
+-- downstream has to know about telescopes: what comes out is an ordinary
+-- parametrised module, elaborated and discharged as before. Expanding before
+-- the module is hashed is also what makes an include behave like an import for
+-- staleness, since a changed telescope changes the printed form of every module
+-- that includes it.
+--
+-- The included fields come first, in the order the clauses are written, and the
+-- module's own parameters follow. A telescope may be included by any number of
+-- modules and is elaborated afresh in each, which is what keeps the elaboration
+-- canonical: nothing is shared between two modules but the source.
+resolveUnits :: [Raw.Unit] -> Either BuildError [Raw.Module]
+resolveUnits units
+  | (dup : _) <- duplicates = Left ("telescope declared twice: " <> prettyVarIdent dup)
+  | otherwise = traverse expandIncludes modules
+  where
+    declared = [t | Raw.UnitTelescope _ t <- units]
+    modules  = [m | Raw.UnitModule _ m <- units]
+
+    telescopes :: Telescopes
+    telescopes = Map.fromList [(name, params) | Raw.ATelescope _ name params <- declared]
+
+    duplicates =
+      [name | name : _ : _ <- group (sort [name | Raw.ATelescope _ name _ <- declared])]
+
+    expandIncludes (Raw.AModule loc name includes params imports decls) = do
+      included <- concat <$> traverse include includes
+      return (Raw.AModule loc name [] (included <> params) imports decls)
+
+    include (Raw.AnInclude _loc name) = case Map.lookup name telescopes of
+      Just params -> Right params
+      Nothing     -> Left ("no telescope named " <> prettyVarIdent name <> " is declared")
 
 -- * Name layout
 --
@@ -335,9 +378,18 @@ stripeRange (StripeIndex i) = Foil.NameRange (hi - stripeSize + 1) hi
 
 -- | Interpret a program: order its modules by their imports, then check each.
 interpretProgram :: Raw.Program -> [CommandResult]
-interpretProgram (Raw.AProgram _loc modules) = interpretModules modules
+interpretProgram (Raw.AProgram _loc units) = interpretUnits units
 
--- | Interpret modules gathered from any number of sources.
+-- | Interpret units gathered from any number of sources.
+--
+-- The telescopes are resolved over all of them at once, exactly as the imports
+-- are, so a module may include a telescope declared in another file.
+interpretUnits :: [Raw.Unit] -> [CommandResult]
+interpretUnits units = case resolveUnits units of
+  Left err      -> [Failed err]
+  Right modules -> interpretModules modules
+
+-- | Interpret modules whose includes have already been resolved.
 --
 -- Build order is computed over all of them at once, so a module may import one
 -- declared in another file, or later in the same file.
@@ -754,12 +806,12 @@ interpret input = interpretProgram <$> parseProgram input
 --
 -- Each source is parsed on its own, so a syntax error is reported against the
 -- line of the file it is in rather than against a concatenation of them all.
--- The modules are pooled afterwards, which is what lets one file import
--- another.
+-- The units are pooled afterwards, which is what lets one file import a module
+-- or include a telescope declared in another.
 interpretSources :: [(FilePath, SourceText)] -> Either ParseError [CommandResult]
-interpretSources sources = interpretModules . concat <$> traverse parseSource sources
+interpretSources sources = interpretUnits . concat <$> traverse parseSource sources
   where
     parseSource (path, input) = case parseProgram input of
-      Left err                    -> Left (path <> ":" <> err)
-      Right (Raw.AProgram _ms ms) -> Right ms
+      Left err                       -> Left (path <> ":" <> err)
+      Right (Raw.AProgram _loc units) -> Right units
 

--- a/haskell/mltt/src/Language/MLTT/Impl.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl.hs
@@ -532,7 +532,7 @@ withParams
   -> [Raw.Param]
   -> (String -> r)        -- ^ A parameter's type did not resolve.
   -> (forall p. Foil.DExt n p
-        => Telescope Raw.BNFC'Position n p -> Env p -> r)
+        => ParamTelescope Raw.BNFC'Position n p -> Env p -> r)
   -> r
 withParams env [] _onErr cont = cont TelescopeEmpty env
 withParams env (Raw.AParam _loc name rawTy : rest) onErr cont =

--- a/haskell/mltt/src/Language/MLTT/Syntax/Abs.hs
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Abs.hs
@@ -24,12 +24,25 @@ import qualified Data.Data    as C (Data, Typeable)
 import qualified GHC.Generics as C (Generic)
 
 type Program = Program' BNFC'Position
-data Program' a = AProgram a [Module' a]
+data Program' a = AProgram a [Unit' a]
+  deriving (C.Eq, C.Ord, C.Show, C.Read, C.Functor, C.Foldable, C.Traversable, C.Data, C.Typeable, C.Generic)
+
+type Unit = Unit' BNFC'Position
+data Unit' a
+    = UnitModule a (Module' a) | UnitTelescope a (TelescopeDecl' a)
   deriving (C.Eq, C.Ord, C.Show, C.Read, C.Functor, C.Foldable, C.Traversable, C.Data, C.Typeable, C.Generic)
 
 type Module = Module' BNFC'Position
 data Module' a
-    = AModule a VarIdent [Param' a] [Import' a] [Decl' a]
+    = AModule a VarIdent [Include' a] [Param' a] [Import' a] [Decl' a]
+  deriving (C.Eq, C.Ord, C.Show, C.Read, C.Functor, C.Foldable, C.Traversable, C.Data, C.Typeable, C.Generic)
+
+type Include = Include' BNFC'Position
+data Include' a = AnInclude a VarIdent
+  deriving (C.Eq, C.Ord, C.Show, C.Read, C.Functor, C.Foldable, C.Traversable, C.Data, C.Typeable, C.Generic)
+
+type TelescopeDecl = TelescopeDecl' BNFC'Position
+data TelescopeDecl' a = ATelescope a VarIdent [Param' a]
   deriving (C.Eq, C.Ord, C.Show, C.Read, C.Functor, C.Foldable, C.Traversable, C.Data, C.Typeable, C.Generic)
 
 type Param = Param' BNFC'Position
@@ -109,9 +122,22 @@ instance HasPosition Program where
   hasPosition = \case
     AProgram p _ -> p
 
+instance HasPosition Unit where
+  hasPosition = \case
+    UnitModule p _ -> p
+    UnitTelescope p _ -> p
+
 instance HasPosition Module where
   hasPosition = \case
-    AModule p _ _ _ _ -> p
+    AModule p _ _ _ _ _ -> p
+
+instance HasPosition Include where
+  hasPosition = \case
+    AnInclude p _ -> p
+
+instance HasPosition TelescopeDecl where
+  hasPosition = \case
+    ATelescope p _ _ -> p
 
 instance HasPosition Param where
   hasPosition = \case

--- a/haskell/mltt/src/Language/MLTT/Syntax/Doc.txt
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Doc.txt
@@ -22,11 +22,11 @@ The set of reserved words is the set of terminals appearing in the grammar. Thos
 
 The reserved words used in Syntax are the following:
   | ``Id`` | ``J`` | ``check`` | ``compute``
-  | ``def`` | ``import`` | ``in`` | ``let``
-  | ``module`` | ``namespace`` | ``open`` | ``over``
-  | ``private`` | ``refl`` | ``tt`` | ``where``
-  | ``Π`` | ``Σ`` | ``λ`` | ``π₁``
-  | ``π₂`` | ``𝕌`` |  |
+  | ``def`` | ``import`` | ``in`` | ``include``
+  | ``let`` | ``module`` | ``namespace`` | ``open``
+  | ``over`` | ``private`` | ``refl`` | ``telescope``
+  | ``tt`` | ``where`` | ``Π`` | ``Σ``
+  | ``λ`` | ``π₁`` | ``π₂`` | ``𝕌``
 
 The symbols used in Syntax are the following:
   | ; | ( | : | )
@@ -43,10 +43,16 @@ The symbols -> (production),  **|**  (union)
 and **eps** (empty rule) belong to the BNF notation.
 All other symbols are terminals.
 
-  | //Program// | -> | //[Module]//
-  | //[Module]// | -> | **eps**
-  |  |  **|**  | //Module// //[Module]//
-  | //Module// | -> | ``module`` //VarIdent// //[Param]// ``;`` //[Import]// //[Decl]//
+  | //Program// | -> | //[Unit]//
+  | //[Unit]// | -> | **eps**
+  |  |  **|**  | //Unit// //[Unit]//
+  | //Unit// | -> | //Module//
+  |  |  **|**  | //TelescopeDecl//
+  | //Module// | -> | ``module`` //VarIdent// //[Include]// //[Param]// ``;`` //[Import]// //[Decl]//
+  | //Include// | -> | ``include`` //VarIdent//
+  | //[Include]// | -> | **eps**
+  |  |  **|**  | //Include// //[Include]//
+  | //TelescopeDecl// | -> | ``telescope`` //VarIdent// //[Param]// ``;``
   | //Param// | -> | ``(`` //VarIdent// ``:`` //Term// ``)``
   | //[Param]// | -> | **eps**
   |  |  **|**  | //Param// //[Param]//

--- a/haskell/mltt/src/Language/MLTT/Syntax/Layout.hs
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Layout.hs
@@ -27,8 +27,8 @@ data LayoutDelimiters
     }
 
 layoutWords :: [(TokSymbol, LayoutDelimiters)]
-layoutWords = [( TokSymbol "where" 24
-               , LayoutDelimiters (TokSymbol ";" 6) (Just (TokSymbol "{" 25)) (Just (TokSymbol "}" 26))
+layoutWords = [( TokSymbol "where" 26
+               , LayoutDelimiters (TokSymbol ";" 6) (Just (TokSymbol "{" 27)) (Just (TokSymbol "}" 28))
                )]
 
 layoutStopWords :: [TokSymbol]

--- a/haskell/mltt/src/Language/MLTT/Syntax/Lex.hs
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Lex.hs
@@ -4858,7 +4858,7 @@ eitherResIdent tv s = treeFind resWords
 -- | The keywords and symbols of the language organized as binary search tree.
 resWords :: BTree
 resWords =
-  b "open" 19
+  b "open" 20
     (b "_" 10
        (b ":=" 5
           (b "," 3 (b ")" 2 (b "(" 1 N N) N) (b ":" 4 N N))
@@ -4866,15 +4866,17 @@ resWords =
        (b "in" 15
           (b "def" 13
              (b "compute" 12 (b "check" 11 N N) N) (b "import" 14 N N))
-          (b "module" 17 (b "let" 16 N N) (b "namespace" 18 N N))))
-    (b "\928" 28
-       (b "where" 24
-          (b "refl" 22 (b "private" 21 (b "over" 20 N N) N) (b "tt" 23 N N))
-          (b "}" 26 (b "{" 25 N N) (b "\215" 27 N N)))
-       (b "\8594" 33
-          (b "\960\8321" 31
-             (b "\955" 30 (b "\931" 29 N N) N) (b "\960\8322" 32 N N))
-          (b "\120140" 35 (b "\8658" 34 N N) (b "\120793" 36 N N))))
+          (b "module" 18
+             (b "let" 17 (b "include" 16 N N) N) (b "namespace" 19 N N))))
+    (b "\928" 30
+       (b "tt" 25
+          (b "refl" 23
+             (b "private" 22 (b "over" 21 N N) N) (b "telescope" 24 N N))
+          (b "}" 28 (b "{" 27 (b "where" 26 N N) N) (b "\215" 29 N N)))
+       (b "\8594" 35
+          (b "\960\8321" 33
+             (b "\955" 32 (b "\931" 31 N N) N) (b "\960\8322" 34 N N))
+          (b "\120140" 37 (b "\8658" 36 N N) (b "\120793" 38 N N))))
   where
   b s n = B bs (TS bs n)
     where

--- a/haskell/mltt/src/Language/MLTT/Syntax/Par.hs
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Par.hs
@@ -6,8 +6,12 @@ module Language.MLTT.Syntax.Par
   ( happyError
   , myLexer
   , pProgram
-  , pListModule
+  , pListUnit
+  , pUnit
   , pModule
+  , pInclude
+  , pListInclude
+  , pTelescopeDecl
   , pParam
   , pListParam
   , pImport
@@ -37,21 +41,25 @@ import Control.Monad (ap)
 data HappyAbsSyn 
 	= HappyTerminal (Token)
 	| HappyErrorToken Prelude.Int
-	| HappyAbsSyn19 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.VarIdent))
-	| HappyAbsSyn20 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Program))
-	| HappyAbsSyn21 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Module]))
-	| HappyAbsSyn22 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Module))
-	| HappyAbsSyn23 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Param))
-	| HappyAbsSyn24 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Param]))
-	| HappyAbsSyn25 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Import))
-	| HappyAbsSyn26 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Import]))
-	| HappyAbsSyn27 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Decl))
-	| HappyAbsSyn28 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Decl]))
-	| HappyAbsSyn29 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Discharge))
-	| HappyAbsSyn30 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.VarIdent]))
-	| HappyAbsSyn31 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Term))
-	| HappyAbsSyn34 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.ScopedTerm))
-	| HappyAbsSyn35 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Pattern))
+	| HappyAbsSyn23 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.VarIdent))
+	| HappyAbsSyn24 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Program))
+	| HappyAbsSyn25 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Unit]))
+	| HappyAbsSyn26 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Unit))
+	| HappyAbsSyn27 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Module))
+	| HappyAbsSyn28 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Include))
+	| HappyAbsSyn29 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Include]))
+	| HappyAbsSyn30 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.TelescopeDecl))
+	| HappyAbsSyn31 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Param))
+	| HappyAbsSyn32 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Param]))
+	| HappyAbsSyn33 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Import))
+	| HappyAbsSyn34 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Import]))
+	| HappyAbsSyn35 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Decl))
+	| HappyAbsSyn36 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Decl]))
+	| HappyAbsSyn37 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Discharge))
+	| HappyAbsSyn38 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.VarIdent]))
+	| HappyAbsSyn39 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Term))
+	| HappyAbsSyn42 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.ScopedTerm))
+	| HappyAbsSyn43 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Pattern))
 
 {- to allow type-synonyms as our monads (likely
  - with explicitly-specified bind and return)
@@ -239,7 +247,26 @@ action_0,
  action_168,
  action_169,
  action_170,
- action_171 :: () => Prelude.Int -> ({-HappyReduction (Err) = -}
+ action_171,
+ action_172,
+ action_173,
+ action_174,
+ action_175,
+ action_176,
+ action_177,
+ action_178,
+ action_179,
+ action_180,
+ action_181,
+ action_182,
+ action_183,
+ action_184,
+ action_185,
+ action_186,
+ action_187,
+ action_188,
+ action_189,
+ action_190 :: () => Prelude.Int -> ({-HappyReduction (Err) = -}
 	   Prelude.Int 
 	-> (Token)
 	-> HappyState (Token) (HappyStk HappyAbsSyn -> [(Token)] -> (Err) HappyAbsSyn)
@@ -247,11 +274,7 @@ action_0,
 	-> HappyStk HappyAbsSyn 
 	-> [(Token)] -> (Err) HappyAbsSyn)
 
-happyReduce_16,
- happyReduce_17,
- happyReduce_18,
- happyReduce_19,
- happyReduce_20,
+happyReduce_20,
  happyReduce_21,
  happyReduce_22,
  happyReduce_23,
@@ -296,7 +319,17 @@ happyReduce_16,
  happyReduce_62,
  happyReduce_63,
  happyReduce_64,
- happyReduce_65 :: () => ({-HappyReduction (Err) = -}
+ happyReduce_65,
+ happyReduce_66,
+ happyReduce_67,
+ happyReduce_68,
+ happyReduce_69,
+ happyReduce_70,
+ happyReduce_71,
+ happyReduce_72,
+ happyReduce_73,
+ happyReduce_74,
+ happyReduce_75 :: () => ({-HappyReduction (Err) = -}
 	   Prelude.Int 
 	-> (Token)
 	-> HappyState (Token) (HappyStk HappyAbsSyn -> [(Token)] -> (Err) HappyAbsSyn)
@@ -305,1656 +338,1781 @@ happyReduce_16,
 	-> [(Token)] -> (Err) HappyAbsSyn)
 
 happyExpList :: Happy_Data_Array.Array Prelude.Int Prelude.Int
-happyExpList = Happy_Data_Array.listArray (0,361) ([0,0,0,8,0,0,0,4096,0,0,0,0,32,0,0,16384,0,0,0,0,128,0,0,0,0,8192,0,0,0,0,64,0,0,0,28672,88,0,0,0,45280,0,0,0,0,128,0,0,0,0,0,2,0,24640,6176,1854,0,32768,192,24624,14,0,33024,24577,7360,0,0,770,61633,57,0,1024,8,16384,0,0,0,0,128,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,128,1,2048,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2048,12,60963,0,0,0,0,0,0,0,0,0,0,0,24640,6176,1854,0,32768,0,0,0,0,256,0,0,0,0,1026,0,32,0,1024,0,0,0,0,0,0,0,0,4096,0,0,0,0,32,0,0,0,16384,128,0,4,0,49280,12288,3680,0,0,385,49248,28,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,6160,1536,460,0,0,0,0,0,0,256,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,32768,0,0,0,0,0,0,0,0,4096,2072,53126,1,0,12320,3088,927,0,0,0,0,4,0,0,0,2048,0,0,0,0,16,0,0,32,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,32768,0,0,0,0,0,0,0,0,0,0,0,32,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,16384,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,16384,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8,0,0,0,0,0,8,0,0,0,0,0,0,0,256,0,0,0,8192,0,0,0,0,0,0,0,32768,0,0,0,0,32768,707,0,0,0,0,0,4,0,0,0,2048,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4096,0,0,8208,0,256,0,8192,64,0,2,0,24640,6176,1854,0,0,32,0,0,0,33024,24705,7416,0,0,770,61633,57,0,14336,0,0,0,0,3080,49924,231,0,4096,2072,53126,1,0,128,0,0,0,16384,128,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1540,57730,115,0,2048,1036,59331,0,0,64,0,0,0,32768,0,0,0,0,24640,6176,1854,0,0,1,0,0,0,2048,0,0,0,0,16,0,0,0,1024,33286,29665,0,0,0,0,0,0,8192,0,0,0,0,0,0,0,0,16384,8288,15896,7,0,1024,0,0,0,0,0,256,0,0,0,4096,0,0,0,0,0,0,0,2048,1036,59331,0,0,512,0,0,0,0,1024,0,0,0,128,0,0,0,0,4,0,0,0,0,5660,0,0,0,770,61633,57,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,12320,3088,927,0,16384,8288,15896,7,0,0,0,0,0,0,16384,0,0,0,512,49411,14832,0,0,1540,57730,115,0,4096,0,0,0,0,32,0,0,0,16384,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8,0,0,0,4096,0,0,0,0,3080,49924,231,0,8192,0,0,0,0,64,0,0,0,0,4,0,0,0,0,0,1,0,0,33153,63584,28,0,0,0,0,0,0,28672,88,0,0,0,0,0,0,0,256,0,0,0,0,0,0,0,0,24640,6176,1854,0,0,0,512,0,0,0,0,256,0,0,0,0,0,0,1024,33286,29665,0,0,3080,49924,231,0,8192,0,0,0,0,64,0,0,0,16384,8288,15896,7,0,49280,12352,3708,0,0,0,0,0,0,512,49411,14832,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+happyExpList = Happy_Data_Array.listArray (0,394) ([0,0,0,4096,4,0,0,0,32768,32,0,0,0,0,260,0,0,0,0,32,0,0,0,0,64,0,0,0,0,512,0,0,0,0,0,16,0,0,0,1,0,0,0,0,8,0,0,0,0,0,8,0,0,0,0,64,0,0,0,0,49600,2,0,0,0,3584,22,0,0,0,0,64,0,0,0,0,0,2048,0,0,33024,16641,29665,0,0,2048,12,38922,3,0,16384,96,49232,28,0,0,770,49794,231,0,0,8208,0,1024,0,0,0,0,8192,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4104,0,512,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32768,192,34976,59,0,0,0,0,0,0,0,0,0,0,0,0,33024,16641,29665,0,0,2048,0,0,0,0,16384,0,0,0,0,0,1026,0,128,0,0,16,0,0,0,0,0,0,0,0,0,1024,0,0,0,0,8192,0,0,0,0,0,513,0,64,0,0,3080,2560,920,0,0,24640,20480,7360,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1540,1280,460,0,0,0,0,0,0,0,1024,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,512,0,0,0,0,0,0,0,0,0,1024,1030,53125,1,0,8192,8240,31784,14,0,0,0,0,64,0,0,0,0,512,0,0,0,0,4096,0,0,0,32,0,0,0,0,0,0,0,0,0,16,0,0,0,0,0,0,0,0,0,0,0,2048,0,0,0,0,0,0,0,2048,0,0,0,0,0,0,0,0,0,0,0,0,128,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,4096,0,0,0,0,0,0,0,0,0,0,0,512,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4096,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,64,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,64,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,512,0,0,0,0,0,0,32,0,0,0,0,0,0,0,0,16384,0,0,0,0,4096,0,0,0,0,0,0,0,0,0,2,0,0,0,0,14336,88,0,0,0,0,0,1024,0,0,0,0,8192,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,64,0,0,32832,0,4096,0,0,512,4,32768,0,0,4096,4120,15892,7,0,0,32,0,0,0,0,1540,34052,463,0,0,12320,10272,3708,0,0,3584,0,0,0,0,2048,2060,40714,3,0,16384,16480,63568,28,0,0,8,0,0,0,0,8208,0,1024,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,385,57665,115,0,0,3080,2568,927,0,0,256,0,0,0,0,2048,0,0,0,0,4096,4120,15892,7,0,0,1,0,0,0,0,32,0,0,0,0,256,0,0,0,0,33024,16641,29665,0,0,0,0,0,0,0,32768,0,0,0,0,0,0,0,0,0,0,6160,5136,1854,0,0,1024,0,0,0,0,0,0,16,0,0,0,0,2,0,0,0,0,0,0,0,0,3080,2568,927,0,0,2048,0,0,0,0,512,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,8,0,0,0,0,256,0,0,0,0,0,11292,0,0,0,2048,2060,40714,3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,49280,41088,14832,0,0,1024,1030,53125,1,0,0,0,0,0,0,0,16384,0,0,0,0,3080,2568,927,0,0,24640,20544,7416,0,0,1024,0,0,0,0,8192,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8192,0,0,0,0,0,1,0,0,0,0,770,49794,231,0,0,32,0,0,0,0,256,0,0,0,0,16384,0,0,0,0,0,0,256,0,0,0,385,57665,115,0,0,0,0,0,0,0,0,8,0,0,0,0,22584,0,0,0,0,1,0,0,0,0,0,0,0,0,0,1540,34052,463,0,0,0,0,2,0,0,0,0,1024,0,0,0,0,0,0,0,16384,16480,63568,28,0,0,770,49794,231,0,0,32,0,0,0,0,256,0,0,0,0,1024,1030,53125,1,0,8192,8240,31784,14,0,0,0,0,0,0,0,3080,2568,927,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 	])
 
 {-# NOINLINE happyExpListPerState #-}
 happyExpListPerState st =
     token_strs_expected
-  where token_strs = ["error","%dummy","%start_pProgram_internal","%start_pListModule_internal","%start_pModule_internal","%start_pParam_internal","%start_pListParam_internal","%start_pImport_internal","%start_pListImport_internal","%start_pDecl_internal","%start_pListDecl_internal","%start_pDischarge_internal","%start_pListVarIdent_internal","%start_pTerm_internal","%start_pTerm1_internal","%start_pTerm2_internal","%start_pScopedTerm_internal","%start_pPattern_internal","VarIdent","Program","ListModule","Module","Param","ListParam","Import","ListImport","Decl","ListDecl","Discharge","ListVarIdent","Term","Term1","Term2","ScopedTerm","Pattern","'('","')'","','","':'","':='","';'","'='","'Id'","'J'","'_'","'check'","'compute'","'def'","'import'","'in'","'let'","'module'","'namespace'","'open'","'over'","'private'","'refl'","'tt'","'where'","'{'","'}'","'\215'","'\928'","'\931'","'\955'","'\960\8321'","'\960\8322'","'\8594'","'\8658'","'\120140'","'\120793'","L_VarIdent","%eof"]
-        bit_start = st Prelude.* 73
-        bit_end = (st Prelude.+ 1) Prelude.* 73
+  where token_strs = ["error","%dummy","%start_pProgram_internal","%start_pListUnit_internal","%start_pUnit_internal","%start_pModule_internal","%start_pInclude_internal","%start_pListInclude_internal","%start_pTelescopeDecl_internal","%start_pParam_internal","%start_pListParam_internal","%start_pImport_internal","%start_pListImport_internal","%start_pDecl_internal","%start_pListDecl_internal","%start_pDischarge_internal","%start_pListVarIdent_internal","%start_pTerm_internal","%start_pTerm1_internal","%start_pTerm2_internal","%start_pScopedTerm_internal","%start_pPattern_internal","VarIdent","Program","ListUnit","Unit","Module","Include","ListInclude","TelescopeDecl","Param","ListParam","Import","ListImport","Decl","ListDecl","Discharge","ListVarIdent","Term","Term1","Term2","ScopedTerm","Pattern","'('","')'","','","':'","':='","';'","'='","'Id'","'J'","'_'","'check'","'compute'","'def'","'import'","'in'","'include'","'let'","'module'","'namespace'","'open'","'over'","'private'","'refl'","'telescope'","'tt'","'where'","'{'","'}'","'\215'","'\928'","'\931'","'\955'","'\960\8321'","'\960\8322'","'\8594'","'\8658'","'\120140'","'\120793'","L_VarIdent","%eof"]
+        bit_start = st Prelude.* 83
+        bit_end = (st Prelude.+ 1) Prelude.* 83
         read_bit = readArrayBit happyExpList
         bits = Prelude.map read_bit [bit_start..bit_end Prelude.- 1]
-        bits_indexed = Prelude.zip bits [0..72]
+        bits_indexed = Prelude.zip bits [0..82]
         token_strs_expected = Prelude.concatMap f bits_indexed
         f (Prelude.False, _) = []
         f (Prelude.True, nr) = [token_strs Prelude.!! nr]
 
-action_0 (52) = happyShift action_65
-action_0 (20) = happyGoto action_68
-action_0 (21) = happyGoto action_69
-action_0 (22) = happyGoto action_67
-action_0 _ = happyReduce_18
+action_0 (61) = happyShift action_75
+action_0 (67) = happyShift action_69
+action_0 (24) = happyGoto action_81
+action_0 (25) = happyGoto action_82
+action_0 (26) = happyGoto action_80
+action_0 (27) = happyGoto action_77
+action_0 (30) = happyGoto action_78
+action_0 _ = happyReduce_22
 
-action_1 (52) = happyShift action_65
-action_1 (21) = happyGoto action_66
-action_1 (22) = happyGoto action_67
-action_1 _ = happyReduce_18
+action_1 (61) = happyShift action_75
+action_1 (67) = happyShift action_69
+action_1 (25) = happyGoto action_79
+action_1 (26) = happyGoto action_80
+action_1 (27) = happyGoto action_77
+action_1 (30) = happyGoto action_78
+action_1 _ = happyReduce_22
 
-action_2 (52) = happyShift action_65
-action_2 (22) = happyGoto action_64
+action_2 (61) = happyShift action_75
+action_2 (67) = happyShift action_69
+action_2 (26) = happyGoto action_76
+action_2 (27) = happyGoto action_77
+action_2 (30) = happyGoto action_78
 action_2 _ = happyFail (happyExpListPerState 2)
 
-action_3 (36) = happyShift action_62
-action_3 (23) = happyGoto action_63
+action_3 (61) = happyShift action_75
+action_3 (27) = happyGoto action_74
 action_3 _ = happyFail (happyExpListPerState 3)
 
-action_4 (36) = happyShift action_62
-action_4 (23) = happyGoto action_60
-action_4 (24) = happyGoto action_61
-action_4 _ = happyReduce_22
+action_4 (59) = happyShift action_72
+action_4 (28) = happyGoto action_73
+action_4 _ = happyFail (happyExpListPerState 4)
 
-action_5 (49) = happyShift action_58
-action_5 (25) = happyGoto action_59
-action_5 _ = happyFail (happyExpListPerState 5)
+action_5 (59) = happyShift action_72
+action_5 (28) = happyGoto action_70
+action_5 (29) = happyGoto action_71
+action_5 _ = happyReduce_28
 
-action_6 (49) = happyShift action_58
-action_6 (25) = happyGoto action_56
-action_6 (26) = happyGoto action_57
-action_6 _ = happyReduce_25
+action_6 (67) = happyShift action_69
+action_6 (30) = happyGoto action_68
+action_6 _ = happyFail (happyExpListPerState 6)
 
-action_7 (46) = happyShift action_49
-action_7 (47) = happyShift action_50
-action_7 (48) = happyShift action_51
-action_7 (53) = happyShift action_52
-action_7 (54) = happyShift action_53
-action_7 (56) = happyShift action_54
-action_7 (27) = happyGoto action_55
+action_7 (44) = happyShift action_66
+action_7 (31) = happyGoto action_67
 action_7 _ = happyFail (happyExpListPerState 7)
 
-action_8 (46) = happyShift action_49
-action_8 (47) = happyShift action_50
-action_8 (48) = happyShift action_51
-action_8 (53) = happyShift action_52
-action_8 (54) = happyShift action_53
-action_8 (56) = happyShift action_54
-action_8 (27) = happyGoto action_47
-action_8 (28) = happyGoto action_48
-action_8 _ = happyReduce_33
+action_8 (44) = happyShift action_66
+action_8 (31) = happyGoto action_64
+action_8 (32) = happyGoto action_65
+action_8 _ = happyReduce_32
 
-action_9 (55) = happyShift action_46
-action_9 (29) = happyGoto action_45
-action_9 _ = happyReduce_36
+action_9 (57) = happyShift action_62
+action_9 (33) = happyGoto action_63
+action_9 _ = happyFail (happyExpListPerState 9)
 
-action_10 (72) = happyShift action_17
-action_10 (19) = happyGoto action_43
-action_10 (30) = happyGoto action_44
-action_10 _ = happyReduce_38
+action_10 (57) = happyShift action_62
+action_10 (33) = happyGoto action_60
+action_10 (34) = happyGoto action_61
+action_10 _ = happyReduce_35
 
-action_11 (36) = happyShift action_27
-action_11 (43) = happyShift action_28
-action_11 (44) = happyShift action_29
-action_11 (51) = happyShift action_30
-action_11 (57) = happyShift action_31
-action_11 (58) = happyShift action_32
-action_11 (63) = happyShift action_33
-action_11 (64) = happyShift action_34
-action_11 (65) = happyShift action_35
-action_11 (66) = happyShift action_36
-action_11 (67) = happyShift action_37
-action_11 (70) = happyShift action_38
-action_11 (71) = happyShift action_39
-action_11 (72) = happyShift action_17
-action_11 (19) = happyGoto action_22
-action_11 (31) = happyGoto action_42
-action_11 (32) = happyGoto action_24
-action_11 (33) = happyGoto action_25
+action_11 (54) = happyShift action_53
+action_11 (55) = happyShift action_54
+action_11 (56) = happyShift action_55
+action_11 (62) = happyShift action_56
+action_11 (63) = happyShift action_57
+action_11 (65) = happyShift action_58
+action_11 (35) = happyGoto action_59
 action_11 _ = happyFail (happyExpListPerState 11)
 
-action_12 (36) = happyShift action_27
-action_12 (43) = happyShift action_28
-action_12 (44) = happyShift action_29
-action_12 (57) = happyShift action_31
-action_12 (58) = happyShift action_32
-action_12 (66) = happyShift action_36
-action_12 (67) = happyShift action_37
-action_12 (70) = happyShift action_38
-action_12 (71) = happyShift action_39
-action_12 (72) = happyShift action_17
-action_12 (19) = happyGoto action_22
-action_12 (32) = happyGoto action_41
-action_12 (33) = happyGoto action_25
-action_12 _ = happyFail (happyExpListPerState 12)
+action_12 (54) = happyShift action_53
+action_12 (55) = happyShift action_54
+action_12 (56) = happyShift action_55
+action_12 (62) = happyShift action_56
+action_12 (63) = happyShift action_57
+action_12 (65) = happyShift action_58
+action_12 (35) = happyGoto action_51
+action_12 (36) = happyGoto action_52
+action_12 _ = happyReduce_43
 
-action_13 (36) = happyShift action_27
-action_13 (43) = happyShift action_28
-action_13 (44) = happyShift action_29
-action_13 (57) = happyShift action_31
-action_13 (58) = happyShift action_32
-action_13 (66) = happyShift action_36
-action_13 (67) = happyShift action_37
-action_13 (70) = happyShift action_38
-action_13 (71) = happyShift action_39
-action_13 (72) = happyShift action_17
-action_13 (19) = happyGoto action_22
-action_13 (33) = happyGoto action_40
-action_13 _ = happyFail (happyExpListPerState 13)
+action_13 (64) = happyShift action_50
+action_13 (37) = happyGoto action_49
+action_13 _ = happyReduce_46
 
-action_14 (36) = happyShift action_27
-action_14 (43) = happyShift action_28
-action_14 (44) = happyShift action_29
-action_14 (51) = happyShift action_30
-action_14 (57) = happyShift action_31
-action_14 (58) = happyShift action_32
-action_14 (63) = happyShift action_33
-action_14 (64) = happyShift action_34
-action_14 (65) = happyShift action_35
-action_14 (66) = happyShift action_36
-action_14 (67) = happyShift action_37
-action_14 (70) = happyShift action_38
-action_14 (71) = happyShift action_39
-action_14 (72) = happyShift action_17
-action_14 (19) = happyGoto action_22
-action_14 (31) = happyGoto action_23
-action_14 (32) = happyGoto action_24
-action_14 (33) = happyGoto action_25
-action_14 (34) = happyGoto action_26
-action_14 _ = happyFail (happyExpListPerState 14)
+action_14 (82) = happyShift action_21
+action_14 (23) = happyGoto action_47
+action_14 (38) = happyGoto action_48
+action_14 _ = happyReduce_48
 
-action_15 (36) = happyShift action_20
-action_15 (45) = happyShift action_21
-action_15 (72) = happyShift action_17
-action_15 (19) = happyGoto action_18
-action_15 (35) = happyGoto action_19
+action_15 (44) = happyShift action_31
+action_15 (51) = happyShift action_32
+action_15 (52) = happyShift action_33
+action_15 (60) = happyShift action_34
+action_15 (66) = happyShift action_35
+action_15 (68) = happyShift action_36
+action_15 (73) = happyShift action_37
+action_15 (74) = happyShift action_38
+action_15 (75) = happyShift action_39
+action_15 (76) = happyShift action_40
+action_15 (77) = happyShift action_41
+action_15 (80) = happyShift action_42
+action_15 (81) = happyShift action_43
+action_15 (82) = happyShift action_21
+action_15 (23) = happyGoto action_26
+action_15 (39) = happyGoto action_46
+action_15 (40) = happyGoto action_28
+action_15 (41) = happyGoto action_29
 action_15 _ = happyFail (happyExpListPerState 15)
 
-action_16 (72) = happyShift action_17
+action_16 (44) = happyShift action_31
+action_16 (51) = happyShift action_32
+action_16 (52) = happyShift action_33
+action_16 (66) = happyShift action_35
+action_16 (68) = happyShift action_36
+action_16 (76) = happyShift action_40
+action_16 (77) = happyShift action_41
+action_16 (80) = happyShift action_42
+action_16 (81) = happyShift action_43
+action_16 (82) = happyShift action_21
+action_16 (23) = happyGoto action_26
+action_16 (40) = happyGoto action_45
+action_16 (41) = happyGoto action_29
 action_16 _ = happyFail (happyExpListPerState 16)
 
-action_17 _ = happyReduce_16
+action_17 (44) = happyShift action_31
+action_17 (51) = happyShift action_32
+action_17 (52) = happyShift action_33
+action_17 (66) = happyShift action_35
+action_17 (68) = happyShift action_36
+action_17 (76) = happyShift action_40
+action_17 (77) = happyShift action_41
+action_17 (80) = happyShift action_42
+action_17 (81) = happyShift action_43
+action_17 (82) = happyShift action_21
+action_17 (23) = happyGoto action_26
+action_17 (41) = happyGoto action_44
+action_17 _ = happyFail (happyExpListPerState 17)
 
-action_18 _ = happyReduce_64
+action_18 (44) = happyShift action_31
+action_18 (51) = happyShift action_32
+action_18 (52) = happyShift action_33
+action_18 (60) = happyShift action_34
+action_18 (66) = happyShift action_35
+action_18 (68) = happyShift action_36
+action_18 (73) = happyShift action_37
+action_18 (74) = happyShift action_38
+action_18 (75) = happyShift action_39
+action_18 (76) = happyShift action_40
+action_18 (77) = happyShift action_41
+action_18 (80) = happyShift action_42
+action_18 (81) = happyShift action_43
+action_18 (82) = happyShift action_21
+action_18 (23) = happyGoto action_26
+action_18 (39) = happyGoto action_27
+action_18 (40) = happyGoto action_28
+action_18 (41) = happyGoto action_29
+action_18 (42) = happyGoto action_30
+action_18 _ = happyFail (happyExpListPerState 18)
 
-action_19 (73) = happyAccept
+action_19 (44) = happyShift action_24
+action_19 (53) = happyShift action_25
+action_19 (82) = happyShift action_21
+action_19 (23) = happyGoto action_22
+action_19 (43) = happyGoto action_23
 action_19 _ = happyFail (happyExpListPerState 19)
 
-action_20 (36) = happyShift action_20
-action_20 (45) = happyShift action_21
-action_20 (72) = happyShift action_17
-action_20 (19) = happyGoto action_18
-action_20 (35) = happyGoto action_98
+action_20 (82) = happyShift action_21
 action_20 _ = happyFail (happyExpListPerState 20)
 
-action_21 _ = happyReduce_63
+action_21 _ = happyReduce_20
 
-action_22 _ = happyReduce_55
+action_22 _ = happyReduce_74
 
-action_23 _ = happyReduce_62
+action_23 (83) = happyAccept
+action_23 _ = happyFail (happyExpListPerState 23)
 
-action_24 (36) = happyShift action_27
-action_24 (43) = happyShift action_28
-action_24 (44) = happyShift action_29
-action_24 (57) = happyShift action_31
-action_24 (58) = happyShift action_32
-action_24 (62) = happyShift action_96
-action_24 (66) = happyShift action_36
-action_24 (67) = happyShift action_37
-action_24 (68) = happyShift action_97
-action_24 (70) = happyShift action_38
-action_24 (71) = happyShift action_39
-action_24 (72) = happyShift action_17
-action_24 (19) = happyGoto action_22
-action_24 (33) = happyGoto action_85
-action_24 _ = happyReduce_47
+action_24 (44) = happyShift action_24
+action_24 (53) = happyShift action_25
+action_24 (82) = happyShift action_21
+action_24 (23) = happyGoto action_22
+action_24 (43) = happyGoto action_114
+action_24 _ = happyFail (happyExpListPerState 24)
 
-action_25 _ = happyReduce_49
+action_25 _ = happyReduce_73
 
-action_26 (73) = happyAccept
-action_26 _ = happyFail (happyExpListPerState 26)
+action_26 _ = happyReduce_65
 
-action_27 (36) = happyShift action_27
-action_27 (43) = happyShift action_28
-action_27 (44) = happyShift action_29
-action_27 (51) = happyShift action_30
-action_27 (57) = happyShift action_31
-action_27 (58) = happyShift action_32
-action_27 (63) = happyShift action_33
-action_27 (64) = happyShift action_34
-action_27 (65) = happyShift action_35
-action_27 (66) = happyShift action_36
-action_27 (67) = happyShift action_37
-action_27 (70) = happyShift action_38
-action_27 (71) = happyShift action_39
-action_27 (72) = happyShift action_17
-action_27 (19) = happyGoto action_22
-action_27 (31) = happyGoto action_95
-action_27 (32) = happyGoto action_24
-action_27 (33) = happyGoto action_25
-action_27 _ = happyFail (happyExpListPerState 27)
+action_27 _ = happyReduce_72
 
-action_28 (36) = happyShift action_94
-action_28 _ = happyFail (happyExpListPerState 28)
+action_28 (44) = happyShift action_31
+action_28 (51) = happyShift action_32
+action_28 (52) = happyShift action_33
+action_28 (66) = happyShift action_35
+action_28 (68) = happyShift action_36
+action_28 (72) = happyShift action_112
+action_28 (76) = happyShift action_40
+action_28 (77) = happyShift action_41
+action_28 (78) = happyShift action_113
+action_28 (80) = happyShift action_42
+action_28 (81) = happyShift action_43
+action_28 (82) = happyShift action_21
+action_28 (23) = happyGoto action_26
+action_28 (41) = happyGoto action_101
+action_28 _ = happyReduce_57
 
-action_29 (36) = happyShift action_93
-action_29 _ = happyFail (happyExpListPerState 29)
+action_29 _ = happyReduce_59
 
-action_30 (36) = happyShift action_20
-action_30 (45) = happyShift action_21
-action_30 (72) = happyShift action_17
-action_30 (19) = happyGoto action_18
-action_30 (35) = happyGoto action_92
+action_30 (83) = happyAccept
 action_30 _ = happyFail (happyExpListPerState 30)
 
-action_31 (36) = happyShift action_91
+action_31 (44) = happyShift action_31
+action_31 (51) = happyShift action_32
+action_31 (52) = happyShift action_33
+action_31 (60) = happyShift action_34
+action_31 (66) = happyShift action_35
+action_31 (68) = happyShift action_36
+action_31 (73) = happyShift action_37
+action_31 (74) = happyShift action_38
+action_31 (75) = happyShift action_39
+action_31 (76) = happyShift action_40
+action_31 (77) = happyShift action_41
+action_31 (80) = happyShift action_42
+action_31 (81) = happyShift action_43
+action_31 (82) = happyShift action_21
+action_31 (23) = happyGoto action_26
+action_31 (39) = happyGoto action_111
+action_31 (40) = happyGoto action_28
+action_31 (41) = happyGoto action_29
 action_31 _ = happyFail (happyExpListPerState 31)
 
-action_32 _ = happyReduce_54
+action_32 (44) = happyShift action_110
+action_32 _ = happyFail (happyExpListPerState 32)
 
-action_33 (36) = happyShift action_90
+action_33 (44) = happyShift action_109
 action_33 _ = happyFail (happyExpListPerState 33)
 
-action_34 (36) = happyShift action_89
+action_34 (44) = happyShift action_24
+action_34 (53) = happyShift action_25
+action_34 (82) = happyShift action_21
+action_34 (23) = happyGoto action_22
+action_34 (43) = happyGoto action_108
 action_34 _ = happyFail (happyExpListPerState 34)
 
-action_35 (36) = happyShift action_20
-action_35 (45) = happyShift action_21
-action_35 (72) = happyShift action_17
-action_35 (19) = happyGoto action_18
-action_35 (35) = happyGoto action_88
+action_35 (44) = happyShift action_107
 action_35 _ = happyFail (happyExpListPerState 35)
 
-action_36 (36) = happyShift action_27
-action_36 (43) = happyShift action_28
-action_36 (44) = happyShift action_29
-action_36 (57) = happyShift action_31
-action_36 (58) = happyShift action_32
-action_36 (66) = happyShift action_36
-action_36 (67) = happyShift action_37
-action_36 (70) = happyShift action_38
-action_36 (71) = happyShift action_39
-action_36 (72) = happyShift action_17
-action_36 (19) = happyGoto action_22
-action_36 (33) = happyGoto action_87
-action_36 _ = happyFail (happyExpListPerState 36)
+action_36 _ = happyReduce_64
 
-action_37 (36) = happyShift action_27
-action_37 (43) = happyShift action_28
-action_37 (44) = happyShift action_29
-action_37 (57) = happyShift action_31
-action_37 (58) = happyShift action_32
-action_37 (66) = happyShift action_36
-action_37 (67) = happyShift action_37
-action_37 (70) = happyShift action_38
-action_37 (71) = happyShift action_39
-action_37 (72) = happyShift action_17
-action_37 (19) = happyGoto action_22
-action_37 (33) = happyGoto action_86
+action_37 (44) = happyShift action_106
 action_37 _ = happyFail (happyExpListPerState 37)
 
-action_38 _ = happyReduce_52
+action_38 (44) = happyShift action_105
+action_38 _ = happyFail (happyExpListPerState 38)
 
-action_39 _ = happyReduce_53
+action_39 (44) = happyShift action_24
+action_39 (53) = happyShift action_25
+action_39 (82) = happyShift action_21
+action_39 (23) = happyGoto action_22
+action_39 (43) = happyGoto action_104
+action_39 _ = happyFail (happyExpListPerState 39)
 
-action_40 (73) = happyAccept
+action_40 (44) = happyShift action_31
+action_40 (51) = happyShift action_32
+action_40 (52) = happyShift action_33
+action_40 (66) = happyShift action_35
+action_40 (68) = happyShift action_36
+action_40 (76) = happyShift action_40
+action_40 (77) = happyShift action_41
+action_40 (80) = happyShift action_42
+action_40 (81) = happyShift action_43
+action_40 (82) = happyShift action_21
+action_40 (23) = happyGoto action_26
+action_40 (41) = happyGoto action_103
 action_40 _ = happyFail (happyExpListPerState 40)
 
-action_41 (36) = happyShift action_27
-action_41 (43) = happyShift action_28
-action_41 (44) = happyShift action_29
-action_41 (57) = happyShift action_31
-action_41 (58) = happyShift action_32
-action_41 (66) = happyShift action_36
-action_41 (67) = happyShift action_37
-action_41 (70) = happyShift action_38
-action_41 (71) = happyShift action_39
-action_41 (72) = happyShift action_17
-action_41 (73) = happyAccept
-action_41 (19) = happyGoto action_22
-action_41 (33) = happyGoto action_85
+action_41 (44) = happyShift action_31
+action_41 (51) = happyShift action_32
+action_41 (52) = happyShift action_33
+action_41 (66) = happyShift action_35
+action_41 (68) = happyShift action_36
+action_41 (76) = happyShift action_40
+action_41 (77) = happyShift action_41
+action_41 (80) = happyShift action_42
+action_41 (81) = happyShift action_43
+action_41 (82) = happyShift action_21
+action_41 (23) = happyGoto action_26
+action_41 (41) = happyGoto action_102
 action_41 _ = happyFail (happyExpListPerState 41)
 
-action_42 (73) = happyAccept
-action_42 _ = happyFail (happyExpListPerState 42)
+action_42 _ = happyReduce_62
 
-action_43 (38) = happyShift action_84
-action_43 _ = happyReduce_39
+action_43 _ = happyReduce_63
 
-action_44 (73) = happyAccept
+action_44 (83) = happyAccept
 action_44 _ = happyFail (happyExpListPerState 44)
 
-action_45 (73) = happyAccept
+action_45 (44) = happyShift action_31
+action_45 (51) = happyShift action_32
+action_45 (52) = happyShift action_33
+action_45 (66) = happyShift action_35
+action_45 (68) = happyShift action_36
+action_45 (76) = happyShift action_40
+action_45 (77) = happyShift action_41
+action_45 (80) = happyShift action_42
+action_45 (81) = happyShift action_43
+action_45 (82) = happyShift action_21
+action_45 (83) = happyAccept
+action_45 (23) = happyGoto action_26
+action_45 (41) = happyGoto action_101
 action_45 _ = happyFail (happyExpListPerState 45)
 
-action_46 (36) = happyShift action_83
+action_46 (83) = happyAccept
 action_46 _ = happyFail (happyExpListPerState 46)
 
-action_47 (41) = happyShift action_82
-action_47 _ = happyReduce_34
+action_47 (46) = happyShift action_100
+action_47 _ = happyReduce_49
 
-action_48 (73) = happyAccept
+action_48 (83) = happyAccept
 action_48 _ = happyFail (happyExpListPerState 48)
 
-action_49 (36) = happyShift action_27
-action_49 (43) = happyShift action_28
-action_49 (44) = happyShift action_29
-action_49 (51) = happyShift action_30
-action_49 (57) = happyShift action_31
-action_49 (58) = happyShift action_32
-action_49 (63) = happyShift action_33
-action_49 (64) = happyShift action_34
-action_49 (65) = happyShift action_35
-action_49 (66) = happyShift action_36
-action_49 (67) = happyShift action_37
-action_49 (70) = happyShift action_38
-action_49 (71) = happyShift action_39
-action_49 (72) = happyShift action_17
-action_49 (19) = happyGoto action_22
-action_49 (31) = happyGoto action_81
-action_49 (32) = happyGoto action_24
-action_49 (33) = happyGoto action_25
+action_49 (83) = happyAccept
 action_49 _ = happyFail (happyExpListPerState 49)
 
-action_50 (36) = happyShift action_27
-action_50 (43) = happyShift action_28
-action_50 (44) = happyShift action_29
-action_50 (51) = happyShift action_30
-action_50 (57) = happyShift action_31
-action_50 (58) = happyShift action_32
-action_50 (63) = happyShift action_33
-action_50 (64) = happyShift action_34
-action_50 (65) = happyShift action_35
-action_50 (66) = happyShift action_36
-action_50 (67) = happyShift action_37
-action_50 (70) = happyShift action_38
-action_50 (71) = happyShift action_39
-action_50 (72) = happyShift action_17
-action_50 (19) = happyGoto action_22
-action_50 (31) = happyGoto action_80
-action_50 (32) = happyGoto action_24
-action_50 (33) = happyGoto action_25
+action_50 (44) = happyShift action_99
 action_50 _ = happyFail (happyExpListPerState 50)
 
-action_51 (72) = happyShift action_17
-action_51 (19) = happyGoto action_79
-action_51 _ = happyFail (happyExpListPerState 51)
+action_51 (49) = happyShift action_98
+action_51 _ = happyReduce_44
 
-action_52 (72) = happyShift action_17
-action_52 (19) = happyGoto action_78
+action_52 (83) = happyAccept
 action_52 _ = happyFail (happyExpListPerState 52)
 
-action_53 (72) = happyShift action_17
-action_53 (19) = happyGoto action_77
+action_53 (44) = happyShift action_31
+action_53 (51) = happyShift action_32
+action_53 (52) = happyShift action_33
+action_53 (60) = happyShift action_34
+action_53 (66) = happyShift action_35
+action_53 (68) = happyShift action_36
+action_53 (73) = happyShift action_37
+action_53 (74) = happyShift action_38
+action_53 (75) = happyShift action_39
+action_53 (76) = happyShift action_40
+action_53 (77) = happyShift action_41
+action_53 (80) = happyShift action_42
+action_53 (81) = happyShift action_43
+action_53 (82) = happyShift action_21
+action_53 (23) = happyGoto action_26
+action_53 (39) = happyGoto action_97
+action_53 (40) = happyGoto action_28
+action_53 (41) = happyGoto action_29
 action_53 _ = happyFail (happyExpListPerState 53)
 
-action_54 (48) = happyShift action_76
+action_54 (44) = happyShift action_31
+action_54 (51) = happyShift action_32
+action_54 (52) = happyShift action_33
+action_54 (60) = happyShift action_34
+action_54 (66) = happyShift action_35
+action_54 (68) = happyShift action_36
+action_54 (73) = happyShift action_37
+action_54 (74) = happyShift action_38
+action_54 (75) = happyShift action_39
+action_54 (76) = happyShift action_40
+action_54 (77) = happyShift action_41
+action_54 (80) = happyShift action_42
+action_54 (81) = happyShift action_43
+action_54 (82) = happyShift action_21
+action_54 (23) = happyGoto action_26
+action_54 (39) = happyGoto action_96
+action_54 (40) = happyGoto action_28
+action_54 (41) = happyGoto action_29
 action_54 _ = happyFail (happyExpListPerState 54)
 
-action_55 (73) = happyAccept
+action_55 (82) = happyShift action_21
+action_55 (23) = happyGoto action_95
 action_55 _ = happyFail (happyExpListPerState 55)
 
-action_56 (41) = happyShift action_75
+action_56 (82) = happyShift action_21
+action_56 (23) = happyGoto action_94
 action_56 _ = happyFail (happyExpListPerState 56)
 
-action_57 (73) = happyAccept
+action_57 (82) = happyShift action_21
+action_57 (23) = happyGoto action_93
 action_57 _ = happyFail (happyExpListPerState 57)
 
-action_58 (72) = happyShift action_17
-action_58 (19) = happyGoto action_74
+action_58 (56) = happyShift action_92
 action_58 _ = happyFail (happyExpListPerState 58)
 
-action_59 (73) = happyAccept
+action_59 (83) = happyAccept
 action_59 _ = happyFail (happyExpListPerState 59)
 
-action_60 (36) = happyShift action_62
-action_60 (23) = happyGoto action_60
-action_60 (24) = happyGoto action_73
-action_60 _ = happyReduce_22
+action_60 (49) = happyShift action_91
+action_60 _ = happyFail (happyExpListPerState 60)
 
-action_61 (73) = happyAccept
+action_61 (83) = happyAccept
 action_61 _ = happyFail (happyExpListPerState 61)
 
-action_62 (72) = happyShift action_17
-action_62 (19) = happyGoto action_72
+action_62 (82) = happyShift action_21
+action_62 (23) = happyGoto action_90
 action_62 _ = happyFail (happyExpListPerState 62)
 
-action_63 (73) = happyAccept
+action_63 (83) = happyAccept
 action_63 _ = happyFail (happyExpListPerState 63)
 
-action_64 (73) = happyAccept
-action_64 _ = happyFail (happyExpListPerState 64)
+action_64 (44) = happyShift action_66
+action_64 (31) = happyGoto action_64
+action_64 (32) = happyGoto action_89
+action_64 _ = happyReduce_32
 
-action_65 (72) = happyShift action_17
-action_65 (19) = happyGoto action_71
+action_65 (83) = happyAccept
 action_65 _ = happyFail (happyExpListPerState 65)
 
-action_66 (73) = happyAccept
+action_66 (82) = happyShift action_21
+action_66 (23) = happyGoto action_88
 action_66 _ = happyFail (happyExpListPerState 66)
 
-action_67 (52) = happyShift action_65
-action_67 (21) = happyGoto action_70
-action_67 (22) = happyGoto action_67
-action_67 _ = happyReduce_18
+action_67 (83) = happyAccept
+action_67 _ = happyFail (happyExpListPerState 67)
 
-action_68 (73) = happyAccept
+action_68 (83) = happyAccept
 action_68 _ = happyFail (happyExpListPerState 68)
 
-action_69 _ = happyReduce_17
+action_69 (82) = happyShift action_21
+action_69 (23) = happyGoto action_87
+action_69 _ = happyFail (happyExpListPerState 69)
 
-action_70 _ = happyReduce_19
+action_70 (59) = happyShift action_72
+action_70 (28) = happyGoto action_70
+action_70 (29) = happyGoto action_86
+action_70 _ = happyReduce_28
 
-action_71 (36) = happyShift action_62
-action_71 (23) = happyGoto action_60
-action_71 (24) = happyGoto action_121
-action_71 _ = happyReduce_22
+action_71 (83) = happyAccept
+action_71 _ = happyFail (happyExpListPerState 71)
 
-action_72 (39) = happyShift action_120
+action_72 (82) = happyShift action_21
+action_72 (23) = happyGoto action_85
 action_72 _ = happyFail (happyExpListPerState 72)
 
-action_73 _ = happyReduce_23
+action_73 (83) = happyAccept
+action_73 _ = happyFail (happyExpListPerState 73)
 
-action_74 _ = happyReduce_24
+action_74 (83) = happyAccept
+action_74 _ = happyFail (happyExpListPerState 74)
 
-action_75 (49) = happyShift action_58
-action_75 (25) = happyGoto action_56
-action_75 (26) = happyGoto action_119
-action_75 _ = happyReduce_25
+action_75 (82) = happyShift action_21
+action_75 (23) = happyGoto action_84
+action_75 _ = happyFail (happyExpListPerState 75)
 
-action_76 (72) = happyShift action_17
-action_76 (19) = happyGoto action_118
+action_76 (83) = happyAccept
 action_76 _ = happyFail (happyExpListPerState 76)
 
-action_77 _ = happyReduce_30
+action_77 _ = happyReduce_24
 
-action_78 (59) = happyShift action_117
-action_78 _ = happyFail (happyExpListPerState 78)
+action_78 _ = happyReduce_25
 
-action_79 (55) = happyShift action_46
-action_79 (29) = happyGoto action_116
-action_79 _ = happyReduce_36
+action_79 (83) = happyAccept
+action_79 _ = happyFail (happyExpListPerState 79)
 
-action_80 _ = happyReduce_32
+action_80 (61) = happyShift action_75
+action_80 (67) = happyShift action_69
+action_80 (25) = happyGoto action_83
+action_80 (26) = happyGoto action_80
+action_80 (27) = happyGoto action_77
+action_80 (30) = happyGoto action_78
+action_80 _ = happyReduce_22
 
-action_81 (39) = happyShift action_115
+action_81 (83) = happyAccept
 action_81 _ = happyFail (happyExpListPerState 81)
 
-action_82 (46) = happyShift action_49
-action_82 (47) = happyShift action_50
-action_82 (48) = happyShift action_51
-action_82 (53) = happyShift action_52
-action_82 (54) = happyShift action_53
-action_82 (56) = happyShift action_54
-action_82 (27) = happyGoto action_47
-action_82 (28) = happyGoto action_114
-action_82 _ = happyReduce_33
+action_82 _ = happyReduce_21
 
-action_83 (72) = happyShift action_17
-action_83 (19) = happyGoto action_43
-action_83 (30) = happyGoto action_113
-action_83 _ = happyReduce_38
+action_83 _ = happyReduce_23
 
-action_84 (72) = happyShift action_17
-action_84 (19) = happyGoto action_43
-action_84 (30) = happyGoto action_112
-action_84 _ = happyReduce_38
+action_84 (59) = happyShift action_72
+action_84 (28) = happyGoto action_70
+action_84 (29) = happyGoto action_138
+action_84 _ = happyReduce_28
 
-action_85 _ = happyReduce_48
+action_85 _ = happyReduce_27
 
-action_86 _ = happyReduce_51
+action_86 _ = happyReduce_29
 
-action_87 _ = happyReduce_50
+action_87 (44) = happyShift action_66
+action_87 (31) = happyGoto action_64
+action_87 (32) = happyGoto action_137
+action_87 _ = happyReduce_32
 
-action_88 (69) = happyShift action_111
+action_88 (47) = happyShift action_136
 action_88 _ = happyFail (happyExpListPerState 88)
 
-action_89 (36) = happyShift action_20
-action_89 (45) = happyShift action_21
-action_89 (72) = happyShift action_17
-action_89 (19) = happyGoto action_18
-action_89 (35) = happyGoto action_110
-action_89 _ = happyFail (happyExpListPerState 89)
+action_89 _ = happyReduce_33
 
-action_90 (36) = happyShift action_20
-action_90 (45) = happyShift action_21
-action_90 (72) = happyShift action_17
-action_90 (19) = happyGoto action_18
-action_90 (35) = happyGoto action_109
-action_90 _ = happyFail (happyExpListPerState 90)
+action_90 _ = happyReduce_34
 
-action_91 (36) = happyShift action_27
-action_91 (43) = happyShift action_28
-action_91 (44) = happyShift action_29
-action_91 (51) = happyShift action_30
-action_91 (57) = happyShift action_31
-action_91 (58) = happyShift action_32
-action_91 (63) = happyShift action_33
-action_91 (64) = happyShift action_34
-action_91 (65) = happyShift action_35
-action_91 (66) = happyShift action_36
-action_91 (67) = happyShift action_37
-action_91 (70) = happyShift action_38
-action_91 (71) = happyShift action_39
-action_91 (72) = happyShift action_17
-action_91 (19) = happyGoto action_22
-action_91 (31) = happyGoto action_108
-action_91 (32) = happyGoto action_24
-action_91 (33) = happyGoto action_25
-action_91 _ = happyFail (happyExpListPerState 91)
+action_91 (57) = happyShift action_62
+action_91 (33) = happyGoto action_60
+action_91 (34) = happyGoto action_135
+action_91 _ = happyReduce_35
 
-action_92 (42) = happyShift action_107
+action_92 (82) = happyShift action_21
+action_92 (23) = happyGoto action_134
 action_92 _ = happyFail (happyExpListPerState 92)
 
-action_93 (36) = happyShift action_27
-action_93 (43) = happyShift action_28
-action_93 (44) = happyShift action_29
-action_93 (51) = happyShift action_30
-action_93 (57) = happyShift action_31
-action_93 (58) = happyShift action_32
-action_93 (63) = happyShift action_33
-action_93 (64) = happyShift action_34
-action_93 (65) = happyShift action_35
-action_93 (66) = happyShift action_36
-action_93 (67) = happyShift action_37
-action_93 (70) = happyShift action_38
-action_93 (71) = happyShift action_39
-action_93 (72) = happyShift action_17
-action_93 (19) = happyGoto action_22
-action_93 (31) = happyGoto action_106
-action_93 (32) = happyGoto action_24
-action_93 (33) = happyGoto action_25
-action_93 _ = happyFail (happyExpListPerState 93)
+action_93 _ = happyReduce_40
 
-action_94 (36) = happyShift action_27
-action_94 (43) = happyShift action_28
-action_94 (44) = happyShift action_29
-action_94 (51) = happyShift action_30
-action_94 (57) = happyShift action_31
-action_94 (58) = happyShift action_32
-action_94 (63) = happyShift action_33
-action_94 (64) = happyShift action_34
-action_94 (65) = happyShift action_35
-action_94 (66) = happyShift action_36
-action_94 (67) = happyShift action_37
-action_94 (70) = happyShift action_38
-action_94 (71) = happyShift action_39
-action_94 (72) = happyShift action_17
-action_94 (19) = happyGoto action_22
-action_94 (31) = happyGoto action_105
-action_94 (32) = happyGoto action_24
-action_94 (33) = happyGoto action_25
+action_94 (69) = happyShift action_133
 action_94 _ = happyFail (happyExpListPerState 94)
 
-action_95 (37) = happyShift action_102
-action_95 (38) = happyShift action_103
-action_95 (39) = happyShift action_104
-action_95 _ = happyFail (happyExpListPerState 95)
+action_95 (64) = happyShift action_50
+action_95 (37) = happyGoto action_132
+action_95 _ = happyReduce_46
 
-action_96 (36) = happyShift action_27
-action_96 (43) = happyShift action_28
-action_96 (44) = happyShift action_29
-action_96 (51) = happyShift action_30
-action_96 (57) = happyShift action_31
-action_96 (58) = happyShift action_32
-action_96 (63) = happyShift action_33
-action_96 (64) = happyShift action_34
-action_96 (65) = happyShift action_35
-action_96 (66) = happyShift action_36
-action_96 (67) = happyShift action_37
-action_96 (70) = happyShift action_38
-action_96 (71) = happyShift action_39
-action_96 (72) = happyShift action_17
-action_96 (19) = happyGoto action_22
-action_96 (31) = happyGoto action_101
-action_96 (32) = happyGoto action_24
-action_96 (33) = happyGoto action_25
-action_96 _ = happyFail (happyExpListPerState 96)
+action_96 _ = happyReduce_42
 
-action_97 (36) = happyShift action_27
-action_97 (43) = happyShift action_28
-action_97 (44) = happyShift action_29
-action_97 (51) = happyShift action_30
-action_97 (57) = happyShift action_31
-action_97 (58) = happyShift action_32
-action_97 (63) = happyShift action_33
-action_97 (64) = happyShift action_34
-action_97 (65) = happyShift action_35
-action_97 (66) = happyShift action_36
-action_97 (67) = happyShift action_37
-action_97 (70) = happyShift action_38
-action_97 (71) = happyShift action_39
-action_97 (72) = happyShift action_17
-action_97 (19) = happyGoto action_22
-action_97 (31) = happyGoto action_100
-action_97 (32) = happyGoto action_24
-action_97 (33) = happyGoto action_25
+action_97 (47) = happyShift action_131
 action_97 _ = happyFail (happyExpListPerState 97)
 
-action_98 (38) = happyShift action_99
-action_98 _ = happyFail (happyExpListPerState 98)
+action_98 (54) = happyShift action_53
+action_98 (55) = happyShift action_54
+action_98 (56) = happyShift action_55
+action_98 (62) = happyShift action_56
+action_98 (63) = happyShift action_57
+action_98 (65) = happyShift action_58
+action_98 (35) = happyGoto action_51
+action_98 (36) = happyGoto action_130
+action_98 _ = happyReduce_43
 
-action_99 (36) = happyShift action_20
-action_99 (45) = happyShift action_21
-action_99 (72) = happyShift action_17
-action_99 (19) = happyGoto action_18
-action_99 (35) = happyGoto action_138
-action_99 _ = happyFail (happyExpListPerState 99)
+action_99 (82) = happyShift action_21
+action_99 (23) = happyGoto action_47
+action_99 (38) = happyGoto action_129
+action_99 _ = happyReduce_48
 
-action_100 _ = happyReduce_45
+action_100 (82) = happyShift action_21
+action_100 (23) = happyGoto action_47
+action_100 (38) = happyGoto action_128
+action_100 _ = happyReduce_48
 
-action_101 _ = happyReduce_46
+action_101 _ = happyReduce_58
 
 action_102 _ = happyReduce_61
 
-action_103 (36) = happyShift action_27
-action_103 (43) = happyShift action_28
-action_103 (44) = happyShift action_29
-action_103 (51) = happyShift action_30
-action_103 (57) = happyShift action_31
-action_103 (58) = happyShift action_32
-action_103 (63) = happyShift action_33
-action_103 (64) = happyShift action_34
-action_103 (65) = happyShift action_35
-action_103 (66) = happyShift action_36
-action_103 (67) = happyShift action_37
-action_103 (70) = happyShift action_38
-action_103 (71) = happyShift action_39
-action_103 (72) = happyShift action_17
-action_103 (19) = happyGoto action_22
-action_103 (31) = happyGoto action_137
-action_103 (32) = happyGoto action_24
-action_103 (33) = happyGoto action_25
-action_103 _ = happyFail (happyExpListPerState 103)
+action_103 _ = happyReduce_60
 
-action_104 (36) = happyShift action_27
-action_104 (43) = happyShift action_28
-action_104 (44) = happyShift action_29
-action_104 (51) = happyShift action_30
-action_104 (57) = happyShift action_31
-action_104 (58) = happyShift action_32
-action_104 (63) = happyShift action_33
-action_104 (64) = happyShift action_34
-action_104 (65) = happyShift action_35
-action_104 (66) = happyShift action_36
-action_104 (67) = happyShift action_37
-action_104 (70) = happyShift action_38
-action_104 (71) = happyShift action_39
-action_104 (72) = happyShift action_17
-action_104 (19) = happyGoto action_22
-action_104 (31) = happyGoto action_136
-action_104 (32) = happyGoto action_24
-action_104 (33) = happyGoto action_25
+action_104 (79) = happyShift action_127
 action_104 _ = happyFail (happyExpListPerState 104)
 
-action_105 (38) = happyShift action_135
+action_105 (44) = happyShift action_24
+action_105 (53) = happyShift action_25
+action_105 (82) = happyShift action_21
+action_105 (23) = happyGoto action_22
+action_105 (43) = happyGoto action_126
 action_105 _ = happyFail (happyExpListPerState 105)
 
-action_106 (38) = happyShift action_134
+action_106 (44) = happyShift action_24
+action_106 (53) = happyShift action_25
+action_106 (82) = happyShift action_21
+action_106 (23) = happyGoto action_22
+action_106 (43) = happyGoto action_125
 action_106 _ = happyFail (happyExpListPerState 106)
 
-action_107 (36) = happyShift action_27
-action_107 (43) = happyShift action_28
-action_107 (44) = happyShift action_29
-action_107 (51) = happyShift action_30
-action_107 (57) = happyShift action_31
-action_107 (58) = happyShift action_32
-action_107 (63) = happyShift action_33
-action_107 (64) = happyShift action_34
-action_107 (65) = happyShift action_35
-action_107 (66) = happyShift action_36
-action_107 (67) = happyShift action_37
-action_107 (70) = happyShift action_38
-action_107 (71) = happyShift action_39
-action_107 (72) = happyShift action_17
-action_107 (19) = happyGoto action_22
-action_107 (31) = happyGoto action_133
-action_107 (32) = happyGoto action_24
-action_107 (33) = happyGoto action_25
+action_107 (44) = happyShift action_31
+action_107 (51) = happyShift action_32
+action_107 (52) = happyShift action_33
+action_107 (60) = happyShift action_34
+action_107 (66) = happyShift action_35
+action_107 (68) = happyShift action_36
+action_107 (73) = happyShift action_37
+action_107 (74) = happyShift action_38
+action_107 (75) = happyShift action_39
+action_107 (76) = happyShift action_40
+action_107 (77) = happyShift action_41
+action_107 (80) = happyShift action_42
+action_107 (81) = happyShift action_43
+action_107 (82) = happyShift action_21
+action_107 (23) = happyGoto action_26
+action_107 (39) = happyGoto action_124
+action_107 (40) = happyGoto action_28
+action_107 (41) = happyGoto action_29
 action_107 _ = happyFail (happyExpListPerState 107)
 
-action_108 (37) = happyShift action_132
+action_108 (50) = happyShift action_123
 action_108 _ = happyFail (happyExpListPerState 108)
 
-action_109 (39) = happyShift action_131
+action_109 (44) = happyShift action_31
+action_109 (51) = happyShift action_32
+action_109 (52) = happyShift action_33
+action_109 (60) = happyShift action_34
+action_109 (66) = happyShift action_35
+action_109 (68) = happyShift action_36
+action_109 (73) = happyShift action_37
+action_109 (74) = happyShift action_38
+action_109 (75) = happyShift action_39
+action_109 (76) = happyShift action_40
+action_109 (77) = happyShift action_41
+action_109 (80) = happyShift action_42
+action_109 (81) = happyShift action_43
+action_109 (82) = happyShift action_21
+action_109 (23) = happyGoto action_26
+action_109 (39) = happyGoto action_122
+action_109 (40) = happyGoto action_28
+action_109 (41) = happyGoto action_29
 action_109 _ = happyFail (happyExpListPerState 109)
 
-action_110 (39) = happyShift action_130
+action_110 (44) = happyShift action_31
+action_110 (51) = happyShift action_32
+action_110 (52) = happyShift action_33
+action_110 (60) = happyShift action_34
+action_110 (66) = happyShift action_35
+action_110 (68) = happyShift action_36
+action_110 (73) = happyShift action_37
+action_110 (74) = happyShift action_38
+action_110 (75) = happyShift action_39
+action_110 (76) = happyShift action_40
+action_110 (77) = happyShift action_41
+action_110 (80) = happyShift action_42
+action_110 (81) = happyShift action_43
+action_110 (82) = happyShift action_21
+action_110 (23) = happyGoto action_26
+action_110 (39) = happyGoto action_121
+action_110 (40) = happyGoto action_28
+action_110 (41) = happyGoto action_29
 action_110 _ = happyFail (happyExpListPerState 110)
 
-action_111 (36) = happyShift action_27
-action_111 (43) = happyShift action_28
-action_111 (44) = happyShift action_29
-action_111 (51) = happyShift action_30
-action_111 (57) = happyShift action_31
-action_111 (58) = happyShift action_32
-action_111 (63) = happyShift action_33
-action_111 (64) = happyShift action_34
-action_111 (65) = happyShift action_35
-action_111 (66) = happyShift action_36
-action_111 (67) = happyShift action_37
-action_111 (70) = happyShift action_38
-action_111 (71) = happyShift action_39
-action_111 (72) = happyShift action_17
-action_111 (19) = happyGoto action_22
-action_111 (31) = happyGoto action_23
-action_111 (32) = happyGoto action_24
-action_111 (33) = happyGoto action_25
-action_111 (34) = happyGoto action_129
+action_111 (45) = happyShift action_118
+action_111 (46) = happyShift action_119
+action_111 (47) = happyShift action_120
 action_111 _ = happyFail (happyExpListPerState 111)
 
-action_112 _ = happyReduce_40
+action_112 (44) = happyShift action_31
+action_112 (51) = happyShift action_32
+action_112 (52) = happyShift action_33
+action_112 (60) = happyShift action_34
+action_112 (66) = happyShift action_35
+action_112 (68) = happyShift action_36
+action_112 (73) = happyShift action_37
+action_112 (74) = happyShift action_38
+action_112 (75) = happyShift action_39
+action_112 (76) = happyShift action_40
+action_112 (77) = happyShift action_41
+action_112 (80) = happyShift action_42
+action_112 (81) = happyShift action_43
+action_112 (82) = happyShift action_21
+action_112 (23) = happyGoto action_26
+action_112 (39) = happyGoto action_117
+action_112 (40) = happyGoto action_28
+action_112 (41) = happyGoto action_29
+action_112 _ = happyFail (happyExpListPerState 112)
 
-action_113 (37) = happyShift action_128
+action_113 (44) = happyShift action_31
+action_113 (51) = happyShift action_32
+action_113 (52) = happyShift action_33
+action_113 (60) = happyShift action_34
+action_113 (66) = happyShift action_35
+action_113 (68) = happyShift action_36
+action_113 (73) = happyShift action_37
+action_113 (74) = happyShift action_38
+action_113 (75) = happyShift action_39
+action_113 (76) = happyShift action_40
+action_113 (77) = happyShift action_41
+action_113 (80) = happyShift action_42
+action_113 (81) = happyShift action_43
+action_113 (82) = happyShift action_21
+action_113 (23) = happyGoto action_26
+action_113 (39) = happyGoto action_116
+action_113 (40) = happyGoto action_28
+action_113 (41) = happyGoto action_29
 action_113 _ = happyFail (happyExpListPerState 113)
 
-action_114 _ = happyReduce_35
+action_114 (46) = happyShift action_115
+action_114 _ = happyFail (happyExpListPerState 114)
 
-action_115 (36) = happyShift action_27
-action_115 (43) = happyShift action_28
-action_115 (44) = happyShift action_29
-action_115 (51) = happyShift action_30
-action_115 (57) = happyShift action_31
-action_115 (58) = happyShift action_32
-action_115 (63) = happyShift action_33
-action_115 (64) = happyShift action_34
-action_115 (65) = happyShift action_35
-action_115 (66) = happyShift action_36
-action_115 (67) = happyShift action_37
-action_115 (70) = happyShift action_38
-action_115 (71) = happyShift action_39
-action_115 (72) = happyShift action_17
-action_115 (19) = happyGoto action_22
-action_115 (31) = happyGoto action_127
-action_115 (32) = happyGoto action_24
-action_115 (33) = happyGoto action_25
+action_115 (44) = happyShift action_24
+action_115 (53) = happyShift action_25
+action_115 (82) = happyShift action_21
+action_115 (23) = happyGoto action_22
+action_115 (43) = happyGoto action_156
 action_115 _ = happyFail (happyExpListPerState 115)
 
-action_116 (39) = happyShift action_126
-action_116 _ = happyFail (happyExpListPerState 116)
+action_116 _ = happyReduce_55
 
-action_117 (60) = happyShift action_125
-action_117 _ = happyFail (happyExpListPerState 117)
+action_117 _ = happyReduce_56
 
-action_118 (55) = happyShift action_46
-action_118 (29) = happyGoto action_124
-action_118 _ = happyReduce_36
+action_118 _ = happyReduce_71
 
-action_119 _ = happyReduce_26
+action_119 (44) = happyShift action_31
+action_119 (51) = happyShift action_32
+action_119 (52) = happyShift action_33
+action_119 (60) = happyShift action_34
+action_119 (66) = happyShift action_35
+action_119 (68) = happyShift action_36
+action_119 (73) = happyShift action_37
+action_119 (74) = happyShift action_38
+action_119 (75) = happyShift action_39
+action_119 (76) = happyShift action_40
+action_119 (77) = happyShift action_41
+action_119 (80) = happyShift action_42
+action_119 (81) = happyShift action_43
+action_119 (82) = happyShift action_21
+action_119 (23) = happyGoto action_26
+action_119 (39) = happyGoto action_155
+action_119 (40) = happyGoto action_28
+action_119 (41) = happyGoto action_29
+action_119 _ = happyFail (happyExpListPerState 119)
 
-action_120 (36) = happyShift action_27
-action_120 (43) = happyShift action_28
-action_120 (44) = happyShift action_29
-action_120 (51) = happyShift action_30
-action_120 (57) = happyShift action_31
-action_120 (58) = happyShift action_32
-action_120 (63) = happyShift action_33
-action_120 (64) = happyShift action_34
-action_120 (65) = happyShift action_35
-action_120 (66) = happyShift action_36
-action_120 (67) = happyShift action_37
-action_120 (70) = happyShift action_38
-action_120 (71) = happyShift action_39
-action_120 (72) = happyShift action_17
-action_120 (19) = happyGoto action_22
-action_120 (31) = happyGoto action_123
-action_120 (32) = happyGoto action_24
-action_120 (33) = happyGoto action_25
+action_120 (44) = happyShift action_31
+action_120 (51) = happyShift action_32
+action_120 (52) = happyShift action_33
+action_120 (60) = happyShift action_34
+action_120 (66) = happyShift action_35
+action_120 (68) = happyShift action_36
+action_120 (73) = happyShift action_37
+action_120 (74) = happyShift action_38
+action_120 (75) = happyShift action_39
+action_120 (76) = happyShift action_40
+action_120 (77) = happyShift action_41
+action_120 (80) = happyShift action_42
+action_120 (81) = happyShift action_43
+action_120 (82) = happyShift action_21
+action_120 (23) = happyGoto action_26
+action_120 (39) = happyGoto action_154
+action_120 (40) = happyGoto action_28
+action_120 (41) = happyGoto action_29
 action_120 _ = happyFail (happyExpListPerState 120)
 
-action_121 (41) = happyShift action_122
+action_121 (46) = happyShift action_153
 action_121 _ = happyFail (happyExpListPerState 121)
 
-action_122 (49) = happyShift action_58
-action_122 (25) = happyGoto action_56
-action_122 (26) = happyGoto action_151
-action_122 _ = happyReduce_25
+action_122 (46) = happyShift action_152
+action_122 _ = happyFail (happyExpListPerState 122)
 
-action_123 (37) = happyShift action_150
+action_123 (44) = happyShift action_31
+action_123 (51) = happyShift action_32
+action_123 (52) = happyShift action_33
+action_123 (60) = happyShift action_34
+action_123 (66) = happyShift action_35
+action_123 (68) = happyShift action_36
+action_123 (73) = happyShift action_37
+action_123 (74) = happyShift action_38
+action_123 (75) = happyShift action_39
+action_123 (76) = happyShift action_40
+action_123 (77) = happyShift action_41
+action_123 (80) = happyShift action_42
+action_123 (81) = happyShift action_43
+action_123 (82) = happyShift action_21
+action_123 (23) = happyGoto action_26
+action_123 (39) = happyGoto action_151
+action_123 (40) = happyGoto action_28
+action_123 (41) = happyGoto action_29
 action_123 _ = happyFail (happyExpListPerState 123)
 
-action_124 (39) = happyShift action_149
+action_124 (45) = happyShift action_150
 action_124 _ = happyFail (happyExpListPerState 124)
 
-action_125 (46) = happyShift action_49
-action_125 (47) = happyShift action_50
-action_125 (48) = happyShift action_51
-action_125 (53) = happyShift action_52
-action_125 (54) = happyShift action_53
-action_125 (56) = happyShift action_54
-action_125 (27) = happyGoto action_47
-action_125 (28) = happyGoto action_148
-action_125 _ = happyReduce_33
+action_125 (47) = happyShift action_149
+action_125 _ = happyFail (happyExpListPerState 125)
 
-action_126 (36) = happyShift action_27
-action_126 (43) = happyShift action_28
-action_126 (44) = happyShift action_29
-action_126 (51) = happyShift action_30
-action_126 (57) = happyShift action_31
-action_126 (58) = happyShift action_32
-action_126 (63) = happyShift action_33
-action_126 (64) = happyShift action_34
-action_126 (65) = happyShift action_35
-action_126 (66) = happyShift action_36
-action_126 (67) = happyShift action_37
-action_126 (70) = happyShift action_38
-action_126 (71) = happyShift action_39
-action_126 (72) = happyShift action_17
-action_126 (19) = happyGoto action_22
-action_126 (31) = happyGoto action_147
-action_126 (32) = happyGoto action_24
-action_126 (33) = happyGoto action_25
+action_126 (47) = happyShift action_148
 action_126 _ = happyFail (happyExpListPerState 126)
 
-action_127 _ = happyReduce_31
+action_127 (44) = happyShift action_31
+action_127 (51) = happyShift action_32
+action_127 (52) = happyShift action_33
+action_127 (60) = happyShift action_34
+action_127 (66) = happyShift action_35
+action_127 (68) = happyShift action_36
+action_127 (73) = happyShift action_37
+action_127 (74) = happyShift action_38
+action_127 (75) = happyShift action_39
+action_127 (76) = happyShift action_40
+action_127 (77) = happyShift action_41
+action_127 (80) = happyShift action_42
+action_127 (81) = happyShift action_43
+action_127 (82) = happyShift action_21
+action_127 (23) = happyGoto action_26
+action_127 (39) = happyGoto action_27
+action_127 (40) = happyGoto action_28
+action_127 (41) = happyGoto action_29
+action_127 (42) = happyGoto action_147
+action_127 _ = happyFail (happyExpListPerState 127)
 
-action_128 _ = happyReduce_37
+action_128 _ = happyReduce_50
 
-action_129 _ = happyReduce_43
+action_129 (45) = happyShift action_146
+action_129 _ = happyFail (happyExpListPerState 129)
 
-action_130 (36) = happyShift action_27
-action_130 (43) = happyShift action_28
-action_130 (44) = happyShift action_29
-action_130 (51) = happyShift action_30
-action_130 (57) = happyShift action_31
-action_130 (58) = happyShift action_32
-action_130 (63) = happyShift action_33
-action_130 (64) = happyShift action_34
-action_130 (65) = happyShift action_35
-action_130 (66) = happyShift action_36
-action_130 (67) = happyShift action_37
-action_130 (70) = happyShift action_38
-action_130 (71) = happyShift action_39
-action_130 (72) = happyShift action_17
-action_130 (19) = happyGoto action_22
-action_130 (31) = happyGoto action_146
-action_130 (32) = happyGoto action_24
-action_130 (33) = happyGoto action_25
-action_130 _ = happyFail (happyExpListPerState 130)
+action_130 _ = happyReduce_45
 
-action_131 (36) = happyShift action_27
-action_131 (43) = happyShift action_28
-action_131 (44) = happyShift action_29
-action_131 (51) = happyShift action_30
-action_131 (57) = happyShift action_31
-action_131 (58) = happyShift action_32
-action_131 (63) = happyShift action_33
-action_131 (64) = happyShift action_34
-action_131 (65) = happyShift action_35
-action_131 (66) = happyShift action_36
-action_131 (67) = happyShift action_37
-action_131 (70) = happyShift action_38
-action_131 (71) = happyShift action_39
-action_131 (72) = happyShift action_17
-action_131 (19) = happyGoto action_22
-action_131 (31) = happyGoto action_145
-action_131 (32) = happyGoto action_24
-action_131 (33) = happyGoto action_25
+action_131 (44) = happyShift action_31
+action_131 (51) = happyShift action_32
+action_131 (52) = happyShift action_33
+action_131 (60) = happyShift action_34
+action_131 (66) = happyShift action_35
+action_131 (68) = happyShift action_36
+action_131 (73) = happyShift action_37
+action_131 (74) = happyShift action_38
+action_131 (75) = happyShift action_39
+action_131 (76) = happyShift action_40
+action_131 (77) = happyShift action_41
+action_131 (80) = happyShift action_42
+action_131 (81) = happyShift action_43
+action_131 (82) = happyShift action_21
+action_131 (23) = happyGoto action_26
+action_131 (39) = happyGoto action_145
+action_131 (40) = happyGoto action_28
+action_131 (41) = happyGoto action_29
 action_131 _ = happyFail (happyExpListPerState 131)
 
-action_132 _ = happyReduce_57
+action_132 (47) = happyShift action_144
+action_132 _ = happyFail (happyExpListPerState 132)
 
-action_133 (50) = happyShift action_144
+action_133 (70) = happyShift action_143
 action_133 _ = happyFail (happyExpListPerState 133)
 
-action_134 (36) = happyShift action_27
-action_134 (43) = happyShift action_28
-action_134 (44) = happyShift action_29
-action_134 (51) = happyShift action_30
-action_134 (57) = happyShift action_31
-action_134 (58) = happyShift action_32
-action_134 (63) = happyShift action_33
-action_134 (64) = happyShift action_34
-action_134 (65) = happyShift action_35
-action_134 (66) = happyShift action_36
-action_134 (67) = happyShift action_37
-action_134 (70) = happyShift action_38
-action_134 (71) = happyShift action_39
-action_134 (72) = happyShift action_17
-action_134 (19) = happyGoto action_22
-action_134 (31) = happyGoto action_143
-action_134 (32) = happyGoto action_24
-action_134 (33) = happyGoto action_25
-action_134 _ = happyFail (happyExpListPerState 134)
+action_134 (64) = happyShift action_50
+action_134 (37) = happyGoto action_142
+action_134 _ = happyReduce_46
 
-action_135 (36) = happyShift action_27
-action_135 (43) = happyShift action_28
-action_135 (44) = happyShift action_29
-action_135 (51) = happyShift action_30
-action_135 (57) = happyShift action_31
-action_135 (58) = happyShift action_32
-action_135 (63) = happyShift action_33
-action_135 (64) = happyShift action_34
-action_135 (65) = happyShift action_35
-action_135 (66) = happyShift action_36
-action_135 (67) = happyShift action_37
-action_135 (70) = happyShift action_38
-action_135 (71) = happyShift action_39
-action_135 (72) = happyShift action_17
-action_135 (19) = happyGoto action_22
-action_135 (31) = happyGoto action_142
-action_135 (32) = happyGoto action_24
-action_135 (33) = happyGoto action_25
-action_135 _ = happyFail (happyExpListPerState 135)
+action_135 _ = happyReduce_36
 
-action_136 (37) = happyShift action_141
+action_136 (44) = happyShift action_31
+action_136 (51) = happyShift action_32
+action_136 (52) = happyShift action_33
+action_136 (60) = happyShift action_34
+action_136 (66) = happyShift action_35
+action_136 (68) = happyShift action_36
+action_136 (73) = happyShift action_37
+action_136 (74) = happyShift action_38
+action_136 (75) = happyShift action_39
+action_136 (76) = happyShift action_40
+action_136 (77) = happyShift action_41
+action_136 (80) = happyShift action_42
+action_136 (81) = happyShift action_43
+action_136 (82) = happyShift action_21
+action_136 (23) = happyGoto action_26
+action_136 (39) = happyGoto action_141
+action_136 (40) = happyGoto action_28
+action_136 (41) = happyGoto action_29
 action_136 _ = happyFail (happyExpListPerState 136)
 
-action_137 (37) = happyShift action_140
+action_137 (49) = happyShift action_140
 action_137 _ = happyFail (happyExpListPerState 137)
 
-action_138 (37) = happyShift action_139
-action_138 _ = happyFail (happyExpListPerState 138)
+action_138 (44) = happyShift action_66
+action_138 (31) = happyGoto action_64
+action_138 (32) = happyGoto action_139
+action_138 _ = happyReduce_32
 
-action_139 _ = happyReduce_65
+action_139 (49) = happyShift action_169
+action_139 _ = happyFail (happyExpListPerState 139)
 
-action_140 _ = happyReduce_59
+action_140 _ = happyReduce_30
 
-action_141 _ = happyReduce_60
+action_141 (45) = happyShift action_168
+action_141 _ = happyFail (happyExpListPerState 141)
 
-action_142 (38) = happyShift action_160
+action_142 (47) = happyShift action_167
 action_142 _ = happyFail (happyExpListPerState 142)
 
-action_143 (38) = happyShift action_159
-action_143 _ = happyFail (happyExpListPerState 143)
+action_143 (54) = happyShift action_53
+action_143 (55) = happyShift action_54
+action_143 (56) = happyShift action_55
+action_143 (62) = happyShift action_56
+action_143 (63) = happyShift action_57
+action_143 (65) = happyShift action_58
+action_143 (35) = happyGoto action_51
+action_143 (36) = happyGoto action_166
+action_143 _ = happyReduce_43
 
-action_144 (36) = happyShift action_27
-action_144 (43) = happyShift action_28
-action_144 (44) = happyShift action_29
-action_144 (51) = happyShift action_30
-action_144 (57) = happyShift action_31
-action_144 (58) = happyShift action_32
-action_144 (63) = happyShift action_33
-action_144 (64) = happyShift action_34
-action_144 (65) = happyShift action_35
-action_144 (66) = happyShift action_36
-action_144 (67) = happyShift action_37
-action_144 (70) = happyShift action_38
-action_144 (71) = happyShift action_39
-action_144 (72) = happyShift action_17
-action_144 (19) = happyGoto action_22
-action_144 (31) = happyGoto action_23
-action_144 (32) = happyGoto action_24
-action_144 (33) = happyGoto action_25
-action_144 (34) = happyGoto action_158
+action_144 (44) = happyShift action_31
+action_144 (51) = happyShift action_32
+action_144 (52) = happyShift action_33
+action_144 (60) = happyShift action_34
+action_144 (66) = happyShift action_35
+action_144 (68) = happyShift action_36
+action_144 (73) = happyShift action_37
+action_144 (74) = happyShift action_38
+action_144 (75) = happyShift action_39
+action_144 (76) = happyShift action_40
+action_144 (77) = happyShift action_41
+action_144 (80) = happyShift action_42
+action_144 (81) = happyShift action_43
+action_144 (82) = happyShift action_21
+action_144 (23) = happyGoto action_26
+action_144 (39) = happyGoto action_165
+action_144 (40) = happyGoto action_28
+action_144 (41) = happyGoto action_29
 action_144 _ = happyFail (happyExpListPerState 144)
 
-action_145 (37) = happyShift action_157
-action_145 _ = happyFail (happyExpListPerState 145)
+action_145 _ = happyReduce_41
 
-action_146 (37) = happyShift action_156
-action_146 _ = happyFail (happyExpListPerState 146)
+action_146 _ = happyReduce_47
 
-action_147 (40) = happyShift action_155
-action_147 _ = happyFail (happyExpListPerState 147)
+action_147 _ = happyReduce_53
 
-action_148 (61) = happyShift action_154
+action_148 (44) = happyShift action_31
+action_148 (51) = happyShift action_32
+action_148 (52) = happyShift action_33
+action_148 (60) = happyShift action_34
+action_148 (66) = happyShift action_35
+action_148 (68) = happyShift action_36
+action_148 (73) = happyShift action_37
+action_148 (74) = happyShift action_38
+action_148 (75) = happyShift action_39
+action_148 (76) = happyShift action_40
+action_148 (77) = happyShift action_41
+action_148 (80) = happyShift action_42
+action_148 (81) = happyShift action_43
+action_148 (82) = happyShift action_21
+action_148 (23) = happyGoto action_26
+action_148 (39) = happyGoto action_164
+action_148 (40) = happyGoto action_28
+action_148 (41) = happyGoto action_29
 action_148 _ = happyFail (happyExpListPerState 148)
 
-action_149 (36) = happyShift action_27
-action_149 (43) = happyShift action_28
-action_149 (44) = happyShift action_29
-action_149 (51) = happyShift action_30
-action_149 (57) = happyShift action_31
-action_149 (58) = happyShift action_32
-action_149 (63) = happyShift action_33
-action_149 (64) = happyShift action_34
-action_149 (65) = happyShift action_35
-action_149 (66) = happyShift action_36
-action_149 (67) = happyShift action_37
-action_149 (70) = happyShift action_38
-action_149 (71) = happyShift action_39
-action_149 (72) = happyShift action_17
-action_149 (19) = happyGoto action_22
-action_149 (31) = happyGoto action_153
-action_149 (32) = happyGoto action_24
-action_149 (33) = happyGoto action_25
+action_149 (44) = happyShift action_31
+action_149 (51) = happyShift action_32
+action_149 (52) = happyShift action_33
+action_149 (60) = happyShift action_34
+action_149 (66) = happyShift action_35
+action_149 (68) = happyShift action_36
+action_149 (73) = happyShift action_37
+action_149 (74) = happyShift action_38
+action_149 (75) = happyShift action_39
+action_149 (76) = happyShift action_40
+action_149 (77) = happyShift action_41
+action_149 (80) = happyShift action_42
+action_149 (81) = happyShift action_43
+action_149 (82) = happyShift action_21
+action_149 (23) = happyGoto action_26
+action_149 (39) = happyGoto action_163
+action_149 (40) = happyGoto action_28
+action_149 (41) = happyGoto action_29
 action_149 _ = happyFail (happyExpListPerState 149)
 
-action_150 _ = happyReduce_21
+action_150 _ = happyReduce_67
 
-action_151 (46) = happyShift action_49
-action_151 (47) = happyShift action_50
-action_151 (48) = happyShift action_51
-action_151 (53) = happyShift action_52
-action_151 (54) = happyShift action_53
-action_151 (56) = happyShift action_54
-action_151 (27) = happyGoto action_47
-action_151 (28) = happyGoto action_152
-action_151 _ = happyReduce_33
+action_151 (58) = happyShift action_162
+action_151 _ = happyFail (happyExpListPerState 151)
 
-action_152 _ = happyReduce_20
+action_152 (44) = happyShift action_31
+action_152 (51) = happyShift action_32
+action_152 (52) = happyShift action_33
+action_152 (60) = happyShift action_34
+action_152 (66) = happyShift action_35
+action_152 (68) = happyShift action_36
+action_152 (73) = happyShift action_37
+action_152 (74) = happyShift action_38
+action_152 (75) = happyShift action_39
+action_152 (76) = happyShift action_40
+action_152 (77) = happyShift action_41
+action_152 (80) = happyShift action_42
+action_152 (81) = happyShift action_43
+action_152 (82) = happyShift action_21
+action_152 (23) = happyGoto action_26
+action_152 (39) = happyGoto action_161
+action_152 (40) = happyGoto action_28
+action_152 (41) = happyGoto action_29
+action_152 _ = happyFail (happyExpListPerState 152)
 
-action_153 (40) = happyShift action_166
+action_153 (44) = happyShift action_31
+action_153 (51) = happyShift action_32
+action_153 (52) = happyShift action_33
+action_153 (60) = happyShift action_34
+action_153 (66) = happyShift action_35
+action_153 (68) = happyShift action_36
+action_153 (73) = happyShift action_37
+action_153 (74) = happyShift action_38
+action_153 (75) = happyShift action_39
+action_153 (76) = happyShift action_40
+action_153 (77) = happyShift action_41
+action_153 (80) = happyShift action_42
+action_153 (81) = happyShift action_43
+action_153 (82) = happyShift action_21
+action_153 (23) = happyGoto action_26
+action_153 (39) = happyGoto action_160
+action_153 (40) = happyGoto action_28
+action_153 (41) = happyGoto action_29
 action_153 _ = happyFail (happyExpListPerState 153)
 
-action_154 _ = happyReduce_29
+action_154 (45) = happyShift action_159
+action_154 _ = happyFail (happyExpListPerState 154)
 
-action_155 (36) = happyShift action_27
-action_155 (43) = happyShift action_28
-action_155 (44) = happyShift action_29
-action_155 (51) = happyShift action_30
-action_155 (57) = happyShift action_31
-action_155 (58) = happyShift action_32
-action_155 (63) = happyShift action_33
-action_155 (64) = happyShift action_34
-action_155 (65) = happyShift action_35
-action_155 (66) = happyShift action_36
-action_155 (67) = happyShift action_37
-action_155 (70) = happyShift action_38
-action_155 (71) = happyShift action_39
-action_155 (72) = happyShift action_17
-action_155 (19) = happyGoto action_22
-action_155 (31) = happyGoto action_165
-action_155 (32) = happyGoto action_24
-action_155 (33) = happyGoto action_25
+action_155 (45) = happyShift action_158
 action_155 _ = happyFail (happyExpListPerState 155)
 
-action_156 (62) = happyShift action_164
+action_156 (45) = happyShift action_157
 action_156 _ = happyFail (happyExpListPerState 156)
 
-action_157 (68) = happyShift action_163
-action_157 _ = happyFail (happyExpListPerState 157)
+action_157 _ = happyReduce_75
 
-action_158 _ = happyReduce_44
+action_158 _ = happyReduce_69
 
-action_159 (36) = happyShift action_27
-action_159 (43) = happyShift action_28
-action_159 (44) = happyShift action_29
-action_159 (51) = happyShift action_30
-action_159 (57) = happyShift action_31
-action_159 (58) = happyShift action_32
-action_159 (63) = happyShift action_33
-action_159 (64) = happyShift action_34
-action_159 (65) = happyShift action_35
-action_159 (66) = happyShift action_36
-action_159 (67) = happyShift action_37
-action_159 (70) = happyShift action_38
-action_159 (71) = happyShift action_39
-action_159 (72) = happyShift action_17
-action_159 (19) = happyGoto action_22
-action_159 (31) = happyGoto action_162
-action_159 (32) = happyGoto action_24
-action_159 (33) = happyGoto action_25
-action_159 _ = happyFail (happyExpListPerState 159)
+action_159 _ = happyReduce_70
 
-action_160 (36) = happyShift action_27
-action_160 (43) = happyShift action_28
-action_160 (44) = happyShift action_29
-action_160 (51) = happyShift action_30
-action_160 (57) = happyShift action_31
-action_160 (58) = happyShift action_32
-action_160 (63) = happyShift action_33
-action_160 (64) = happyShift action_34
-action_160 (65) = happyShift action_35
-action_160 (66) = happyShift action_36
-action_160 (67) = happyShift action_37
-action_160 (70) = happyShift action_38
-action_160 (71) = happyShift action_39
-action_160 (72) = happyShift action_17
-action_160 (19) = happyGoto action_22
-action_160 (31) = happyGoto action_161
-action_160 (32) = happyGoto action_24
-action_160 (33) = happyGoto action_25
+action_160 (46) = happyShift action_178
 action_160 _ = happyFail (happyExpListPerState 160)
 
-action_161 (37) = happyShift action_171
+action_161 (46) = happyShift action_177
 action_161 _ = happyFail (happyExpListPerState 161)
 
-action_162 (37) = happyShift action_170
+action_162 (44) = happyShift action_31
+action_162 (51) = happyShift action_32
+action_162 (52) = happyShift action_33
+action_162 (60) = happyShift action_34
+action_162 (66) = happyShift action_35
+action_162 (68) = happyShift action_36
+action_162 (73) = happyShift action_37
+action_162 (74) = happyShift action_38
+action_162 (75) = happyShift action_39
+action_162 (76) = happyShift action_40
+action_162 (77) = happyShift action_41
+action_162 (80) = happyShift action_42
+action_162 (81) = happyShift action_43
+action_162 (82) = happyShift action_21
+action_162 (23) = happyGoto action_26
+action_162 (39) = happyGoto action_27
+action_162 (40) = happyGoto action_28
+action_162 (41) = happyGoto action_29
+action_162 (42) = happyGoto action_176
 action_162 _ = happyFail (happyExpListPerState 162)
 
-action_163 (36) = happyShift action_27
-action_163 (43) = happyShift action_28
-action_163 (44) = happyShift action_29
-action_163 (51) = happyShift action_30
-action_163 (57) = happyShift action_31
-action_163 (58) = happyShift action_32
-action_163 (63) = happyShift action_33
-action_163 (64) = happyShift action_34
-action_163 (65) = happyShift action_35
-action_163 (66) = happyShift action_36
-action_163 (67) = happyShift action_37
-action_163 (70) = happyShift action_38
-action_163 (71) = happyShift action_39
-action_163 (72) = happyShift action_17
-action_163 (19) = happyGoto action_22
-action_163 (31) = happyGoto action_23
-action_163 (32) = happyGoto action_24
-action_163 (33) = happyGoto action_25
-action_163 (34) = happyGoto action_169
+action_163 (45) = happyShift action_175
 action_163 _ = happyFail (happyExpListPerState 163)
 
-action_164 (36) = happyShift action_27
-action_164 (43) = happyShift action_28
-action_164 (44) = happyShift action_29
-action_164 (51) = happyShift action_30
-action_164 (57) = happyShift action_31
-action_164 (58) = happyShift action_32
-action_164 (63) = happyShift action_33
-action_164 (64) = happyShift action_34
-action_164 (65) = happyShift action_35
-action_164 (66) = happyShift action_36
-action_164 (67) = happyShift action_37
-action_164 (70) = happyShift action_38
-action_164 (71) = happyShift action_39
-action_164 (72) = happyShift action_17
-action_164 (19) = happyGoto action_22
-action_164 (31) = happyGoto action_23
-action_164 (32) = happyGoto action_24
-action_164 (33) = happyGoto action_25
-action_164 (34) = happyGoto action_168
+action_164 (45) = happyShift action_174
 action_164 _ = happyFail (happyExpListPerState 164)
 
-action_165 _ = happyReduce_27
+action_165 (48) = happyShift action_173
+action_165 _ = happyFail (happyExpListPerState 165)
 
-action_166 (36) = happyShift action_27
-action_166 (43) = happyShift action_28
-action_166 (44) = happyShift action_29
-action_166 (51) = happyShift action_30
-action_166 (57) = happyShift action_31
-action_166 (58) = happyShift action_32
-action_166 (63) = happyShift action_33
-action_166 (64) = happyShift action_34
-action_166 (65) = happyShift action_35
-action_166 (66) = happyShift action_36
-action_166 (67) = happyShift action_37
-action_166 (70) = happyShift action_38
-action_166 (71) = happyShift action_39
-action_166 (72) = happyShift action_17
-action_166 (19) = happyGoto action_22
-action_166 (31) = happyGoto action_167
-action_166 (32) = happyGoto action_24
-action_166 (33) = happyGoto action_25
+action_166 (71) = happyShift action_172
 action_166 _ = happyFail (happyExpListPerState 166)
 
-action_167 _ = happyReduce_28
+action_167 (44) = happyShift action_31
+action_167 (51) = happyShift action_32
+action_167 (52) = happyShift action_33
+action_167 (60) = happyShift action_34
+action_167 (66) = happyShift action_35
+action_167 (68) = happyShift action_36
+action_167 (73) = happyShift action_37
+action_167 (74) = happyShift action_38
+action_167 (75) = happyShift action_39
+action_167 (76) = happyShift action_40
+action_167 (77) = happyShift action_41
+action_167 (80) = happyShift action_42
+action_167 (81) = happyShift action_43
+action_167 (82) = happyShift action_21
+action_167 (23) = happyGoto action_26
+action_167 (39) = happyGoto action_171
+action_167 (40) = happyGoto action_28
+action_167 (41) = happyGoto action_29
+action_167 _ = happyFail (happyExpListPerState 167)
 
-action_168 _ = happyReduce_42
+action_168 _ = happyReduce_31
 
-action_169 _ = happyReduce_41
+action_169 (57) = happyShift action_62
+action_169 (33) = happyGoto action_60
+action_169 (34) = happyGoto action_170
+action_169 _ = happyReduce_35
 
-action_170 _ = happyReduce_58
+action_170 (54) = happyShift action_53
+action_170 (55) = happyShift action_54
+action_170 (56) = happyShift action_55
+action_170 (62) = happyShift action_56
+action_170 (63) = happyShift action_57
+action_170 (65) = happyShift action_58
+action_170 (35) = happyGoto action_51
+action_170 (36) = happyGoto action_185
+action_170 _ = happyReduce_43
 
-action_171 _ = happyReduce_56
+action_171 (48) = happyShift action_184
+action_171 _ = happyFail (happyExpListPerState 171)
 
-happyReduce_16 = happySpecReduce_1  19 happyReduction_16
-happyReduction_16 (HappyTerminal happy_var_1)
-	 =  HappyAbsSyn19
+action_172 _ = happyReduce_39
+
+action_173 (44) = happyShift action_31
+action_173 (51) = happyShift action_32
+action_173 (52) = happyShift action_33
+action_173 (60) = happyShift action_34
+action_173 (66) = happyShift action_35
+action_173 (68) = happyShift action_36
+action_173 (73) = happyShift action_37
+action_173 (74) = happyShift action_38
+action_173 (75) = happyShift action_39
+action_173 (76) = happyShift action_40
+action_173 (77) = happyShift action_41
+action_173 (80) = happyShift action_42
+action_173 (81) = happyShift action_43
+action_173 (82) = happyShift action_21
+action_173 (23) = happyGoto action_26
+action_173 (39) = happyGoto action_183
+action_173 (40) = happyGoto action_28
+action_173 (41) = happyGoto action_29
+action_173 _ = happyFail (happyExpListPerState 173)
+
+action_174 (72) = happyShift action_182
+action_174 _ = happyFail (happyExpListPerState 174)
+
+action_175 (78) = happyShift action_181
+action_175 _ = happyFail (happyExpListPerState 175)
+
+action_176 _ = happyReduce_54
+
+action_177 (44) = happyShift action_31
+action_177 (51) = happyShift action_32
+action_177 (52) = happyShift action_33
+action_177 (60) = happyShift action_34
+action_177 (66) = happyShift action_35
+action_177 (68) = happyShift action_36
+action_177 (73) = happyShift action_37
+action_177 (74) = happyShift action_38
+action_177 (75) = happyShift action_39
+action_177 (76) = happyShift action_40
+action_177 (77) = happyShift action_41
+action_177 (80) = happyShift action_42
+action_177 (81) = happyShift action_43
+action_177 (82) = happyShift action_21
+action_177 (23) = happyGoto action_26
+action_177 (39) = happyGoto action_180
+action_177 (40) = happyGoto action_28
+action_177 (41) = happyGoto action_29
+action_177 _ = happyFail (happyExpListPerState 177)
+
+action_178 (44) = happyShift action_31
+action_178 (51) = happyShift action_32
+action_178 (52) = happyShift action_33
+action_178 (60) = happyShift action_34
+action_178 (66) = happyShift action_35
+action_178 (68) = happyShift action_36
+action_178 (73) = happyShift action_37
+action_178 (74) = happyShift action_38
+action_178 (75) = happyShift action_39
+action_178 (76) = happyShift action_40
+action_178 (77) = happyShift action_41
+action_178 (80) = happyShift action_42
+action_178 (81) = happyShift action_43
+action_178 (82) = happyShift action_21
+action_178 (23) = happyGoto action_26
+action_178 (39) = happyGoto action_179
+action_178 (40) = happyGoto action_28
+action_178 (41) = happyGoto action_29
+action_178 _ = happyFail (happyExpListPerState 178)
+
+action_179 (45) = happyShift action_190
+action_179 _ = happyFail (happyExpListPerState 179)
+
+action_180 (45) = happyShift action_189
+action_180 _ = happyFail (happyExpListPerState 180)
+
+action_181 (44) = happyShift action_31
+action_181 (51) = happyShift action_32
+action_181 (52) = happyShift action_33
+action_181 (60) = happyShift action_34
+action_181 (66) = happyShift action_35
+action_181 (68) = happyShift action_36
+action_181 (73) = happyShift action_37
+action_181 (74) = happyShift action_38
+action_181 (75) = happyShift action_39
+action_181 (76) = happyShift action_40
+action_181 (77) = happyShift action_41
+action_181 (80) = happyShift action_42
+action_181 (81) = happyShift action_43
+action_181 (82) = happyShift action_21
+action_181 (23) = happyGoto action_26
+action_181 (39) = happyGoto action_27
+action_181 (40) = happyGoto action_28
+action_181 (41) = happyGoto action_29
+action_181 (42) = happyGoto action_188
+action_181 _ = happyFail (happyExpListPerState 181)
+
+action_182 (44) = happyShift action_31
+action_182 (51) = happyShift action_32
+action_182 (52) = happyShift action_33
+action_182 (60) = happyShift action_34
+action_182 (66) = happyShift action_35
+action_182 (68) = happyShift action_36
+action_182 (73) = happyShift action_37
+action_182 (74) = happyShift action_38
+action_182 (75) = happyShift action_39
+action_182 (76) = happyShift action_40
+action_182 (77) = happyShift action_41
+action_182 (80) = happyShift action_42
+action_182 (81) = happyShift action_43
+action_182 (82) = happyShift action_21
+action_182 (23) = happyGoto action_26
+action_182 (39) = happyGoto action_27
+action_182 (40) = happyGoto action_28
+action_182 (41) = happyGoto action_29
+action_182 (42) = happyGoto action_187
+action_182 _ = happyFail (happyExpListPerState 182)
+
+action_183 _ = happyReduce_37
+
+action_184 (44) = happyShift action_31
+action_184 (51) = happyShift action_32
+action_184 (52) = happyShift action_33
+action_184 (60) = happyShift action_34
+action_184 (66) = happyShift action_35
+action_184 (68) = happyShift action_36
+action_184 (73) = happyShift action_37
+action_184 (74) = happyShift action_38
+action_184 (75) = happyShift action_39
+action_184 (76) = happyShift action_40
+action_184 (77) = happyShift action_41
+action_184 (80) = happyShift action_42
+action_184 (81) = happyShift action_43
+action_184 (82) = happyShift action_21
+action_184 (23) = happyGoto action_26
+action_184 (39) = happyGoto action_186
+action_184 (40) = happyGoto action_28
+action_184 (41) = happyGoto action_29
+action_184 _ = happyFail (happyExpListPerState 184)
+
+action_185 _ = happyReduce_26
+
+action_186 _ = happyReduce_38
+
+action_187 _ = happyReduce_52
+
+action_188 _ = happyReduce_51
+
+action_189 _ = happyReduce_68
+
+action_190 _ = happyReduce_66
+
+happyReduce_20 = happySpecReduce_1  23 happyReduction_20
+happyReduction_20 (HappyTerminal happy_var_1)
+	 =  HappyAbsSyn23
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.VarIdent (tokenText happy_var_1))
 	)
-happyReduction_16 _  = notHappyAtAll 
+happyReduction_20 _  = notHappyAtAll 
 
-happyReduce_17 = happySpecReduce_1  20 happyReduction_17
-happyReduction_17 (HappyAbsSyn21  happy_var_1)
-	 =  HappyAbsSyn20
+happyReduce_21 = happySpecReduce_1  24 happyReduction_21
+happyReduction_21 (HappyAbsSyn25  happy_var_1)
+	 =  HappyAbsSyn24
 		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.AProgram (fst happy_var_1) (snd happy_var_1))
 	)
-happyReduction_17 _  = notHappyAtAll 
+happyReduction_21 _  = notHappyAtAll 
 
-happyReduce_18 = happySpecReduce_0  21 happyReduction_18
-happyReduction_18  =  HappyAbsSyn21
+happyReduce_22 = happySpecReduce_0  25 happyReduction_22
+happyReduction_22  =  HappyAbsSyn25
 		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
 	)
 
-happyReduce_19 = happySpecReduce_2  21 happyReduction_19
-happyReduction_19 (HappyAbsSyn21  happy_var_2)
-	(HappyAbsSyn22  happy_var_1)
-	 =  HappyAbsSyn21
-		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_2))
-	)
-happyReduction_19 _ _  = notHappyAtAll 
-
-happyReduce_20 = happyReduce 6 22 happyReduction_20
-happyReduction_20 ((HappyAbsSyn28  happy_var_6) `HappyStk`
-	(HappyAbsSyn26  happy_var_5) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn24  happy_var_3) `HappyStk`
-	(HappyAbsSyn19  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn22
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.AModule (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_3) (snd happy_var_5) (snd happy_var_6))
-	) `HappyStk` happyRest
-
-happyReduce_21 = happyReduce 5 23 happyReduction_21
-happyReduction_21 (_ `HappyStk`
-	(HappyAbsSyn31  happy_var_4) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn19  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn23
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.AParam (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
-	) `HappyStk` happyRest
-
-happyReduce_22 = happySpecReduce_0  24 happyReduction_22
-happyReduction_22  =  HappyAbsSyn24
-		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
-	)
-
-happyReduce_23 = happySpecReduce_2  24 happyReduction_23
-happyReduction_23 (HappyAbsSyn24  happy_var_2)
-	(HappyAbsSyn23  happy_var_1)
-	 =  HappyAbsSyn24
+happyReduce_23 = happySpecReduce_2  25 happyReduction_23
+happyReduction_23 (HappyAbsSyn25  happy_var_2)
+	(HappyAbsSyn26  happy_var_1)
+	 =  HappyAbsSyn25
 		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_2))
 	)
 happyReduction_23 _ _  = notHappyAtAll 
 
-happyReduce_24 = happySpecReduce_2  25 happyReduction_24
-happyReduction_24 (HappyAbsSyn19  happy_var_2)
+happyReduce_24 = happySpecReduce_1  26 happyReduction_24
+happyReduction_24 (HappyAbsSyn27  happy_var_1)
+	 =  HappyAbsSyn26
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.UnitModule (fst happy_var_1) (snd happy_var_1))
+	)
+happyReduction_24 _  = notHappyAtAll 
+
+happyReduce_25 = happySpecReduce_1  26 happyReduction_25
+happyReduction_25 (HappyAbsSyn30  happy_var_1)
+	 =  HappyAbsSyn26
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.UnitTelescope (fst happy_var_1) (snd happy_var_1))
+	)
+happyReduction_25 _  = notHappyAtAll 
+
+happyReduce_26 = happyReduce 7 27 happyReduction_26
+happyReduction_26 ((HappyAbsSyn36  happy_var_7) `HappyStk`
+	(HappyAbsSyn34  happy_var_6) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn32  happy_var_4) `HappyStk`
+	(HappyAbsSyn29  happy_var_3) `HappyStk`
+	(HappyAbsSyn23  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn27
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.AModule (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_3) (snd happy_var_4) (snd happy_var_6) (snd happy_var_7))
+	) `HappyStk` happyRest
+
+happyReduce_27 = happySpecReduce_2  28 happyReduction_27
+happyReduction_27 (HappyAbsSyn23  happy_var_2)
 	(HappyTerminal happy_var_1)
-	 =  HappyAbsSyn25
+	 =  HappyAbsSyn28
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.AnInclude (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
+	)
+happyReduction_27 _ _  = notHappyAtAll 
+
+happyReduce_28 = happySpecReduce_0  29 happyReduction_28
+happyReduction_28  =  HappyAbsSyn29
+		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
+	)
+
+happyReduce_29 = happySpecReduce_2  29 happyReduction_29
+happyReduction_29 (HappyAbsSyn29  happy_var_2)
+	(HappyAbsSyn28  happy_var_1)
+	 =  HappyAbsSyn29
+		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_2))
+	)
+happyReduction_29 _ _  = notHappyAtAll 
+
+happyReduce_30 = happyReduce 4 30 happyReduction_30
+happyReduction_30 (_ `HappyStk`
+	(HappyAbsSyn32  happy_var_3) `HappyStk`
+	(HappyAbsSyn23  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn30
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.ATelescope (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_3))
+	) `HappyStk` happyRest
+
+happyReduce_31 = happyReduce 5 31 happyReduction_31
+happyReduction_31 (_ `HappyStk`
+	(HappyAbsSyn39  happy_var_4) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn23  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn31
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.AParam (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
+	) `HappyStk` happyRest
+
+happyReduce_32 = happySpecReduce_0  32 happyReduction_32
+happyReduction_32  =  HappyAbsSyn32
+		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
+	)
+
+happyReduce_33 = happySpecReduce_2  32 happyReduction_33
+happyReduction_33 (HappyAbsSyn32  happy_var_2)
+	(HappyAbsSyn31  happy_var_1)
+	 =  HappyAbsSyn32
+		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_2))
+	)
+happyReduction_33 _ _  = notHappyAtAll 
+
+happyReduce_34 = happySpecReduce_2  33 happyReduction_34
+happyReduction_34 (HappyAbsSyn23  happy_var_2)
+	(HappyTerminal happy_var_1)
+	 =  HappyAbsSyn33
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.AnImport (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
 	)
-happyReduction_24 _ _  = notHappyAtAll 
+happyReduction_34 _ _  = notHappyAtAll 
 
-happyReduce_25 = happySpecReduce_0  26 happyReduction_25
-happyReduction_25  =  HappyAbsSyn26
+happyReduce_35 = happySpecReduce_0  34 happyReduction_35
+happyReduction_35  =  HappyAbsSyn34
 		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
 	)
 
-happyReduce_26 = happySpecReduce_3  26 happyReduction_26
-happyReduction_26 (HappyAbsSyn26  happy_var_3)
+happyReduce_36 = happySpecReduce_3  34 happyReduction_36
+happyReduction_36 (HappyAbsSyn34  happy_var_3)
 	_
-	(HappyAbsSyn25  happy_var_1)
-	 =  HappyAbsSyn26
-		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_3))
-	)
-happyReduction_26 _ _ _  = notHappyAtAll 
-
-happyReduce_27 = happyReduce 7 27 happyReduction_27
-happyReduction_27 ((HappyAbsSyn31  happy_var_7) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn31  happy_var_5) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn29  happy_var_3) `HappyStk`
-	(HappyAbsSyn19  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn27
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclDef (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_3) (snd happy_var_5) (snd happy_var_7))
-	) `HappyStk` happyRest
-
-happyReduce_28 = happyReduce 8 27 happyReduction_28
-happyReduction_28 ((HappyAbsSyn31  happy_var_8) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn31  happy_var_6) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn29  happy_var_4) `HappyStk`
-	(HappyAbsSyn19  happy_var_3) `HappyStk`
-	_ `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn27
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclPrivateDef (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_4) (snd happy_var_6) (snd happy_var_8))
-	) `HappyStk` happyRest
-
-happyReduce_29 = happyReduce 6 27 happyReduction_29
-happyReduction_29 (_ `HappyStk`
-	(HappyAbsSyn28  happy_var_5) `HappyStk`
-	_ `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn19  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn27
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclNamespace (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_5))
-	) `HappyStk` happyRest
-
-happyReduce_30 = happySpecReduce_2  27 happyReduction_30
-happyReduction_30 (HappyAbsSyn19  happy_var_2)
-	(HappyTerminal happy_var_1)
-	 =  HappyAbsSyn27
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclOpen (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
-	)
-happyReduction_30 _ _  = notHappyAtAll 
-
-happyReduce_31 = happyReduce 4 27 happyReduction_31
-happyReduction_31 ((HappyAbsSyn31  happy_var_4) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn31  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn27
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclCheck (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
-	) `HappyStk` happyRest
-
-happyReduce_32 = happySpecReduce_2  27 happyReduction_32
-happyReduction_32 (HappyAbsSyn31  happy_var_2)
-	(HappyTerminal happy_var_1)
-	 =  HappyAbsSyn27
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclCompute (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
-	)
-happyReduction_32 _ _  = notHappyAtAll 
-
-happyReduce_33 = happySpecReduce_0  28 happyReduction_33
-happyReduction_33  =  HappyAbsSyn28
-		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
-	)
-
-happyReduce_34 = happySpecReduce_1  28 happyReduction_34
-happyReduction_34 (HappyAbsSyn27  happy_var_1)
-	 =  HappyAbsSyn28
-		 ((fst happy_var_1, (:[]) (snd happy_var_1))
-	)
-happyReduction_34 _  = notHappyAtAll 
-
-happyReduce_35 = happySpecReduce_3  28 happyReduction_35
-happyReduction_35 (HappyAbsSyn28  happy_var_3)
-	_
-	(HappyAbsSyn27  happy_var_1)
-	 =  HappyAbsSyn28
-		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_3))
-	)
-happyReduction_35 _ _ _  = notHappyAtAll 
-
-happyReduce_36 = happySpecReduce_0  29 happyReduction_36
-happyReduction_36  =  HappyAbsSyn29
-		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, Language.MLTT.Syntax.Abs.NoDischarge Language.MLTT.Syntax.Abs.BNFC'NoPosition)
-	)
-
-happyReduce_37 = happyReduce 4 29 happyReduction_37
-happyReduction_37 (_ `HappyStk`
-	(HappyAbsSyn30  happy_var_3) `HappyStk`
-	_ `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn29
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DischargeOver (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3))
-	) `HappyStk` happyRest
-
-happyReduce_38 = happySpecReduce_0  30 happyReduction_38
-happyReduction_38  =  HappyAbsSyn30
-		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
-	)
-
-happyReduce_39 = happySpecReduce_1  30 happyReduction_39
-happyReduction_39 (HappyAbsSyn19  happy_var_1)
-	 =  HappyAbsSyn30
-		 ((fst happy_var_1, (:[]) (snd happy_var_1))
-	)
-happyReduction_39 _  = notHappyAtAll 
-
-happyReduce_40 = happySpecReduce_3  30 happyReduction_40
-happyReduction_40 (HappyAbsSyn30  happy_var_3)
-	_
-	(HappyAbsSyn19  happy_var_1)
-	 =  HappyAbsSyn30
-		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_3))
-	)
-happyReduction_40 _ _ _  = notHappyAtAll 
-
-happyReduce_41 = happyReduce 8 31 happyReduction_41
-happyReduction_41 ((HappyAbsSyn34  happy_var_8) `HappyStk`
-	_ `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn31  happy_var_5) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn35  happy_var_3) `HappyStk`
-	_ `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn31
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Pi (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_8))
-	) `HappyStk` happyRest
-
-happyReduce_42 = happyReduce 8 31 happyReduction_42
-happyReduction_42 ((HappyAbsSyn34  happy_var_8) `HappyStk`
-	_ `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn31  happy_var_5) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn35  happy_var_3) `HappyStk`
-	_ `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn31
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Sigma (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_8))
-	) `HappyStk` happyRest
-
-happyReduce_43 = happyReduce 4 31 happyReduction_43
-happyReduction_43 ((HappyAbsSyn34  happy_var_4) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn35  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn31
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Lam (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
-	) `HappyStk` happyRest
-
-happyReduce_44 = happyReduce 6 31 happyReduction_44
-happyReduction_44 ((HappyAbsSyn34  happy_var_6) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn31  happy_var_4) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn35  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn31
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Let (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4) (snd happy_var_6))
-	) `HappyStk` happyRest
-
-happyReduce_45 = happySpecReduce_3  31 happyReduction_45
-happyReduction_45 (HappyAbsSyn31  happy_var_3)
-	_
-	(HappyAbsSyn31  happy_var_1)
-	 =  HappyAbsSyn31
-		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.Arrow (fst happy_var_1) (snd happy_var_1) (snd happy_var_3))
-	)
-happyReduction_45 _ _ _  = notHappyAtAll 
-
-happyReduce_46 = happySpecReduce_3  31 happyReduction_46
-happyReduction_46 (HappyAbsSyn31  happy_var_3)
-	_
-	(HappyAbsSyn31  happy_var_1)
-	 =  HappyAbsSyn31
-		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.Product (fst happy_var_1) (snd happy_var_1) (snd happy_var_3))
-	)
-happyReduction_46 _ _ _  = notHappyAtAll 
-
-happyReduce_47 = happySpecReduce_1  31 happyReduction_47
-happyReduction_47 (HappyAbsSyn31  happy_var_1)
-	 =  HappyAbsSyn31
-		 ((fst happy_var_1, (snd happy_var_1))
-	)
-happyReduction_47 _  = notHappyAtAll 
-
-happyReduce_48 = happySpecReduce_2  32 happyReduction_48
-happyReduction_48 (HappyAbsSyn31  happy_var_2)
-	(HappyAbsSyn31  happy_var_1)
-	 =  HappyAbsSyn31
-		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.App (fst happy_var_1) (snd happy_var_1) (snd happy_var_2))
-	)
-happyReduction_48 _ _  = notHappyAtAll 
-
-happyReduce_49 = happySpecReduce_1  32 happyReduction_49
-happyReduction_49 (HappyAbsSyn31  happy_var_1)
-	 =  HappyAbsSyn31
-		 ((fst happy_var_1, (snd happy_var_1))
-	)
-happyReduction_49 _  = notHappyAtAll 
-
-happyReduce_50 = happySpecReduce_2  33 happyReduction_50
-happyReduction_50 (HappyAbsSyn31  happy_var_2)
-	(HappyTerminal happy_var_1)
-	 =  HappyAbsSyn31
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.First (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
-	)
-happyReduction_50 _ _  = notHappyAtAll 
-
-happyReduce_51 = happySpecReduce_2  33 happyReduction_51
-happyReduction_51 (HappyAbsSyn31  happy_var_2)
-	(HappyTerminal happy_var_1)
-	 =  HappyAbsSyn31
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Second (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
-	)
-happyReduction_51 _ _  = notHappyAtAll 
-
-happyReduce_52 = happySpecReduce_1  33 happyReduction_52
-happyReduction_52 (HappyTerminal happy_var_1)
-	 =  HappyAbsSyn31
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Universe (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
-	)
-happyReduction_52 _  = notHappyAtAll 
-
-happyReduce_53 = happySpecReduce_1  33 happyReduction_53
-happyReduction_53 (HappyTerminal happy_var_1)
-	 =  HappyAbsSyn31
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.UnitType (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
-	)
-happyReduction_53 _  = notHappyAtAll 
-
-happyReduce_54 = happySpecReduce_1  33 happyReduction_54
-happyReduction_54 (HappyTerminal happy_var_1)
-	 =  HappyAbsSyn31
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.UnitVal (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
-	)
-happyReduction_54 _  = notHappyAtAll 
-
-happyReduce_55 = happySpecReduce_1  33 happyReduction_55
-happyReduction_55 (HappyAbsSyn19  happy_var_1)
-	 =  HappyAbsSyn31
-		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.Var (fst happy_var_1) (snd happy_var_1))
-	)
-happyReduction_55 _  = notHappyAtAll 
-
-happyReduce_56 = happyReduce 8 33 happyReduction_56
-happyReduction_56 (_ `HappyStk`
-	(HappyAbsSyn31  happy_var_7) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn31  happy_var_5) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn31  happy_var_3) `HappyStk`
-	_ `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn31
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.IdType (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_7))
-	) `HappyStk` happyRest
-
-happyReduce_57 = happyReduce 4 33 happyReduction_57
-happyReduction_57 (_ `HappyStk`
-	(HappyAbsSyn31  happy_var_3) `HappyStk`
-	_ `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn31
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Refl (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3))
-	) `HappyStk` happyRest
-
-happyReduce_58 = happyReduce 8 33 happyReduction_58
-happyReduction_58 (_ `HappyStk`
-	(HappyAbsSyn31  happy_var_7) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn31  happy_var_5) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn31  happy_var_3) `HappyStk`
-	_ `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn31
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.J (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_7))
-	) `HappyStk` happyRest
-
-happyReduce_59 = happyReduce 5 33 happyReduction_59
-happyReduction_59 (_ `HappyStk`
-	(HappyAbsSyn31  happy_var_4) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn31  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn31
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Pair (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
-	) `HappyStk` happyRest
-
-happyReduce_60 = happyReduce 5 33 happyReduction_60
-happyReduction_60 (_ `HappyStk`
-	(HappyAbsSyn31  happy_var_4) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn31  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn31
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Ann (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
-	) `HappyStk` happyRest
-
-happyReduce_61 = happySpecReduce_3  33 happyReduction_61
-happyReduction_61 _
-	(HappyAbsSyn31  happy_var_2)
-	(HappyTerminal happy_var_1)
-	 =  HappyAbsSyn31
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), (snd happy_var_2))
-	)
-happyReduction_61 _ _ _  = notHappyAtAll 
-
-happyReduce_62 = happySpecReduce_1  34 happyReduction_62
-happyReduction_62 (HappyAbsSyn31  happy_var_1)
+	(HappyAbsSyn33  happy_var_1)
 	 =  HappyAbsSyn34
-		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.AScopedTerm (fst happy_var_1) (snd happy_var_1))
+		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_3))
 	)
-happyReduction_62 _  = notHappyAtAll 
+happyReduction_36 _ _ _  = notHappyAtAll 
 
-happyReduce_63 = happySpecReduce_1  35 happyReduction_63
-happyReduction_63 (HappyTerminal happy_var_1)
-	 =  HappyAbsSyn35
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.PatternWildcard (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
-	)
-happyReduction_63 _  = notHappyAtAll 
-
-happyReduce_64 = happySpecReduce_1  35 happyReduction_64
-happyReduction_64 (HappyAbsSyn19  happy_var_1)
-	 =  HappyAbsSyn35
-		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.PatternVar (fst happy_var_1) (snd happy_var_1))
-	)
-happyReduction_64 _  = notHappyAtAll 
-
-happyReduce_65 = happyReduce 5 35 happyReduction_65
-happyReduction_65 (_ `HappyStk`
-	(HappyAbsSyn35  happy_var_4) `HappyStk`
+happyReduce_37 = happyReduce 7 35 happyReduction_37
+happyReduction_37 ((HappyAbsSyn39  happy_var_7) `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn35  happy_var_2) `HappyStk`
+	(HappyAbsSyn39  happy_var_5) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn37  happy_var_3) `HappyStk`
+	(HappyAbsSyn23  happy_var_2) `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
 	 = HappyAbsSyn35
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclDef (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_3) (snd happy_var_5) (snd happy_var_7))
+	) `HappyStk` happyRest
+
+happyReduce_38 = happyReduce 8 35 happyReduction_38
+happyReduction_38 ((HappyAbsSyn39  happy_var_8) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn39  happy_var_6) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn37  happy_var_4) `HappyStk`
+	(HappyAbsSyn23  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn35
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclPrivateDef (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_4) (snd happy_var_6) (snd happy_var_8))
+	) `HappyStk` happyRest
+
+happyReduce_39 = happyReduce 6 35 happyReduction_39
+happyReduction_39 (_ `HappyStk`
+	(HappyAbsSyn36  happy_var_5) `HappyStk`
+	_ `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn23  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn35
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclNamespace (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_5))
+	) `HappyStk` happyRest
+
+happyReduce_40 = happySpecReduce_2  35 happyReduction_40
+happyReduction_40 (HappyAbsSyn23  happy_var_2)
+	(HappyTerminal happy_var_1)
+	 =  HappyAbsSyn35
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclOpen (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
+	)
+happyReduction_40 _ _  = notHappyAtAll 
+
+happyReduce_41 = happyReduce 4 35 happyReduction_41
+happyReduction_41 ((HappyAbsSyn39  happy_var_4) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn39  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn35
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclCheck (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
+	) `HappyStk` happyRest
+
+happyReduce_42 = happySpecReduce_2  35 happyReduction_42
+happyReduction_42 (HappyAbsSyn39  happy_var_2)
+	(HappyTerminal happy_var_1)
+	 =  HappyAbsSyn35
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclCompute (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
+	)
+happyReduction_42 _ _  = notHappyAtAll 
+
+happyReduce_43 = happySpecReduce_0  36 happyReduction_43
+happyReduction_43  =  HappyAbsSyn36
+		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
+	)
+
+happyReduce_44 = happySpecReduce_1  36 happyReduction_44
+happyReduction_44 (HappyAbsSyn35  happy_var_1)
+	 =  HappyAbsSyn36
+		 ((fst happy_var_1, (:[]) (snd happy_var_1))
+	)
+happyReduction_44 _  = notHappyAtAll 
+
+happyReduce_45 = happySpecReduce_3  36 happyReduction_45
+happyReduction_45 (HappyAbsSyn36  happy_var_3)
+	_
+	(HappyAbsSyn35  happy_var_1)
+	 =  HappyAbsSyn36
+		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_3))
+	)
+happyReduction_45 _ _ _  = notHappyAtAll 
+
+happyReduce_46 = happySpecReduce_0  37 happyReduction_46
+happyReduction_46  =  HappyAbsSyn37
+		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, Language.MLTT.Syntax.Abs.NoDischarge Language.MLTT.Syntax.Abs.BNFC'NoPosition)
+	)
+
+happyReduce_47 = happyReduce 4 37 happyReduction_47
+happyReduction_47 (_ `HappyStk`
+	(HappyAbsSyn38  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn37
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DischargeOver (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3))
+	) `HappyStk` happyRest
+
+happyReduce_48 = happySpecReduce_0  38 happyReduction_48
+happyReduction_48  =  HappyAbsSyn38
+		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
+	)
+
+happyReduce_49 = happySpecReduce_1  38 happyReduction_49
+happyReduction_49 (HappyAbsSyn23  happy_var_1)
+	 =  HappyAbsSyn38
+		 ((fst happy_var_1, (:[]) (snd happy_var_1))
+	)
+happyReduction_49 _  = notHappyAtAll 
+
+happyReduce_50 = happySpecReduce_3  38 happyReduction_50
+happyReduction_50 (HappyAbsSyn38  happy_var_3)
+	_
+	(HappyAbsSyn23  happy_var_1)
+	 =  HappyAbsSyn38
+		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_3))
+	)
+happyReduction_50 _ _ _  = notHappyAtAll 
+
+happyReduce_51 = happyReduce 8 39 happyReduction_51
+happyReduction_51 ((HappyAbsSyn42  happy_var_8) `HappyStk`
+	_ `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn39  happy_var_5) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn43  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn39
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Pi (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_8))
+	) `HappyStk` happyRest
+
+happyReduce_52 = happyReduce 8 39 happyReduction_52
+happyReduction_52 ((HappyAbsSyn42  happy_var_8) `HappyStk`
+	_ `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn39  happy_var_5) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn43  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn39
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Sigma (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_8))
+	) `HappyStk` happyRest
+
+happyReduce_53 = happyReduce 4 39 happyReduction_53
+happyReduction_53 ((HappyAbsSyn42  happy_var_4) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn43  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn39
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Lam (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
+	) `HappyStk` happyRest
+
+happyReduce_54 = happyReduce 6 39 happyReduction_54
+happyReduction_54 ((HappyAbsSyn42  happy_var_6) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn39  happy_var_4) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn43  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn39
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Let (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4) (snd happy_var_6))
+	) `HappyStk` happyRest
+
+happyReduce_55 = happySpecReduce_3  39 happyReduction_55
+happyReduction_55 (HappyAbsSyn39  happy_var_3)
+	_
+	(HappyAbsSyn39  happy_var_1)
+	 =  HappyAbsSyn39
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.Arrow (fst happy_var_1) (snd happy_var_1) (snd happy_var_3))
+	)
+happyReduction_55 _ _ _  = notHappyAtAll 
+
+happyReduce_56 = happySpecReduce_3  39 happyReduction_56
+happyReduction_56 (HappyAbsSyn39  happy_var_3)
+	_
+	(HappyAbsSyn39  happy_var_1)
+	 =  HappyAbsSyn39
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.Product (fst happy_var_1) (snd happy_var_1) (snd happy_var_3))
+	)
+happyReduction_56 _ _ _  = notHappyAtAll 
+
+happyReduce_57 = happySpecReduce_1  39 happyReduction_57
+happyReduction_57 (HappyAbsSyn39  happy_var_1)
+	 =  HappyAbsSyn39
+		 ((fst happy_var_1, (snd happy_var_1))
+	)
+happyReduction_57 _  = notHappyAtAll 
+
+happyReduce_58 = happySpecReduce_2  40 happyReduction_58
+happyReduction_58 (HappyAbsSyn39  happy_var_2)
+	(HappyAbsSyn39  happy_var_1)
+	 =  HappyAbsSyn39
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.App (fst happy_var_1) (snd happy_var_1) (snd happy_var_2))
+	)
+happyReduction_58 _ _  = notHappyAtAll 
+
+happyReduce_59 = happySpecReduce_1  40 happyReduction_59
+happyReduction_59 (HappyAbsSyn39  happy_var_1)
+	 =  HappyAbsSyn39
+		 ((fst happy_var_1, (snd happy_var_1))
+	)
+happyReduction_59 _  = notHappyAtAll 
+
+happyReduce_60 = happySpecReduce_2  41 happyReduction_60
+happyReduction_60 (HappyAbsSyn39  happy_var_2)
+	(HappyTerminal happy_var_1)
+	 =  HappyAbsSyn39
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.First (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
+	)
+happyReduction_60 _ _  = notHappyAtAll 
+
+happyReduce_61 = happySpecReduce_2  41 happyReduction_61
+happyReduction_61 (HappyAbsSyn39  happy_var_2)
+	(HappyTerminal happy_var_1)
+	 =  HappyAbsSyn39
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Second (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
+	)
+happyReduction_61 _ _  = notHappyAtAll 
+
+happyReduce_62 = happySpecReduce_1  41 happyReduction_62
+happyReduction_62 (HappyTerminal happy_var_1)
+	 =  HappyAbsSyn39
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Universe (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
+	)
+happyReduction_62 _  = notHappyAtAll 
+
+happyReduce_63 = happySpecReduce_1  41 happyReduction_63
+happyReduction_63 (HappyTerminal happy_var_1)
+	 =  HappyAbsSyn39
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.UnitType (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
+	)
+happyReduction_63 _  = notHappyAtAll 
+
+happyReduce_64 = happySpecReduce_1  41 happyReduction_64
+happyReduction_64 (HappyTerminal happy_var_1)
+	 =  HappyAbsSyn39
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.UnitVal (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
+	)
+happyReduction_64 _  = notHappyAtAll 
+
+happyReduce_65 = happySpecReduce_1  41 happyReduction_65
+happyReduction_65 (HappyAbsSyn23  happy_var_1)
+	 =  HappyAbsSyn39
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.Var (fst happy_var_1) (snd happy_var_1))
+	)
+happyReduction_65 _  = notHappyAtAll 
+
+happyReduce_66 = happyReduce 8 41 happyReduction_66
+happyReduction_66 (_ `HappyStk`
+	(HappyAbsSyn39  happy_var_7) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn39  happy_var_5) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn39  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn39
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.IdType (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_7))
+	) `HappyStk` happyRest
+
+happyReduce_67 = happyReduce 4 41 happyReduction_67
+happyReduction_67 (_ `HappyStk`
+	(HappyAbsSyn39  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn39
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Refl (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3))
+	) `HappyStk` happyRest
+
+happyReduce_68 = happyReduce 8 41 happyReduction_68
+happyReduction_68 (_ `HappyStk`
+	(HappyAbsSyn39  happy_var_7) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn39  happy_var_5) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn39  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn39
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.J (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_7))
+	) `HappyStk` happyRest
+
+happyReduce_69 = happyReduce 5 41 happyReduction_69
+happyReduction_69 (_ `HappyStk`
+	(HappyAbsSyn39  happy_var_4) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn39  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn39
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Pair (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
+	) `HappyStk` happyRest
+
+happyReduce_70 = happyReduce 5 41 happyReduction_70
+happyReduction_70 (_ `HappyStk`
+	(HappyAbsSyn39  happy_var_4) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn39  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn39
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Ann (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
+	) `HappyStk` happyRest
+
+happyReduce_71 = happySpecReduce_3  41 happyReduction_71
+happyReduction_71 _
+	(HappyAbsSyn39  happy_var_2)
+	(HappyTerminal happy_var_1)
+	 =  HappyAbsSyn39
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), (snd happy_var_2))
+	)
+happyReduction_71 _ _ _  = notHappyAtAll 
+
+happyReduce_72 = happySpecReduce_1  42 happyReduction_72
+happyReduction_72 (HappyAbsSyn39  happy_var_1)
+	 =  HappyAbsSyn42
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.AScopedTerm (fst happy_var_1) (snd happy_var_1))
+	)
+happyReduction_72 _  = notHappyAtAll 
+
+happyReduce_73 = happySpecReduce_1  43 happyReduction_73
+happyReduction_73 (HappyTerminal happy_var_1)
+	 =  HappyAbsSyn43
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.PatternWildcard (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
+	)
+happyReduction_73 _  = notHappyAtAll 
+
+happyReduce_74 = happySpecReduce_1  43 happyReduction_74
+happyReduction_74 (HappyAbsSyn23  happy_var_1)
+	 =  HappyAbsSyn43
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.PatternVar (fst happy_var_1) (snd happy_var_1))
+	)
+happyReduction_74 _  = notHappyAtAll 
+
+happyReduce_75 = happyReduce 5 43 happyReduction_75
+happyReduction_75 (_ `HappyStk`
+	(HappyAbsSyn43  happy_var_4) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn43  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn43
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.PatternPair (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
 	) `HappyStk` happyRest
 
 happyNewToken action sts stk [] =
-	action 73 73 notHappyAtAll (HappyState action) sts stk []
+	action 83 83 notHappyAtAll (HappyState action) sts stk []
 
 happyNewToken action sts stk (tk:tks) =
 	let cont i = action i i tk (HappyState action) sts stk tks in
 	case tk of {
-	PT _ (TS _ 1) -> cont 36;
-	PT _ (TS _ 2) -> cont 37;
-	PT _ (TS _ 3) -> cont 38;
-	PT _ (TS _ 4) -> cont 39;
-	PT _ (TS _ 5) -> cont 40;
-	PT _ (TS _ 6) -> cont 41;
-	PT _ (TS _ 7) -> cont 42;
-	PT _ (TS _ 8) -> cont 43;
-	PT _ (TS _ 9) -> cont 44;
-	PT _ (TS _ 10) -> cont 45;
-	PT _ (TS _ 11) -> cont 46;
-	PT _ (TS _ 12) -> cont 47;
-	PT _ (TS _ 13) -> cont 48;
-	PT _ (TS _ 14) -> cont 49;
-	PT _ (TS _ 15) -> cont 50;
-	PT _ (TS _ 16) -> cont 51;
-	PT _ (TS _ 17) -> cont 52;
-	PT _ (TS _ 18) -> cont 53;
-	PT _ (TS _ 19) -> cont 54;
-	PT _ (TS _ 20) -> cont 55;
-	PT _ (TS _ 21) -> cont 56;
-	PT _ (TS _ 22) -> cont 57;
-	PT _ (TS _ 23) -> cont 58;
-	PT _ (TS _ 24) -> cont 59;
-	PT _ (TS _ 25) -> cont 60;
-	PT _ (TS _ 26) -> cont 61;
-	PT _ (TS _ 27) -> cont 62;
-	PT _ (TS _ 28) -> cont 63;
-	PT _ (TS _ 29) -> cont 64;
-	PT _ (TS _ 30) -> cont 65;
-	PT _ (TS _ 31) -> cont 66;
-	PT _ (TS _ 32) -> cont 67;
-	PT _ (TS _ 33) -> cont 68;
-	PT _ (TS _ 34) -> cont 69;
-	PT _ (TS _ 35) -> cont 70;
-	PT _ (TS _ 36) -> cont 71;
-	PT _ (T_VarIdent _) -> cont 72;
+	PT _ (TS _ 1) -> cont 44;
+	PT _ (TS _ 2) -> cont 45;
+	PT _ (TS _ 3) -> cont 46;
+	PT _ (TS _ 4) -> cont 47;
+	PT _ (TS _ 5) -> cont 48;
+	PT _ (TS _ 6) -> cont 49;
+	PT _ (TS _ 7) -> cont 50;
+	PT _ (TS _ 8) -> cont 51;
+	PT _ (TS _ 9) -> cont 52;
+	PT _ (TS _ 10) -> cont 53;
+	PT _ (TS _ 11) -> cont 54;
+	PT _ (TS _ 12) -> cont 55;
+	PT _ (TS _ 13) -> cont 56;
+	PT _ (TS _ 14) -> cont 57;
+	PT _ (TS _ 15) -> cont 58;
+	PT _ (TS _ 16) -> cont 59;
+	PT _ (TS _ 17) -> cont 60;
+	PT _ (TS _ 18) -> cont 61;
+	PT _ (TS _ 19) -> cont 62;
+	PT _ (TS _ 20) -> cont 63;
+	PT _ (TS _ 21) -> cont 64;
+	PT _ (TS _ 22) -> cont 65;
+	PT _ (TS _ 23) -> cont 66;
+	PT _ (TS _ 24) -> cont 67;
+	PT _ (TS _ 25) -> cont 68;
+	PT _ (TS _ 26) -> cont 69;
+	PT _ (TS _ 27) -> cont 70;
+	PT _ (TS _ 28) -> cont 71;
+	PT _ (TS _ 29) -> cont 72;
+	PT _ (TS _ 30) -> cont 73;
+	PT _ (TS _ 31) -> cont 74;
+	PT _ (TS _ 32) -> cont 75;
+	PT _ (TS _ 33) -> cont 76;
+	PT _ (TS _ 34) -> cont 77;
+	PT _ (TS _ 35) -> cont 78;
+	PT _ (TS _ 36) -> cont 79;
+	PT _ (TS _ 37) -> cont 80;
+	PT _ (TS _ 38) -> cont 81;
+	PT _ (T_VarIdent _) -> cont 82;
 	_ -> happyError' ((tk:tks), [])
 	}
 
-happyError_ explist 73 tk tks = happyError' (tks, explist)
+happyError_ explist 83 tk tks = happyError' (tks, explist)
 happyError_ explist _ tk tks = happyError' ((tk:tks), explist)
 
 happyThen :: () => Err a -> (a -> Err b) -> Err b
@@ -1967,52 +2125,64 @@ happyReturn1 = \a tks -> (return) a
 happyError' :: () => ([(Token)], [Prelude.String]) -> Err a
 happyError' = (\(tokens, _) -> happyError tokens)
 pProgram_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_0 tks) (\x -> case x of {HappyAbsSyn20 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_0 tks) (\x -> case x of {HappyAbsSyn24 z -> happyReturn z; _other -> notHappyAtAll })
 
-pListModule_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_1 tks) (\x -> case x of {HappyAbsSyn21 z -> happyReturn z; _other -> notHappyAtAll })
+pListUnit_internal tks = happySomeParser where
+ happySomeParser = happyThen (happyParse action_1 tks) (\x -> case x of {HappyAbsSyn25 z -> happyReturn z; _other -> notHappyAtAll })
+
+pUnit_internal tks = happySomeParser where
+ happySomeParser = happyThen (happyParse action_2 tks) (\x -> case x of {HappyAbsSyn26 z -> happyReturn z; _other -> notHappyAtAll })
 
 pModule_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_2 tks) (\x -> case x of {HappyAbsSyn22 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_3 tks) (\x -> case x of {HappyAbsSyn27 z -> happyReturn z; _other -> notHappyAtAll })
+
+pInclude_internal tks = happySomeParser where
+ happySomeParser = happyThen (happyParse action_4 tks) (\x -> case x of {HappyAbsSyn28 z -> happyReturn z; _other -> notHappyAtAll })
+
+pListInclude_internal tks = happySomeParser where
+ happySomeParser = happyThen (happyParse action_5 tks) (\x -> case x of {HappyAbsSyn29 z -> happyReturn z; _other -> notHappyAtAll })
+
+pTelescopeDecl_internal tks = happySomeParser where
+ happySomeParser = happyThen (happyParse action_6 tks) (\x -> case x of {HappyAbsSyn30 z -> happyReturn z; _other -> notHappyAtAll })
 
 pParam_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_3 tks) (\x -> case x of {HappyAbsSyn23 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_7 tks) (\x -> case x of {HappyAbsSyn31 z -> happyReturn z; _other -> notHappyAtAll })
 
 pListParam_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_4 tks) (\x -> case x of {HappyAbsSyn24 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_8 tks) (\x -> case x of {HappyAbsSyn32 z -> happyReturn z; _other -> notHappyAtAll })
 
 pImport_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_5 tks) (\x -> case x of {HappyAbsSyn25 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_9 tks) (\x -> case x of {HappyAbsSyn33 z -> happyReturn z; _other -> notHappyAtAll })
 
 pListImport_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_6 tks) (\x -> case x of {HappyAbsSyn26 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_10 tks) (\x -> case x of {HappyAbsSyn34 z -> happyReturn z; _other -> notHappyAtAll })
 
 pDecl_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_7 tks) (\x -> case x of {HappyAbsSyn27 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_11 tks) (\x -> case x of {HappyAbsSyn35 z -> happyReturn z; _other -> notHappyAtAll })
 
 pListDecl_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_8 tks) (\x -> case x of {HappyAbsSyn28 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_12 tks) (\x -> case x of {HappyAbsSyn36 z -> happyReturn z; _other -> notHappyAtAll })
 
 pDischarge_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_9 tks) (\x -> case x of {HappyAbsSyn29 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_13 tks) (\x -> case x of {HappyAbsSyn37 z -> happyReturn z; _other -> notHappyAtAll })
 
 pListVarIdent_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_10 tks) (\x -> case x of {HappyAbsSyn30 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_14 tks) (\x -> case x of {HappyAbsSyn38 z -> happyReturn z; _other -> notHappyAtAll })
 
 pTerm_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_11 tks) (\x -> case x of {HappyAbsSyn31 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_15 tks) (\x -> case x of {HappyAbsSyn39 z -> happyReturn z; _other -> notHappyAtAll })
 
 pTerm1_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_12 tks) (\x -> case x of {HappyAbsSyn31 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_16 tks) (\x -> case x of {HappyAbsSyn39 z -> happyReturn z; _other -> notHappyAtAll })
 
 pTerm2_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_13 tks) (\x -> case x of {HappyAbsSyn31 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_17 tks) (\x -> case x of {HappyAbsSyn39 z -> happyReturn z; _other -> notHappyAtAll })
 
 pScopedTerm_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_14 tks) (\x -> case x of {HappyAbsSyn34 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_18 tks) (\x -> case x of {HappyAbsSyn42 z -> happyReturn z; _other -> notHappyAtAll })
 
 pPattern_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_15 tks) (\x -> case x of {HappyAbsSyn35 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_19 tks) (\x -> case x of {HappyAbsSyn43 z -> happyReturn z; _other -> notHappyAtAll })
 
 happySeq = happyDontSeq
 
@@ -2035,11 +2205,23 @@ myLexer = tokens
 pProgram :: [Token] -> Err Language.MLTT.Syntax.Abs.Program
 pProgram = fmap snd . pProgram_internal
 
-pListModule :: [Token] -> Err [Language.MLTT.Syntax.Abs.Module]
-pListModule = fmap snd . pListModule_internal
+pListUnit :: [Token] -> Err [Language.MLTT.Syntax.Abs.Unit]
+pListUnit = fmap snd . pListUnit_internal
+
+pUnit :: [Token] -> Err Language.MLTT.Syntax.Abs.Unit
+pUnit = fmap snd . pUnit_internal
 
 pModule :: [Token] -> Err Language.MLTT.Syntax.Abs.Module
 pModule = fmap snd . pModule_internal
+
+pInclude :: [Token] -> Err Language.MLTT.Syntax.Abs.Include
+pInclude = fmap snd . pInclude_internal
+
+pListInclude :: [Token] -> Err [Language.MLTT.Syntax.Abs.Include]
+pListInclude = fmap snd . pListInclude_internal
+
+pTelescopeDecl :: [Token] -> Err Language.MLTT.Syntax.Abs.TelescopeDecl
+pTelescopeDecl = fmap snd . pTelescopeDecl_internal
 
 pParam :: [Token] -> Err Language.MLTT.Syntax.Abs.Param
 pParam = fmap snd . pParam_internal

--- a/haskell/mltt/src/Language/MLTT/Syntax/Print.hs
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Print.hs
@@ -141,15 +141,32 @@ instance Print Language.MLTT.Syntax.Abs.VarIdent where
   prt _ (Language.MLTT.Syntax.Abs.VarIdent i) = doc $ showString i
 instance Print (Language.MLTT.Syntax.Abs.Program' a) where
   prt i = \case
-    Language.MLTT.Syntax.Abs.AProgram _ modules -> prPrec i 0 (concatD [prt 0 modules])
+    Language.MLTT.Syntax.Abs.AProgram _ units -> prPrec i 0 (concatD [prt 0 units])
 
-instance Print [Language.MLTT.Syntax.Abs.Module' a] where
+instance Print [Language.MLTT.Syntax.Abs.Unit' a] where
   prt _ [] = concatD []
   prt _ (x:xs) = concatD [prt 0 x, prt 0 xs]
 
+instance Print (Language.MLTT.Syntax.Abs.Unit' a) where
+  prt i = \case
+    Language.MLTT.Syntax.Abs.UnitModule _ module_ -> prPrec i 0 (concatD [prt 0 module_])
+    Language.MLTT.Syntax.Abs.UnitTelescope _ telescopedecl -> prPrec i 0 (concatD [prt 0 telescopedecl])
+
 instance Print (Language.MLTT.Syntax.Abs.Module' a) where
   prt i = \case
-    Language.MLTT.Syntax.Abs.AModule _ varident params imports decls -> prPrec i 0 (concatD [doc (showString "module"), prt 0 varident, prt 0 params, doc (showString ";"), prt 0 imports, prt 0 decls])
+    Language.MLTT.Syntax.Abs.AModule _ varident includes params imports decls -> prPrec i 0 (concatD [doc (showString "module"), prt 0 varident, prt 0 includes, prt 0 params, doc (showString ";"), prt 0 imports, prt 0 decls])
+
+instance Print (Language.MLTT.Syntax.Abs.Include' a) where
+  prt i = \case
+    Language.MLTT.Syntax.Abs.AnInclude _ varident -> prPrec i 0 (concatD [doc (showString "include"), prt 0 varident])
+
+instance Print [Language.MLTT.Syntax.Abs.Include' a] where
+  prt _ [] = concatD []
+  prt _ (x:xs) = concatD [prt 0 x, prt 0 xs]
+
+instance Print (Language.MLTT.Syntax.Abs.TelescopeDecl' a) where
+  prt i = \case
+    Language.MLTT.Syntax.Abs.ATelescope _ varident params -> prPrec i 0 (concatD [doc (showString "telescope"), prt 0 varident, prt 0 params, doc (showString ";")])
 
 instance Print (Language.MLTT.Syntax.Abs.Param' a) where
   prt i = \case

--- a/haskell/mltt/src/Language/MLTT/Telescope.hs
+++ b/haskell/mltt/src/Language/MLTT/Telescope.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
+{-# LANGUAGE InstanceSigs        #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
--- | Module parameters, and closing a declaration over the ones it uses.
+-- | The labelled telescope, module parameters as an instance of it, and closing
+-- a declaration over the parameters it uses.
 --
 -- A parametrised module
 --
@@ -16,6 +19,10 @@
 -- uses no parameter is closed over nothing and stays a plain constant. An
 -- optional @over (…)@ clause states that set in the source, and is checked
 -- against the computed one by 'checkDischarge'.
+--
+-- The parameters may come from an @include@ rather than be written out; that is
+-- resolved before a module is checked (see 'Language.MLTT.Impl.resolveUnits'),
+-- so nothing here can tell the difference.
 --
 -- == Where the scope restriction is
 --
@@ -44,42 +51,174 @@ module Language.MLTT.Telescope where
 import qualified Control.Monad.Foil           as Foil
 import           Control.Monad.Free.Foil      (supportOf, unsinkAST)
 import           Data.List                    (intercalate, sort)
+import           Unsafe.Coerce                (unsafeCoerce)
+
 import           Language.MLTT.Impl.Generated
 import           Language.MLTT.Resolve        (prettyVarIdent)
 import qualified Language.MLTT.Syntax.Abs     as Raw
 
--- | The parameters of a module: a name, a type, and a binder, in order.
+-- | A labelled telescope: a chain of binders, each carrying a label and a
+-- payload in the scope before it.
 --
--- The type of a parameter may mention the parameters before it, which is what
--- makes this a telescope rather than a list.
-data Telescope a n l where
-  TelescopeEmpty :: Telescope a n n
+-- The payload of a step lives in the scope the steps before it extend to, which
+-- is what makes this a telescope rather than a list. For a module's parameters
+-- the label is how the parameter is spelled and the payload is its type, so
+-- that @(A : 𝕌) (m : A → A → A)@ is a two-step telescope whose second payload
+-- mentions the first binder.
+--
+-- Nothing here is specific to MLTT, and the intention is to lift the type and
+-- its instances into free-foil once they have been proven in the demo. See
+-- 'Foil.NameBinderList', which this follows almost line for line.
+data Telescope label e n l where
+  TelescopeEmpty :: Telescope label e n n
   TelescopeCons
-    :: (Foil.Distinct n, Foil.DExt n i, Foil.Ext i l)
-    => Raw.VarIdent           -- ^ How the parameter is spelled.
-    -> Term' a n              -- ^ Its type, in the scope before it.
-    -> Foil.NameBinder n i    -- ^ The binder that introduced it.
-    -> Telescope a i l        -- ^ The parameters after it.
-    -> Telescope a n l
+    :: label                        -- ^ How the step is labelled.
+    -> e n                          -- ^ Its payload, in the scope before it.
+    -> Foil.NameBinder n i          -- ^ The binder it introduces.
+    -> Telescope label e i l        -- ^ The steps after it.
+    -> Telescope label e n l
 
--- | One parameter, with everything about it moved into the innermost scope.
+-- | A module's parameters: the labels are spellings, the payloads are types.
+type ParamTelescope a = Telescope Raw.VarIdent (Term' a)
+
+-- | How a payload is moved from a telescope's own scope into the ambient one.
+--
+-- 'Foil.withPattern' relates the two scopes only through the binders it hands
+-- back, so this is accumulated as the telescope is walked: a step whose binder
+-- came back unchanged leaves raw names alone, and only a step that renamed its
+-- binder makes the transport a real renaming. Since 'Foil.extendScopePattern',
+-- 'Foil.namesOfPattern' and 'Foil.nameBinderListOf' never rename, the payloads
+-- are not walked on any of those paths.
+data Transport n o
+  = Verbatim
+    -- ^ No binder was renamed, so the payload can be taken over as it is.
+  | Renamed (Foil.Name n -> Foil.Name o)
+    -- ^ Some binder was renamed, so the payload has to be traversed.
+
+-- | Move a payload along a 'Transport'.
+transportPayload :: Foil.Sinkable e => Transport n o -> e n -> e o
+transportPayload Verbatim         = unsafeCoerce
+transportPayload (Renamed rename) = Foil.sinkabilityProof rename
+
+-- | Move a single name along a 'Transport'.
+transportName :: Transport n o -> Foil.Name n -> Foil.Name o
+transportName Verbatim         = unsafeCoerce
+transportName (Renamed rename) = rename
+
+-- | Extend a transport by one step of the telescope.
+--
+-- The names of the inner scope are the binder's own name, which goes to the
+-- name the refreshed binder introduces, and the names of the outer scope, which
+-- the transport so far already answers for.
+extendTransport
+  :: Transport n o
+  -> Foil.NameBinder n i    -- ^ The binder as the telescope has it.
+  -> Foil.NameBinder o o'   -- ^ The binder 'Foil.withPattern' handed back.
+  -> Transport i o'
+extendTransport transport binder binder'
+  | Verbatim <- transport, unchanged = Verbatim
+  | otherwise = Renamed $ \name ->
+      if Foil.nameId name == Foil.nameId (Foil.nameOf binder)
+        then Foil.nameOf binder'
+        else unsafeCoerce (transportName transport (unsafeCoerce name))
+  where
+    unchanged =
+      Foil.nameId (Foil.nameOf binder) == Foil.nameId (Foil.nameOf binder')
+
+-- | A telescope is a pattern, so the foil's own machinery walks it.
+--
+-- 'Foil.coSinkabilityProof' is the interesting half. It is proof code (every
+-- call site goes through 'Foil.extendRenaming', which is a coercion), but it
+-- has to typecheck, and it only does because a payload is sunk by the renaming
+-- of the scope /before/ its binder rather than by the extended one.
+instance Foil.Sinkable e => Foil.CoSinkable (Telescope label e) where
+  coSinkabilityProof rename TelescopeEmpty cont = cont rename TelescopeEmpty
+  coSinkabilityProof rename (TelescopeCons label payload binder rest) cont =
+    Foil.coSinkabilityProof rename binder $ \rename' binder' ->
+      Foil.coSinkabilityProof rename' rest $ \rename'' rest' ->
+        cont rename''
+          (TelescopeCons label (Foil.sinkabilityProof rename payload) binder' rest')
+
+  withPattern
+    :: forall f o n l r. Foil.Distinct o
+    => (forall x y z r'. Foil.Distinct z
+          => Foil.Scope z
+          -> Foil.NameBinder x y
+          -> (forall z'. Foil.DExt z z' => f x y z z' -> Foil.NameBinder z z' -> r')
+          -> r')
+    -> (forall x z z'. Foil.DExt z z' => f x x z z')
+    -> (forall x y y' z z' z''. (Foil.DExt z z', Foil.DExt z' z'')
+          => f x y z z' -> f y y' z' z'' -> f x y' z z'')
+    -> Foil.Scope o
+    -> Telescope label e n l
+    -> (forall o'. Foil.DExt o o' => f n l o o' -> Telescope label e o o' -> r)
+    -> r
+  withPattern withBinder unit comp = go Verbatim
+    where
+      go :: forall n' l' o' r'. Foil.Distinct o'
+         => Transport n' o'
+         -> Foil.Scope o'
+         -> Telescope label e n' l'
+         -> (forall o''. Foil.DExt o' o''
+               => f n' l' o' o'' -> Telescope label e o' o'' -> r')
+         -> r'
+      go _transport _scope TelescopeEmpty cont = cont unit TelescopeEmpty
+      go transport scope (TelescopeCons label payload binder rest) cont =
+        withBinder scope binder $ \fbinder binder' ->
+          go (extendTransport transport binder binder')
+             (Foil.extendScope binder' scope)
+             rest $ \frest rest' ->
+            cont (comp fbinder frest)
+              (TelescopeCons label (transportPayload transport payload) binder' rest')
+
+-- | Telescopes unify exactly when their binders do, as for a
+-- 'Foil.NameBinderList'.
+--
+-- Labels and payloads are ignored, which is the library's documented default
+-- for non-binding fields, and is what α-equivalence should do with a label: a
+-- parameter's spelling is no more relevant than a bound variable's. Payloads
+-- are a different matter, since two telescopes agreeing on binders may well
+-- disagree on types. Unfortunately 'Foil.unifyPatterns' has only
+-- 'Foil.Distinct' to work with, and comparing terms up to α needs the scope, so
+-- the caller has to compare the payloads itself.
+instance Foil.Sinkable e => Foil.UnifiablePattern (Telescope label e) where
+  unifyPatterns TelescopeEmpty TelescopeEmpty =
+    Foil.SameNameBinders Foil.emptyNameBinders
+  unifyPatterns (TelescopeCons _ _ x xs) (TelescopeCons _ _ y ys) =
+    case (Foil.assertDistinct x, Foil.assertDistinct y) of
+      (Foil.Distinct, Foil.Distinct) ->
+        Foil.unifyNameBinders x y `Foil.andThenUnifyPatterns` (xs, ys)
+  -- Telescopes of different lengths bind different numbers of names.
+  unifyPatterns _ _ = Foil.NotUnifiable
+
+-- | One step of a telescope, with everything about it moved into the innermost
+-- scope.
 --
 -- Sinking is free, so this is the convenient form for anything that has to
 -- compare parameters with the names of a term checked under all of them.
-data Param a l = Param
-  { paramIdent :: Raw.VarIdent
+data Param label e l = Param
+  { paramLabel :: label
   , paramName  :: Foil.Name l
-  , paramType  :: Term' a l
+  , paramType  :: e l
   }
 
--- | The parameters, outermost first.
-telescopeParams :: Foil.Distinct l => Telescope a n l -> [Param a l]
+-- | The steps of a telescope, outermost first.
+telescopeParams
+  :: (Foil.Sinkable e, Foil.Distinct l)
+  => Telescope label e n l -> [Param label e l]
 telescopeParams TelescopeEmpty = []
-telescopeParams (TelescopeCons name ty binder rest) =
-  Param name (Foil.sink (Foil.nameOf binder)) (Foil.sink ty) : telescopeParams rest
+telescopeParams (TelescopeCons label ty binder rest) =
+  case (Foil.assertExt binder, Foil.assertExt rest) of
+    (Foil.Ext, Foil.Ext) ->
+      Param label (Foil.sink (Foil.nameOf binder)) (Foil.sink ty)
+        : telescopeParams rest
 
--- | The chain of binders the parameters form.
-telescopeBinders :: Telescope a n l -> Foil.NameBinderList n l
+-- | The chain of binders a telescope forms.
+--
+-- This is 'Foil.nameBinderListOf' at a telescope, written out: the general one
+-- goes through 'Foil.withPattern' and so rebuilds the telescope only to throw
+-- it away, and this is on the checking path.
+telescopeBinders :: Telescope label e n l -> Foil.NameBinderList n l
 telescopeBinders TelescopeEmpty = Foil.NameBinderListEmpty
 telescopeBinders (TelescopeCons _ _ binder rest) =
   Foil.NameBinderListCons binder (telescopeBinders rest)
@@ -89,7 +228,9 @@ telescopeBinders (TelescopeCons _ _ binder rest) =
 -- Keeping a parameter puts its type into the result, so whatever that type
 -- mentions has to be kept too. A parameter's type mentions only the parameters
 -- before it, so working from the inside out settles it in one pass.
-closeOverTelescope :: Foil.Distinct l => [Param a l] -> Foil.NameSet l -> Foil.NameSet l
+closeOverTelescope
+  :: Foil.Distinct l
+  => [Param label (Term' a) l] -> Foil.NameSet l -> Foil.NameSet l
 closeOverTelescope params wanted = foldr close wanted params
   where
     close p keep
@@ -120,7 +261,7 @@ discharge
   :: forall a n l. (Foil.Distinct n, Foil.Distinct l)
   => a                        -- ^ The position to put on the abstractions introduced.
   -> Foil.Scope n             -- ^ The module's scope, which the result lives in.
-  -> Telescope a n l
+  -> ParamTelescope a n l
   -> Maybe (Foil.NameSet l)   -- ^ A declared set of parameters, if there is one.
   -> Term' a l                -- ^ The declaration's type, checked with parameters in scope.
   -> Term' a l                -- ^ Its value, likewise.
@@ -132,7 +273,7 @@ discharge loc scope tele declared ty value
         \(thinned :: Foil.NameBinderList n m) ->
           let scopeM = Foil.extendScopePattern thinned scope
            in case (unsinkAST scopeM ty, unsinkAST scopeM value,
-                    traverse (\p -> (,) (paramIdent p) <$> unsinkAST scopeM (paramType p)) kept) of
+                    traverse (\p -> (,) (paramLabel p) <$> unsinkAST scopeM (paramType p)) kept) of
                 (Just tyM, Just valueM, Just paramsM) ->
                   build scope thinned paramsM tyM valueM
                 -- Unreachable: 'keep' contains the support and is closed, which
@@ -154,14 +295,14 @@ discharge loc scope tele declared ty value
     -- up front is what leaves 'build' with nothing to report: every restriction
     -- it performs is then into a scope that has what the term needs.
     missing =
-      [ paramIdent p
+      [ paramLabel p
       | p <- params
       , Foil.nameSetMember (paramName p) needed
       , not (Foil.nameSetMember (paramName p) keep)
       ]
 
     -- Every parameter the declaration needs, whether or not it is being kept.
-    needs = [paramIdent p | p <- params, Foil.nameSetMember (paramName p) needed]
+    needs = [paramLabel p | p <- params, Foil.nameSetMember (paramName p) needed]
 
     -- Rebuild the abstractions along the thinned chain. Everything has already
     -- been restricted into the thinned scope @m@, so each step only has to take

--- a/haskell/mltt/test/Language/MLTT/ArtifactSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ArtifactSpec.hs
@@ -37,7 +37,7 @@ srcU = sourceLines ["module U", "import R", "import T", "compute t r"]
 
 oneModule :: SourceText -> Raw.Module
 oneModule src = case parseProgram src of
-  Right (Raw.AProgram _ [m]) -> m
+  Right (Raw.AProgram _ [Raw.UnitModule _ m]) -> m
   Right _                    -> error "expected exactly one module"
   Left err                   -> error err
 

--- a/haskell/mltt/test/Language/MLTT/BuildSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/BuildSpec.hs
@@ -31,7 +31,7 @@ srcU = sourceLines ["module U", "import R", "import T", "compute t r"]
 
 oneModule :: SourceText -> Raw.Module
 oneModule src = case parseProgram src of
-  Right (Raw.AProgram _ [m]) -> m
+  Right (Raw.AProgram _ [Raw.UnitModule _ m]) -> m
   Right _                    -> error "expected exactly one module"
   Left err                   -> error err
 

--- a/haskell/mltt/test/Language/MLTT/IncludeSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/IncludeSpec.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+-- | Named telescopes and the @include@ clause.
+--
+-- A telescope declaration names a block of module parameters, and an include
+-- puts that block at the front of an including module's own. The property
+-- under test is that nothing downstream of the parameter block changes: the
+-- included fields are checked, discharged and reported exactly as parameters
+-- written out by hand, and an include behaves like an import for staleness.
+module Language.MLTT.IncludeSpec (spec) where
+
+import           System.Directory             (getTemporaryDirectory,
+                                               removePathForcibly)
+import           System.FilePath              ((</>))
+import           Test.Hspec
+
+import           Language.MLTT.Build
+import           Language.MLTT.Impl
+import           Language.MLTT.Impl.Generated (SourceText (..), sourceLines)
+
+-- | Interpret a program, reporting a parse error as a failed command.
+run :: String -> [CommandResult]
+run input = case interpret (SourceText input) of
+  Left err      -> [Failed ("parse error: " <> err)]
+  Right results -> results
+
+-- | The messages of every command that was rejected.
+failures :: [CommandResult] -> [String]
+failures results = [err | Failed err <- results]
+
+-- | A monoid telescope, and whatever units are given after it.
+withMonoid :: [String] -> String
+withMonoid units = unlines
+  ("telescope Monoid (A : 𝕌) (unit : A) (mul : A → A → A)" : units)
+
+spec :: Spec
+spec = do
+  describe "a module that includes a telescope" $ do
+    it "is discharged over the included fields it uses" $
+      run (withMonoid
+            [ "module CommMonoid include Monoid"
+            , "def square : A → A := λ x ⇒ mul x x" ])
+        `shouldSatisfy` (Defined "square" ["A", "mul"] `elem`)
+
+    it "puts the included fields before the ones it declares itself" $
+      -- `inv` is the module's own and comes last, whatever it is used with.
+      run (withMonoid
+            [ "module Group include Monoid (inv : A → A)"
+            , "def undo : A → A := λ x ⇒ mul x (inv x)" ])
+        `shouldSatisfy` (Defined "undo" ["A", "mul", "inv"] `elem`)
+
+    it "lets a parameter of its own mention an included field" $
+      -- `inv : A → A` only resolves because `A` is already in the telescope.
+      failures (run (withMonoid
+            [ "module Group include Monoid (inv : A → A)"
+            , "def unitInverse : A := inv unit" ]))
+        `shouldBe` []
+
+    it "may include a telescope declared after it" $
+      -- Telescopes are resolved over the whole program, as imports are.
+      failures (run (unlines
+            [ "module M include Monoid"
+            , "def square : A → A := λ x ⇒ mul x x"
+            , ""
+            , "telescope Monoid (A : 𝕌) (unit : A) (mul : A → A → A)" ]))
+        `shouldBe` []
+
+    it "shares nothing with another includer but the source" $
+      -- Each module elaborates the telescope afresh, so what leaves them are
+      -- two unrelated closed constants that a client instantiates separately.
+      run (withMonoid
+            [ "module One include Monoid"
+            , "def sq : A → A := λ x ⇒ mul x x"
+            , ""
+            , "module Two include Monoid"
+            , "def dup : A → A := λ x ⇒ mul x x"
+            , ""
+            , "module Client"
+            , "import One"
+            , "import Two"
+            , "compute sq 𝟙 (λ x ⇒ λ y ⇒ x) tt"
+            , "compute dup 𝟙 (λ x ⇒ λ y ⇒ x) tt" ])
+        `shouldSatisfy` ([Computed "tt", Computed "tt"] ==)
+          . filter isComputed
+
+  describe "a telescope that is not there" $ do
+    it "is reported, naming it" $
+      failures (run (unlines
+            ["module M include Nope", "def x : 𝟙 := tt"]))
+        `shouldBe` ["no telescope named Nope is declared"]
+
+    it "is reported once, whatever the module goes on to declare" $
+      length (failures (run (unlines
+            ["module M include Nope", "def x : 𝟙 := tt", "def y : 𝟙 := tt"])))
+        `shouldBe` 1
+
+  describe "a telescope declared twice" $
+    it "is reported rather than one of them silently winning" $
+      failures (run (unlines
+            [ "telescope T (A : 𝕌)"
+            , "telescope T (B : 𝕌)"
+            , "module M include T"
+            , "def x : 𝟙 := tt" ]))
+        `shouldBe` ["telescope declared twice: T"]
+
+  describe "the cache" $
+    it "treats a changed telescope as a changed import of its includers" $ do
+      dir <- (</> "mltt-include-spec-cache") <$> getTemporaryDirectory
+      removePathForcibly dir
+      let telescope fields = ("Tele.mltt", sourceLines ["telescope T " <> fields])
+          user = ("User.mltt", sourceLines
+                    ["module M include T", "def x : A → A := λ y ⇒ y"])
+          build src = buildSources Linked (Just dir) [telescope src, user]
+      r1 <- build "(A : 𝕌)"
+      fmap loadedNames r1 `shouldBe` Right []
+      r2 <- build "(A : 𝕌)"
+      fmap loadedNames r2 `shouldBe` Right ["M"]
+      -- The module's own source is untouched; only the telescope it includes
+      -- has changed, and that has to be enough to rebuild it.
+      r3 <- build "(A : 𝕌) (a : A)"
+      fmap loadedNames r3 `shouldBe` Right []
+      fmap checkedNames r3 `shouldBe` Right ["M"]
+  where
+    isComputed = \case
+      Computed _ -> True
+      _          -> False
+
+    loadedNames results = [name | LoadedModule name <- results]
+    checkedNames results = [name | EnteredModule name <- results]

--- a/haskell/mltt/test/Language/MLTT/IncludeSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/IncludeSpec.hs
@@ -33,6 +33,33 @@ withMonoid :: [String] -> String
 withMonoid units = unlines
   ("telescope Monoid (A : 𝕌) (unit : A) (mul : A → A → A)" : units)
 
+-- | A theory carrying a law, a lemma proved once in it, and an instance: the
+-- Church numerals under addition, whose associativity holds on the nose.
+theoryAndInstance :: String
+theoryAndInstance = unlines
+  [ "telescope Monoid (A : 𝕌) (mul : A → A → A)"
+  , "  (assoc : Π (x : A) → Π (y : A) → Π (z : A)"
+  , "         → Id(A, mul (mul x y) z, mul x (mul y z)))"
+  , ""
+  , "module Theory include Monoid"
+  , "def square : A → A := λ x ⇒ mul x x"
+  , "def squareAssoc : Π (x : A) → Id(A, mul (square x) x, mul x (square x))"
+  , "  := λ x ⇒ assoc x x x"
+  , ""
+  , "module Church"
+  , "def Nat : 𝕌 := Π (A : 𝕌) → (A → A) → A → A"
+  , "def plus : Nat → Nat → Nat := λ m ⇒ λ n ⇒ λ A ⇒ λ f ⇒ λ x ⇒ m A f (n A f x)"
+  , "def plusAssoc : Π (a : Nat) → Π (b : Nat) → Π (c : Nat)"
+  , "              → Id(Nat, plus (plus a b) c, plus a (plus b c))"
+  , "  := λ a ⇒ λ b ⇒ λ c ⇒ refl (plus (plus a b) c)"
+  , ""
+  , "module Client"
+  , "import Theory"
+  , "import Church"
+  , "check squareAssoc Nat plus plusAssoc"
+  , "    : Π (x : Nat) → Id(Nat, plus (plus x x) x, plus x (plus x x))"
+  ]
+
 spec :: Spec
 spec = do
   describe "a module that includes a telescope" $ do
@@ -82,6 +109,19 @@ spec = do
             , "compute dup 𝟙 (λ x ⇒ λ y ⇒ x) tt" ])
         `shouldSatisfy` ([Computed "tt", Computed "tt"] ==)
           . filter isComputed
+
+  describe "a theory and an instance" $ do
+    it "discharges a lemma over the law field it uses, and not otherwise" $
+      -- `square` needs the operation; `squareAssoc` needs the law as well.
+      -- Nothing declares this, and nothing has to: it is what discharge finds.
+      run theoryAndInstance `shouldSatisfy` \results ->
+        Defined "square" ["A", "mul"] `elem` results
+          && Defined "squareAssoc" ["A", "mul", "assoc"] `elem` results
+
+    it "applies the theory's lemma at the instance, which is application" $
+      -- The instance supplies the carrier, the operation and its own proof of
+      -- the law, in telescope order. There is no interpretation step.
+      failures (run theoryAndInstance) `shouldBe` []
 
   describe "a telescope that is not there" $ do
     it "is reported, naming it" $

--- a/haskell/mltt/test/Language/MLTT/LinkSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/LinkSpec.hs
@@ -34,7 +34,7 @@ srcX = sourceLines ["module X", "def unrelated : 𝟙 := tt"]
 
 oneModule :: SourceText -> Raw.Module
 oneModule src = case parseProgram src of
-  Right (Raw.AProgram _ [m]) -> m
+  Right (Raw.AProgram _ [Raw.UnitModule _ m]) -> m
   Right _                    -> error "expected exactly one module"
   Left err                   -> error err
 

--- a/haskell/mltt/test/Language/MLTT/ModulesSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ModulesSpec.hs
@@ -132,7 +132,8 @@ spec = do
         `shouldBe` ["λ x0 ⇒ x0"]
 
   describe "the example programs" $
-    forM_ ["examples/core.mltt", "examples/modules.mltt", "examples/parameters.mltt"] $ \path ->
+    forM_ [ "examples/core.mltt", "examples/modules.mltt"
+          , "examples/parameters.mltt", "examples/telescopes.mltt" ] $ \path ->
       it (path <> " is accepted in full") $ do
         input <- readFile path
         let results = run input

--- a/haskell/mltt/test/Language/MLTT/ModulesSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ModulesSpec.hs
@@ -133,7 +133,8 @@ spec = do
 
   describe "the example programs" $
     forM_ [ "examples/core.mltt", "examples/modules.mltt"
-          , "examples/parameters.mltt", "examples/telescopes.mltt" ] $ \path ->
+          , "examples/parameters.mltt", "examples/telescopes.mltt"
+          , "examples/theories.mltt" ] $ \path ->
       it (path <> " is accepted in full") $ do
         input <- readFile path
         let results = run input

--- a/haskell/mltt/test/Language/MLTT/ReplImportSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ReplImportSpec.hs
@@ -26,7 +26,9 @@ srcQ  = sourceLines ["module Q", "import P", "def q : 𝟙 := base"]
 srcR  = sourceLines ["module R", "import Q", "def r : 𝟙 := q"]
 
 modsOf :: [SourceText] -> [Raw.Module]
-modsOf srcs = concat [ms | Right (Raw.AProgram _ ms) <- map parseProgram srcs]
+modsOf srcs =
+  either error id . resolveUnits $
+    concat [units | Right (Raw.AProgram _ units) <- map parseProgram srcs]
 
 -- | A session over an empty world, on a stripe clear of the cached ones.
 bareSession :: Repl Foil.VoidS

--- a/haskell/mltt/test/Language/MLTT/TelescopeSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/TelescopeSpec.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-- | A telescope as a foil pattern.
+--
+-- The interesting property is the one the foil's pattern API does not give for
+-- free. A telescope carries a payload per step, and refreshing the telescope
+-- has to rename the payloads along with the binders, since a payload may
+-- mention the binders before it. 'Control.Monad.Foil.withPattern' relates the
+-- telescope's own scope to the ambient one only through the binders it hands
+-- back, so the renaming is recovered from those, and the tests below pin both
+-- halves of that: the payload follows a renamed binder, and it is left alone
+-- when nothing is renamed.
+module Language.MLTT.TelescopeSpec (spec) where
+
+import qualified Control.Monad.Foil           as Foil
+import           Control.Monad.Free.Foil      (pattern Var, supportOf)
+import           Language.MLTT.Impl.Generated
+import qualified Language.MLTT.Syntax.Abs     as Raw
+import           Language.MLTT.Telescope
+import           Test.Hspec
+
+pos :: Raw.BNFC'Position
+pos = Raw.BNFC'NoPosition
+
+-- | @(A : 𝕌) (x : A)@, allocated from the empty scope, so its binders are the
+-- raw names 0 and 1 and its second payload mentions the first binder.
+withDependent
+  :: (forall l. Foil.Distinct l
+        => ParamTelescope Raw.BNFC'Position Foil.VoidS l -> r)
+  -> r
+withDependent cont =
+  Foil.withFresh Foil.emptyScope $ \bA ->
+    Foil.withFresh (Foil.extendScope bA Foil.emptyScope) $ \bx ->
+      cont $
+        TelescopeCons (Raw.VarIdent "A") (Universe pos) bA $
+          TelescopeCons (Raw.VarIdent "x") (Var (Foil.nameOf bA)) bx TelescopeEmpty
+
+-- | @(A : 𝕌)@, for comparing telescopes of different lengths.
+withSingle
+  :: (forall l. Foil.Distinct l
+        => ParamTelescope Raw.BNFC'Position Foil.VoidS l -> r)
+  -> r
+withSingle cont =
+  Foil.withFresh Foil.emptyScope $ \bA ->
+    cont (TelescopeCons (Raw.VarIdent "A") (Universe pos) bA TelescopeEmpty)
+
+-- | A scope holding the raw names 0 and 1, so that both binders of
+-- 'withDependent' clash with it.
+withClashingScope :: (forall o. Foil.Distinct o => Foil.Scope o -> r) -> r
+withClashingScope cont =
+  Foil.withFresh Foil.emptyScope $ \b0 ->
+    let scope1 = Foil.extendScope b0 Foil.emptyScope
+     in Foil.withFresh scope1 $ \b1 -> cont (Foil.extendScope b1 scope1)
+
+-- | Refresh a telescope, fixing the expression type that
+-- 'Foil.withRefreshedPattern' leaves for the caller to choose.
+withRefreshedTelescope
+  :: Foil.Distinct o
+  => Foil.Scope o
+  -> ParamTelescope Raw.BNFC'Position n l
+  -> (forall o'. Foil.DExt o o'
+        => ParamTelescope Raw.BNFC'Position o o' -> r)
+  -> r
+withRefreshedTelescope scope tele cont =
+  Foil.withRefreshedPattern scope tele $
+    \(_ :: Foil.Substitution Term n' o -> Foil.Substitution Term l' o') tele' ->
+      cont tele'
+
+-- | The raw names of the binders, outermost first.
+binderNames :: Telescope label e n l -> [Foil.RawName]
+binderNames = go . telescopeBinders
+  where
+    go :: Foil.NameBinderList n' l' -> [Foil.RawName]
+    go Foil.NameBinderListEmpty            = []
+    go (Foil.NameBinderListCons binder bs) =
+      Foil.nameId (Foil.nameOf binder) : go bs
+
+-- | The raw names each payload mentions, outermost first.
+payloadNames :: Foil.Distinct n => ParamTelescope a n l -> [[Foil.RawName]]
+payloadNames TelescopeEmpty = []
+payloadNames (TelescopeCons _ ty binder rest) =
+  case Foil.assertDistinct binder of
+    Foil.Distinct ->
+      map Foil.nameId (Foil.nameSetToList (supportOf ty)) : payloadNames rest
+
+-- | Whether unification found the two telescopes to bind the same names.
+sameBinders :: Foil.UnifyNameBinders binder n l r -> Bool
+sameBinders Foil.SameNameBinders{} = True
+sameBinders _                      = False
+
+spec :: Spec
+spec = do
+  describe "the binders of a telescope" $ do
+    it "are the same through the pattern API as directly" $
+      withDependent $ \tele ->
+        map Foil.nameId (Foil.namesOfPattern tele) `shouldBe` binderNames tele
+
+    it "all extend the ambient scope" $
+      withDependent $ \tele ->
+        let scope = Foil.extendScopePattern tele Foil.emptyScope
+         in map Foil.nameId (Foil.nameSetToList (Foil.scopeToNameSet scope))
+              `shouldBe` binderNames tele
+
+  describe "refreshing a telescope" $ do
+    it "leaves the payloads alone when no binder clashes" $
+      withDependent $ \tele ->
+        withRefreshedTelescope Foil.emptyScope tele $ \tele' ->
+          (binderNames tele', payloadNames tele') `shouldBe` ([0, 1], [[], [0]])
+
+    it "carries a payload's reference to a renamed binder along" $
+      -- Both binders are renamed, so the second payload, which is `A`, has to
+      -- come out mentioning the new first binder rather than the old one.
+      withDependent $ \tele ->
+        withClashingScope $ \scope ->
+          withRefreshedTelescope scope tele $ \tele' ->
+            (binderNames tele', payloadNames tele') `shouldBe` ([2, 3], [[], [2]])
+
+  describe "unifying telescopes" $ do
+    it "unifies a telescope with itself" $
+      withDependent $ \tele ->
+        sameBinders (Foil.unifyPatterns tele tele) `shouldBe` True
+
+    it "ignores the labels, as it ignores a bound variable's spelling" $
+      withDependent $ \tele ->
+        sameBinders (Foil.unifyPatterns tele (relabel tele)) `shouldBe` True
+
+    it "refuses telescopes of different lengths" $
+      withDependent $ \long ->
+        withSingle $ \short ->
+          sameBinders (Foil.unifyPatterns long short) `shouldBe` False
+  where
+    relabel :: ParamTelescope a n l -> ParamTelescope a n l
+    relabel TelescopeEmpty = TelescopeEmpty
+    relabel (TelescopeCons _ ty binder rest) =
+      TelescopeCons (Raw.VarIdent "renamed") ty binder (relabel rest)


### PR DESCRIPTION
A block of module parameters can now be declared once and reused. A `telescope` declaration is a top-level unit beside the modules, and a module `include`s it: the included fields come first in the including module's telescope, before the parameters it declares itself, and one of its own may mention them.

```
telescope Monoid (A : 𝕌) (unit : A) (mul : A → A → A)

module CommMonoid include Monoid
def square : A → A := λ x ⇒ mul x x

module Group include Monoid (inv : A → A)
def undo : A → A := λ x ⇒ mul x (inv x)
```

```
$ mltt examples/telescopes.mltt
module CommMonoid
  ✓ defined square over (A, mul)
module Group
  ✓ defined undo over (A, mul, inv)
```

None of this is my idea. I am following Jon Sterling's framing in the Pterodactyl worklog, where a theory expression denotes a telescope and a refinement such as `Monoid / {car => Nat}` leaves the remaining fields as a telescope again,[^sterling] and that framing is itself inheriting rather than inventing. Telescopes are de Bruijn's,[^debruijn] and labelling their fields, so that a block can be declared once and projected from, is what dependent record types are: Pollack's,[^pollack] and Luo's manifest fields for the refined case this PR defers.[^luo] What is new here, if anything, is only that the telescope is a scope-safe pattern rather than a construction on raw syntax.

Discharge is untouched: `undo` is closed over exactly the fields it uses, included or own, and instantiation is application, so there is no `interpretation` command because there is nothing for one to do.

Three things about how it is put together.

1. Module parameters are now a *labelled telescope*, which is a free-foil pattern: `Telescope label e n l`, a chain of binders carrying a label and a payload per step, each payload in the scope before its own binder. `CoSinkable` and `UnifiablePattern` are written by hand, following `NameBinderList` almost line for line, so scope extension, the names of a block and α-equivalence of two blocks all come from the library. Both the label and the payload are parameters, with a view to lifting the type into free-foil once it has earned it.
2. Writing those instances found a gap in the pattern interface. `withPattern` gives an instance no relation between the pattern's own scope and the ambient one, the only bridge being the pair of binders per step, so a pattern with a scoped payload has to recover the renaming from those pairs, over a coercion for everything else. The instance does that behind a small `Transport` type whose fast case keeps `extendScopePattern`, `namesOfPattern` and `nameBinderListOf` from walking payloads at all; `TelescopeSpec` pins both cases. Related and pre-existing: substitution never descends into pattern payloads, so a pattern carrying terms cannot be the binder of an `AST` node. Neither bites here, because a telescope is a module header and not a term, but both are worth a library fix.
3. An include is resolved before a module is checked, so what reaches the checker is an ordinary parametrised module and nothing downstream had to change. That is also what gives staleness for free: a module's content hash is taken over its resolved header, so changing a telescope rebuilds every module that includes it, and the cache test pins exactly that.

An unknown telescope and a telescope declared twice are both reported, and a telescope may be declared after the module that includes it, or in another file.

[^sterling]: Jon Sterling. *Jon's Pterodactyl Worklog.* <https://www.jonmsterling.com/01HC/> — §01HU, "Towards a specification of theory refinements", for a theory expression as a telescope and for the residual of a refinement.

[^debruijn]: N. G. de Bruijn. *Telescopic mappings in typed lambda calculus.* Information and Computation 91(2):189–204, 1991. <https://doi.org/10.1016/0890-5401(91)90066-B>

[^pollack]: Robert Pollack. *Dependently Typed Records in Type Theory.* Formal Aspects of Computing 13:386–402, 2002. <https://doi.org/10.1007/s001650200018>

[^luo]: Zhaohui Luo. *Manifest Fields and Module Mechanisms in Intensional Type Theory.* TYPES 2008, LNCS 5497. <https://doi.org/10.1007/978-3-642-02444-3_15>