### PR TITLE
Foil: a benchmark for restriction

### DIFF
--- a/haskell/free-foil/bench/restriction/Main.hs
+++ b/haskell/free-foil/bench/restriction/Main.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveTraversable   #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Restriction benchmark: cutting a chain of binders down to the ones a term
+-- actually uses, the two ways it can be done.
+--
+-- This is the operation a parametrised module performs when it discharges a
+-- declaration over the parameters it uses, and it is where the library's
+-- account of /restriction/ is put under pressure. The question is the same
+-- either way — which of these binders can the term do without? — and there are
+-- two answers:
+--
+-- * ask once. 'supportOf' computes the term's free names in one traversal, and
+--   'Foil.withThinnedNameBinderList' cuts the chain down to that set in one
+--   step, so the term is walked once whatever the number of binders;
+--
+-- * ask per binder. 'unsinkAST' answers for one binder at a time, and each call
+--   recomputes the term's support, so the term is walked once per binder.
+--
+-- The second is the shorter thing to write, and it is what a language
+-- implementation reaches for first. The benchmark is here to say what it costs:
+-- the two should separate linearly in the number of binders, and the point at
+-- which they do is worth knowing, since a module with three parameters is the
+-- common case and one with fourteen is not unheard of.
+--
+-- Both directions report the same number, and the benchmark checks that they
+-- agree before timing them, so a change that breaks one is not silently
+-- measured against the other.
+module Main (main) where
+
+import           Data.Bifoldable         (Bifoldable (..))
+import           Data.List               (foldl')
+import           Data.List.NonEmpty      (NonEmpty (..), nonEmpty)
+import           Test.Tasty.Bench
+
+import qualified Control.Monad.Foil      as Foil
+import           Control.Monad.Free.Foil (AST (..), ScopedAST (..), pattern Var,
+                                          supportOf, unsinkAST)
+
+-- * A signature to build terms over
+
+-- | Application and λ, which is all a term needs to have free variables and
+-- binders in it.
+data LamSig scope term
+  = App term term
+  | Lam scope
+  deriving (Functor, Foldable, Traversable)
+
+instance Bifoldable LamSig where
+  bifoldMap f g = \case
+    App l r -> g l <> g r
+    Lam body -> f body
+
+-- | Terms whose binders are single names, which is what a parameter block is.
+type Term = AST Foil.NameBinder LamSig
+
+-- * The workload
+
+-- | A chain of @n@ binders over the empty scope.
+--
+-- The continuation is handed the innermost scope, the chain, and the scope
+-- before each binder, innermost first.
+withChain
+  :: forall r. Int
+  -> (forall l. Foil.Distinct l
+        => Foil.NameBinderList Foil.VoidS l -> r)
+  -> r
+withChain total cont = go total Foil.emptyScope Foil.NameBinderListEmpty
+  where
+    go :: forall i. Foil.Distinct i
+       => Int -> Foil.Scope i -> Foil.NameBinderList Foil.VoidS i -> r
+    go 0 _scope chain = cont chain
+    go k scope chain =
+      Foil.withFresh scope $ \binder ->
+        go (k - 1) (Foil.extendScope binder scope) (Foil.snocNameBinderList chain binder)
+
+-- | A term over the given names, of a size the caller controls.
+--
+-- The names are used in a left-nested application spine, repeated until the
+-- term has @uses@ leaves. Which names appear decides how far the chain can be
+-- thinned; how many leaves there are decides what a traversal of the term
+-- costs, and the two are what the benchmark varies.
+spine :: Int -> NonEmpty (Foil.Name l) -> Term l
+spine uses (first :| rest) = foldl' apply (Var first) (map Var more)
+  where
+    apply f x = Node (App f x)
+    more = take (max 0 (uses - 1)) (cycle (first : rest))
+
+-- * The two directions
+
+-- | Ask once: one 'supportOf', then one thinning.
+thinOnce :: Foil.Distinct l => Foil.NameBinderList Foil.VoidS l -> Term l -> Int
+thinOnce chain term =
+  Foil.withThinnedNameBinderList (supportOf term) chain $ \thinned ->
+    length (Foil.namesOfPattern thinned)
+
+-- | Ask per binder: peel the chain from the inside out, asking 'unsinkAST' at
+-- each binder whether the term can do without it, and abstracting over it when
+-- it cannot.
+--
+-- This is the shape the alternative really has, and the reason it costs what it
+-- costs: the term is /rebuilt/ as the peeling goes, so each 'unsinkAST' faces a
+-- different (and larger) term and has to compute its support afresh. Asking the
+-- same question about one fixed term would let the compiler share that
+-- computation, and then the two directions would be indistinguishable — which
+-- is what a first version of this benchmark measured, and why it is written out
+-- like this instead.
+askPerBinder
+  :: forall n l. Foil.Distinct n
+  => Foil.Scope n -> Foil.NameBinderList n l -> Term l -> Int
+askPerBinder scope binders term = fst (peel scope binders term)
+  where
+    peel :: forall m i. Foil.Distinct m
+         => Foil.Scope m -> Foil.NameBinderList m i -> Term i -> (Int, Term m)
+    peel _scope' Foil.NameBinderListEmpty inner = (0, inner)
+    peel scope' (Foil.NameBinderListCons binder rest) inner =
+      case (Foil.assertDistinct binder, Foil.assertExt binder) of
+        (Foil.Distinct, Foil.Ext) ->
+          let (kept, body) = peel (Foil.extendScope binder scope') rest inner
+           in case unsinkAST scope' body of
+                Just dropped -> (kept, dropped)
+                Nothing      -> (kept + 1, Node (Lam (ScopedAST binder body)))
+
+-- | Both directions, at one size, with the answers checked against each other.
+--
+-- @binders@ is how many the chain has, @keep@ how many of them the term names,
+-- and @uses@ how many leaves the term has.
+sizedBench :: Int -> Int -> Int -> Benchmark
+sizedBench binders keep uses =
+  withChain binders $ \chain ->
+    case nonEmpty (take keep (Foil.namesOfPattern chain)) of
+      Nothing -> error "a benchmark size must use at least one binder"
+      Just names ->
+        let term = spine uses names
+            once = thinOnce chain term
+            perBinder = askPerBinder Foil.emptyScope chain term
+         in if once /= perBinder
+              then error ("the two directions disagree: " <> show (once, perBinder))
+              else bgroup (show binders <> " binders, " <> show keep <> " used, "
+                            <> show uses <> " leaves")
+                     [ bench "thin once"      (whnf (thinOnce chain) term)
+                     , bench "ask per binder"
+                         (whnf (askPerBinder Foil.emptyScope chain) term)
+                     ]
+
+main :: IO ()
+main = defaultMain
+  -- The term is held at one size while the chain grows, so what separates the
+  -- two directions is the number of binders and nothing else.
+  [ bgroup "a fixed term, a growing parameter block"
+      [ sizedBench binders 2 64 | binders <- [1, 3, 7, 14, 32] ]
+  -- And the other way round: a fixed block, a growing term.
+  , bgroup "a fixed parameter block, a growing term"
+      [ sizedBench 8 2 uses | uses <- [16, 64, 256, 1024] ]
+  ]

--- a/haskell/free-foil/free-foil.cabal
+++ b/haskell/free-foil/free-foil.cabal
@@ -160,6 +160,29 @@ benchmark normalize
     , text >=1.2.3.1 && <2.2
   default-language: Haskell2010
 
+benchmark restriction
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Paths_free_foil
+  hs-source-dirs:
+      bench/restriction
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -optP-Wno-nonportable-include-path -O2 -rtsopts
+  build-depends:
+      array >=0.5.3.0 && <0.6
+    , base >=4.19 && <5
+    , bifunctors >=5.5 && <5.7
+    , binary >=0.8
+    , bytestring >=0.11
+    , containers >=0.6.8 && <0.9
+    , deepseq >=1.4 && <1.6
+    , free-foil
+    , kind-generics >=0.5.0 && <0.6
+    , tasty-bench
+    , template-haskell >=2.21.0.0 && <2.24
+    , text >=1.2.3.1 && <2.2
+  default-language: Haskell2010
+
 benchmark zipmatchk
   type: exitcode-stdio-1.0
   main-is: Main.hs

--- a/haskell/free-foil/package.yaml
+++ b/haskell/free-foil/package.yaml
@@ -93,3 +93,13 @@ benchmarks:
     dependencies:
       - free-foil
       - tasty-bench
+
+  restriction:
+    main: Main.hs
+    source-dirs: bench/restriction
+    ghc-options:
+      - -O2
+      - -rtsopts
+    dependencies:
+      - free-foil
+      - tasty-bench


### PR DESCRIPTION
he telescope's haddock claims thinning a chain of binders down to a term's support costs one traversal of the term, where asking `unsinkAST` at each binder costs one per binder. It was unmeasured, so here it is.

A term of 64 leaves using 2 binders, with the block growing:

| binders | thin once | ask per binder | ratio |
|---|---|---|---|
| 1  | 866 ns  | 831 ns  | 1.0× |
| 3  | 901 ns  | 2.56 µs | 2.8× |
| 7  | 923 ns  | 5.93 µs | 6.4× |
| 14 | 969 ns  | 11.8 µs | 12×  |
| 32 | 1.08 µs | 27.5 µs | 25×  |

Thinning is flat in the number of binders; the alternative is linear in it. A parameter block of three is the common case and one of fourteen is not unheard of, so the ratio that matters in practice is between 2.8× and 12×.

Growing the term instead, over 8 binders: 309 ns / 1.79 µs at 16 leaves, 17.8 µs / 142 µs at 1024. Both linear in the term, so the ratio stays near the number of binders.

Both directions answer the same question, and the benchmark checks they agree before it times either.

**One trap, recorded in the module because it cost me a first version.** Asking the question about one *fixed* term at a series of scopes makes the two indistinguishable — the `supportOf` is loop-invariant and GHC floats it out of the loop. The real alternative rebuilds the term as it peels, so each call faces a different and larger term and nothing can be shared. The benchmark does that. A benchmark of "n times the same query" measures the compiler, not the algorithm.