### PR TITLE
MLTT: contract eta in nf

### DIFF
--- a/haskell/mltt/README.md
+++ b/haskell/mltt/README.md
@@ -35,7 +35,9 @@ to be worth seeing. Declarations are laid out rather than punctuated, and a
 `namespace` block is opened by indenting under it.
 
 Conversion is naive: both sides are normalised and compared with the library's
-`alphaEquiv`.
+`alphaEquiv`. `nf` does contract η, which is what makes `plus zero n` and `n`
+convertible for the Church numerals; η as an *expansion* would need types, and
+the evaluator here is untyped.
 
 ## What is deliberately not here
 
@@ -250,13 +252,12 @@ telescope threads a `PatternTransport` instead, which is the library's answer to
 exactly this.
 
 `examples/theories.mltt` puts the layer to work: a `Monoid` telescope carrying
-its associativity law, a lemma proved once from that law, and the Church
-numerals under addition as an instance that discharges the law by `refl`, since
-both sides of associativity normalise to the same term. Using the lemma at the
-instance is then application, and no command registers anything anywhere. The
-unit laws are left out of the telescope deliberately: `plus zero n` normalises
-to `λ A ⇒ λ f ⇒ λ x ⇒ n A f x` and stops one η-contraction short of `n`, and
-conversion here has no η, so no instance could prove one.
+associativity and both unit laws, two lemmas proved once from those laws, and
+the Church numerals under addition as an instance that discharges every law by
+`refl`. Using a lemma at the instance is then application, and no command
+registers anything anywhere. The two lemmas need different fields — one the
+associativity, the other the unit and its law — so each is applied to what it
+took and to nothing else.
 
 The idea is not new here. The framing followed is Jon Sterling's, in the
 [Pterodactyl worklog](https://www.jonmsterling.com/01HC/), where a theory

--- a/haskell/mltt/examples/theories.mltt
+++ b/haskell/mltt/examples/theories.mltt
@@ -13,14 +13,14 @@ telescope Monoid
   (unit : A)
   (mul : A → A → A)
   (assoc : Π (x : A) → Π (y : A) → Π (z : A) → Id(A, mul (mul x y) z, mul x (mul y z)))
+  (unitL : Π (x : A) → Id(A, mul unit x, x))
+  (unitR : Π (x : A) → Id(A, mul x unit, x))
 
--- The unit laws are missing on purpose, and it is worth saying why. Stating
--- `Π (x : A) → Id(A, mul unit x, x)` is fine; what no instance below could then
--- do is prove it. Conversion here normalises both sides and compares them, with
--- no η, so `plus zero n` reduces to `λ A ⇒ λ f ⇒ λ x ⇒ n A f x` and stops one
--- η-contraction short of `n`. Associativity needs no η and holds on the nose,
--- which is why it is the law the demo carries. This is a limitation of the demo
--- language's conversion, not of telescopes.
+-- All three laws are fields like any other, and the instance below discharges
+-- every one of them by `refl`. The unit laws need η to do so: `plus zero n`
+-- reduces to `λ A ⇒ λ f ⇒ λ x ⇒ n A f x`, which is `n` only after three
+-- η-contractions. `nf` performs them, so conversion sees the two sides as
+-- equal.
 
 -- Two theories over the same block, declared once. `Group` adds a field of its
 -- own, and its type may mention the included ones.
@@ -47,6 +47,12 @@ def squareAssoc over (A, mul, assoc)
   : Π (x : A) → Id(A, mul (square x) x, mul x (square x))
   := λ x ⇒ assoc x x x
 
+-- A second lemma, over a different set of fields: this one needs the unit and
+-- its law, and not associativity. Each declaration takes what it uses.
+def unitSquare over (A, unit, mul, unitL)
+  : Π (x : A) → Id(A, mul unit (square x), square x)
+  := λ x ⇒ unitL (square x)
+
 -- * An instance
 
 -- The naturals as Church numerals, which is as much data as a type theory with
@@ -61,11 +67,15 @@ def one : Nat := succ zero
 def two : Nat := succ one
 def three : Nat := succ two
 
--- Both sides of associativity normalise to the same term, for variables and
--- not merely for closed numerals, so the instance discharges the law by `refl`.
+-- Every law holds on the nose here, for variables and not merely for closed
+-- numerals, so each one is discharged by `refl`. Associativity needs no η at
+-- all; the unit laws need it, and get it.
 def plusAssoc
   : Π (a : Nat) → Π (b : Nat) → Π (c : Nat) → Id(Nat, plus (plus a b) c, plus a (plus b c))
   := λ a ⇒ λ b ⇒ λ c ⇒ refl (plus (plus a b) c)
+
+def plusUnitL : Π (a : Nat) → Id(Nat, plus zero a, a) := λ a ⇒ refl (a)
+def plusUnitR : Π (a : Nat) → Id(Nat, plus a zero, a) := λ a ⇒ refl (a)
 
 -- * Using the theory at the instance
 
@@ -82,6 +92,11 @@ compute square Nat plus two
 -- is the third argument. What comes back is the lemma at the naturals.
 check squareAssoc Nat plus plusAssoc
   : Π (x : Nat) → Id(Nat, plus (plus x x) x, plus x (plus x x))
+
+-- The other lemma took a different set of fields, so it is applied to those,
+-- and to no others. There is no one telescope being reinstated.
+check unitSquare Nat zero plus plusUnitL
+  : Π (x : Nat) → Id(Nat, plus zero (plus x x), plus x x)
 
 -- A theory's lemma is a term like any other, so it applies at an element.
 compute squareAssoc Nat plus plusAssoc three

--- a/haskell/mltt/src/Language/MLTT/Eval.hs
+++ b/haskell/mltt/src/Language/MLTT/Eval.hs
@@ -155,17 +155,49 @@ whnf scope defs = go
 -- about consistency.
 --
 -- >>> nf Foil.emptyScope emptyDefs (desugar ("λ f ⇒ λ x ⇒ (λ y ⇒ f y) x" :: Term Foil.VoidS))
--- λ x0 ⇒ λ x1 ⇒ x0 x1
+-- λ x0 ⇒ x0
 nf :: forall a n. Foil.Distinct n => Foil.Scope n -> Defs a n -> Term' a n -> Term' a n
 nf scope defs term = case whnf scope defs term of
     Var x     -> Var x
-    Node node -> Node (bimap nfScoped (nf scope defs) node)
+    Node node -> etaReduce scope (Node (bimap nfScoped (nf scope defs) node))
   where
     nfScoped :: ScopedTerm' a n -> ScopedTerm' a n
     nfScoped (ScopedAST binder body) =
       case (Foil.assertExt binder, Foil.assertDistinct binder) of
         (Foil.Ext, Foil.Distinct) -> ScopedAST binder
           (nf (Foil.extendScopePattern binder scope) (extendDefs binder defs) body)
+
+-- | η-reduce a λ that does nothing but apply a term to the variable it binds.
+--
+-- @λ x ⇒ f x@ is @f@, provided @f@ does not use @x@ itself. That proviso is
+-- exactly what free-foil's /restriction/ answers: 'unsinkAST' succeeds when the
+-- function part of the body lives in the scope outside the binder, so the test
+-- is a subset check on the support and a term that passes is not rebuilt.
+--
+-- This is η as a reduction rather than as an expansion, which is why it can sit
+-- in 'nf': contracting needs no types, whereas expanding would need to know
+-- that the term is of a function type, and the evaluator here is untyped.
+--
+-- >>> nf Foil.emptyScope emptyDefs (desugar ("λ f ⇒ λ x ⇒ f x" :: Term Foil.VoidS))
+-- λ x0 ⇒ x0
+--
+-- The function part has to be free of the binder. Here it is not, so nothing
+-- happens:
+--
+-- >>> nf Foil.emptyScope emptyDefs (desugar ("λ x ⇒ x x" :: Term Foil.VoidS))
+-- λ x0 ⇒ x0 x0
+--
+-- Only a λ binding a single variable qualifies. A pair pattern would be
+-- surjective pairing, which is a different rule and not implemented.
+etaReduce :: Foil.Distinct n => Foil.Scope n -> Term' a n -> Term' a n
+etaReduce scope term = case term of
+  Lam _loc (PatternVar _pos binder) (App _appLoc f (Var x))
+    | x == Foil.nameOf binder ->
+        case Foil.assertDistinct binder of
+          Foil.Distinct -> case unsinkAST scope f of
+            Just f' -> f'
+            Nothing -> term
+  _ -> term
 
 -- | Conversion: are two terms equal up to reduction and renaming of bound
 -- variables?


### PR DESCRIPTION
Third follow-up from #70, and the one with something to show.

`λ x ⇒ f x` is `f` when `f` does not use `x`. Without it, conversion could not see that Church addition has a unit:

```
def unitL : Π (a : Nat) → Id(Nat, plus zero a, a) := λ a ⇒ refl (a)
```

`plus zero a` normalises to `λ A ⇒ λ f ⇒ λ x ⇒ a A f x`, which is `a` after three η-contractions. `nf` now does them, so this typechecks.

Three things worth noting.

1. Contraction, not expansion. Contracting needs no types; expanding would need to know the term has a function type, and this evaluator is untyped. That is why it can live in `nf`.
2. The side condition — `f` must not use `x` — is `unsinkAST`. So the rule is one more use of the library's restriction: a subset check on the support, and a term that passes is not rebuilt.
3. Only a λ binding a single variable. A pair pattern would be surjective pairing, which is a different rule and not here.

What it buys, in `examples/theories.mltt`: the `Monoid` telescope now carries associativity **and both unit laws**, and the Church numerals discharge all three by `refl`. So the demo now has two lemmas over different field sets, each applied at the instance to what it took:

```
module MonoidTheory
  ✓ defined square over (A, mul)
  ✓ defined squareAssoc over (A, mul, assoc)
  ✓ defined unitSquare over (A, unit, mul, unitL)
module Client
  ✓ squareAssoc Nat plus plusAssoc : Π (x0 : Nat) → Id (Nat, plus (plus x0 x0) x0, plus x0 (plus x0 x0))
  ✓ unitSquare Nat zero plus plusUnitL : Π (x0 : Nat) → Id (Nat, plus zero (plus x0 x0), plus x0 x0)
```