### PR TITLE
MLTT: let a telescope include a telescope

### DIFF
--- a/haskell/mltt/README.md
+++ b/haskell/mltt/README.md
@@ -230,6 +230,13 @@ A` above resolves only because `A` came from `Monoid`. Everything downstream is
 unchanged, so `undo` is discharged over `(A, mul, inv)` exactly as if the three
 had been written out.
 
+A telescope may itself include telescopes, so a theory can extend a poorer one:
+`telescope Monoid include Semigroup (unit : A) …` is the monoid block built on
+the semigroup block, and `examples/theories.mltt` runs the hierarchy Semigroup,
+Monoid, CommMonoid, Group in the manner of Pollack's records and Sterling's
+Pterodactyl. Telescope includes are expanded first, in dependency order over
+the declared telescopes, and a cycle is reported by name.
+
 An include is resolved before the module is checked, so what reaches the checker
 is an ordinary parametrised module. That is also what makes an include behave
 like an import for the cache: a module's content hash is taken over its resolved

--- a/haskell/mltt/examples/theories.mltt
+++ b/haskell/mltt/examples/theories.mltt
@@ -3,17 +3,23 @@
 --
 -- This is the demo the module layer was built for. A theory is a named
 -- telescope: its fields are a carrier, the operations on it, and the laws they
--- satisfy, all in one dependent block. A module includes the theory to work in
--- it, and every declaration leaves that module discharged over the fields it
--- used. An instance is a module that fixes those fields to values, so using a
--- theory's lemma at an instance is application. There is no `interpretation`
--- command here, and nothing for one to do.
+-- satisfy, all in one dependent block. A richer theory includes a poorer one,
+-- so the hierarchy below runs Semigroup, Monoid, CommMonoid, Group, in the
+-- manner of Pollack's dependent records and Sterling's Pterodactyl. A module
+-- includes a theory to work in it, and every declaration leaves that module
+-- discharged over the fields it used. An instance is a module that fixes those
+-- fields to values, so using a theory's lemma at an instance is application.
+-- There is no `interpretation` command here, and nothing for one to do.
 
-telescope Monoid
+telescope Semigroup
   (A : 𝕌)
-  (unit : A)
   (mul : A → A → A)
   (assoc : Π (x : A) → Π (y : A) → Π (z : A) → Id(A, mul (mul x y) z, mul x (mul y z)))
+
+-- A monoid is a semigroup with a unit and its laws: the include puts the
+-- semigroup's fields first, and the unit's types may mention them.
+telescope Monoid include Semigroup
+  (unit : A)
   (unitL : Π (x : A) → Id(A, mul unit x, x))
   (unitR : Π (x : A) → Id(A, mul x unit, x))
 
@@ -34,32 +40,28 @@ def squareAssoc over (A, mul, assoc)
   := λ x ⇒ assoc x x x
 
 -- A different set of fields again: the unit and its law, and not associativity.
-def unitSquare over (A, unit, mul, unitL)
+def unitSquare over (A, mul, unit, unitL)
   : Π (x : A) → Id(A, mul unit (square x), square x)
   := λ x ⇒ unitL (square x)
 
 -- * Theories on top of theories
 
--- A module that includes a theory may declare fields of its own after it, and
--- their types may mention what was included, which is how one works in a richer
--- theory than the one that was declared.
---
--- Note what this is not. Pollack builds a monoid by joining a semigroup with a
--- unit and its laws, and Sterling's hierarchy runs Magma, Semigroup, Monoid,
--- Group; each step is a theory, and can be included in turn. Here only a module
--- may include, so `CommMonoid` and `Group` below are modules working in an
--- extended block, not theories a third module could include. A telescope that
--- includes a telescope is the obvious next step.
-module CommMonoid include Monoid
+-- Each of these is a theory in its own right, built on Monoid by inclusion,
+-- and can itself be included by a further telescope or worked in by a module.
+telescope CommMonoid include Monoid
   (comm : Π (x : A) → Π (y : A) → Id(A, mul x y, mul y x))
-def unitFlip over (A, unit, mul, comm)
+
+telescope Group include Monoid
+  (inv : A → A)
+  (invL : Π (x : A) → Id(A, mul (inv x) x, unit))
+
+module CommMonoidTheory include CommMonoid
+def unitFlip over (A, mul, unit, comm)
   : Π (x : A) → Id(A, mul unit x, mul x unit)
   := λ x ⇒ comm unit x
 
-module Group include Monoid
-  (inv : A → A)
-  (invL : Π (x : A) → Id(A, mul (inv x) x, unit))
-def cancelSquare over (A, unit, mul, inv, invL)
+module GroupTheory include Group
+def cancelSquare over (A, mul, unit, inv, invL)
   : Π (x : A) → Id(A, mul (inv (mul x x)) (mul x x), unit)
   := λ x ⇒ invL (mul x x)
 
@@ -112,14 +114,14 @@ def fourth over (mul) : Nat → Nat := λ x ⇒ mul (mul x x) (mul x x)
 -- decided by the structure its module fixed, and neither takes an argument for
 -- it.
 module NatAdd
-  include Monoid / {A := Nat, unit := zero, mul := plus,
-                    assoc := plusAssoc, unitL := plusUnitL, unitR := plusUnitR}
+  include Monoid / {A := Nat, mul := plus, assoc := plusAssoc,
+                    unit := zero, unitL := plusUnitL, unitR := plusUnitR}
 import Church
 def double : Nat → Nat := λ x ⇒ mul x x
 
 module NatMul
-  include Monoid / {A := Nat, unit := one, mul := times,
-                    assoc := timesAssoc, unitL := timesUnitL, unitR := timesUnitR}
+  include Monoid / {A := Nat, mul := times, assoc := timesAssoc,
+                    unit := one, unitL := timesUnitL, unitR := timesUnitR}
 import Church
 def sq : Nat → Nat := λ x ⇒ mul x x
 
@@ -151,5 +153,5 @@ check squareAssoc Nat times timesAssoc
   : Π (x : Nat) → Id(Nat, times (times x x) x, times x (times x x))
 
 -- And one over a different set of fields again.
-check unitSquare Nat zero plus plusUnitL
+check unitSquare Nat plus zero plusUnitL
   : Π (x : Nat) → Id(Nat, plus zero (plus x x), plus x x)

--- a/haskell/mltt/grammar/MLTT/Syntax.cf
+++ b/haskell/mltt/grammar/MLTT/Syntax.cf
@@ -62,7 +62,11 @@ separator Fixed "," ;
 -- A telescope declaration names a block of parameters and binds nothing else.
 -- It is a unit of its own rather than a declaration inside a module, since
 -- what it names is a module header and not a term.
-ATelescope. TelescopeDecl ::= "telescope" VarIdent [Param] ";" ;
+--
+-- A telescope may itself include telescopes, so a theory can extend a poorer
+-- theory: `telescope Monoid include Semigroup (unit : A) ...`. Includes are
+-- expanded before any module's, in dependency order, and a cycle is an error.
+ATelescope. TelescopeDecl ::= "telescope" VarIdent [Include] [Param] ";" ;
 
 -- A parameter is either bound, given a type, or /manifest/, given a value. A
 -- manifest field is an abbreviation and not a variable: it is not discharged

--- a/haskell/mltt/src/Language/MLTT/Impl.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl.hs
@@ -286,29 +286,65 @@ type Telescopes = Map Raw.VarIdent [Raw.Param]
 -- module's own parameters follow. A telescope may be included by any number of
 -- modules and is elaborated afresh in each, which is what keeps the elaboration
 -- canonical: nothing is shared between two modules but the source.
+--
+-- A telescope may itself include telescopes, so a theory can extend a poorer
+-- theory: @telescope Monoid include Semigroup (unit : A) …@ is the monoid
+-- block built on the semigroup one. Telescope includes are expanded first, in
+-- dependency order over the declared telescopes with a cycle reported by name
+-- — the same shape as the build order over modules — so by the time a module
+-- includes a telescope, the telescope is a plain parameter list. A refined
+-- include composes unchanged, since refining a parameter list yields a
+-- parameter list.
 resolveUnits :: [Raw.Unit] -> Either BuildError [Raw.Module]
 resolveUnits units
   | (dup : _) <- duplicates = Left ("telescope declared twice: " <> prettyVarIdent dup)
-  | otherwise = traverse expandIncludes modules
+  | otherwise = do
+      telescopes <- foldM expandDeclared Map.empty (Map.keys rawTelescopes)
+      traverse (expandIncludes telescopes) modules
   where
     declared = [t | Raw.UnitTelescope _ t <- units]
     modules  = [m | Raw.UnitModule _ m <- units]
 
-    telescopes :: Telescopes
-    telescopes = Map.fromList [(name, params) | Raw.ATelescope _ name params <- declared]
+    rawTelescopes :: Map Raw.VarIdent ([Raw.Include], [Raw.Param])
+    rawTelescopes = Map.fromList
+      [(name, (incs, params)) | Raw.ATelescope _ name incs params <- declared]
 
     duplicates =
-      [name | name : _ : _ <- group (sort [name | Raw.ATelescope _ name _ <- declared])]
+      [name | name : _ : _ <- group (sort [name | Raw.ATelescope _ name _ _ <- declared])]
 
-    expandIncludes (Raw.AModule loc name includes params imports decls) = do
-      included <- concat <$> traverse include includes
+    -- Expand one declared telescope into the memo, dependencies first. The
+    -- path carries the includes being expanded, outermost last, so a cycle is
+    -- reported in the order it is entered.
+    expandDeclared done name = fst <$> expandTelescope [] done name
+
+    expandTelescope path done name
+      | name `elem` path =
+          Left ("telescopes include each other in a cycle: "
+                 <> intercalate " -> "
+                      (map prettyVarIdent (reverse (name : path))))
+      | Just params <- Map.lookup name done = Right (done, params)
+      | Just (incs, params) <- Map.lookup name rawTelescopes = do
+          (done', included) <- foldM (includeInto (name : path)) (done, []) incs
+          let expanded = included <> params
+          return (Map.insert name expanded done', expanded)
+      | otherwise =
+          Left ("no telescope named " <> prettyVarIdent name <> " is declared")
+
+    includeInto path (done, acc) (Raw.AnInclude _loc name refinement) = do
+      (done', params) <- expandTelescope path done name
+      fixed <- refinementOf name params refinement
+      return (done', acc <> map (fixParam fixed) params)
+
+    expandIncludes telescopes (Raw.AModule loc name includes params imports decls) = do
+      included <- concat <$> traverse (include telescopes) includes
       return (Raw.AModule loc name [] (included <> params) imports decls)
 
-    include (Raw.AnInclude _loc name refinement) = case Map.lookup name telescopes of
-      Nothing -> Left ("no telescope named " <> prettyVarIdent name <> " is declared")
-      Just params -> do
-        fixed <- refinementOf name params refinement
-        return (map (fixParam fixed) params)
+    include telescopes (Raw.AnInclude _loc name refinement) =
+      case Map.lookup name telescopes of
+        Nothing -> Left ("no telescope named " <> prettyVarIdent name <> " is declared")
+        Just params -> do
+          fixed <- refinementOf name params refinement
+          return (map (fixParam fixed) params)
 
     -- A refined field keeps its place in the telescope and becomes manifest,
     -- so the residual is the same block with fewer variables in it.

--- a/haskell/mltt/src/Language/MLTT/Syntax/Abs.hs
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Abs.hs
@@ -50,7 +50,8 @@ data Fixed' a = AFixed a VarIdent (Term' a)
   deriving (C.Eq, C.Ord, C.Show, C.Read, C.Functor, C.Foldable, C.Traversable, C.Data, C.Typeable, C.Generic)
 
 type TelescopeDecl = TelescopeDecl' BNFC'Position
-data TelescopeDecl' a = ATelescope a VarIdent [Param' a]
+data TelescopeDecl' a
+    = ATelescope a VarIdent [Include' a] [Param' a]
   deriving (C.Eq, C.Ord, C.Show, C.Read, C.Functor, C.Foldable, C.Traversable, C.Data, C.Typeable, C.Generic)
 
 type Param = Param' BNFC'Position
@@ -156,7 +157,7 @@ instance HasPosition Fixed where
 
 instance HasPosition TelescopeDecl where
   hasPosition = \case
-    ATelescope p _ _ -> p
+    ATelescope p _ _ _ -> p
 
 instance HasPosition Param where
   hasPosition = \case

--- a/haskell/mltt/src/Language/MLTT/Syntax/Doc.txt
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Doc.txt
@@ -58,7 +58,7 @@ All other symbols are terminals.
   | //[Fixed]// | -> | **eps**
   |  |  **|**  | //Fixed//
   |  |  **|**  | //Fixed// ``,`` //[Fixed]//
-  | //TelescopeDecl// | -> | ``telescope`` //VarIdent// //[Param]// ``;``
+  | //TelescopeDecl// | -> | ``telescope`` //VarIdent// //[Include]// //[Param]// ``;``
   | //Param// | -> | ``(`` //VarIdent// ``:`` //Term// ``)``
   |  |  **|**  | ``(`` //VarIdent// ``:`` //Term// ``:=`` //Term// ``)``
   | //[Param]// | -> | **eps**

--- a/haskell/mltt/src/Language/MLTT/Syntax/Par.hs
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Par.hs
@@ -292,7 +292,8 @@ action_0,
  action_207,
  action_208,
  action_209,
- action_210 :: () => Prelude.Int -> ({-HappyReduction (Err) = -}
+ action_210,
+ action_211 :: () => Prelude.Int -> ({-HappyReduction (Err) = -}
 	   Prelude.Int 
 	-> (Token)
 	-> HappyState (Token) (HappyStk HappyAbsSyn -> [(Token)] -> (Err) HappyAbsSyn)
@@ -371,7 +372,7 @@ happyReduce_23,
 	-> [(Token)] -> (Err) HappyAbsSyn)
 
 happyExpList :: Happy_Data_Array.Array Prelude.Int Prelude.Int
-happyExpList = Happy_Data_Array.listArray (0,431) ([0,0,0,0,520,0,0,0,0,8192,8,0,0,0,0,8320,0,0,0,0,0,2,0,0,0,0,512,0,0,0,0,0,8,0,0,0,0,1,0,0,0,0,0,0,16384,0,0,0,0,0,256,0,0,0,0,8,0,0,0,32,0,0,0,0,32768,0,0,0,0,0,0,128,0,0,0,0,0,2,0,0,0,0,1792,11,0,0,0,0,11292,0,0,0,0,0,64,0,0,0,0,0,0,4,0,0,24608,20544,7416,0,0,32768,384,320,115,0,0,512,6,52229,1,0,0,6152,5136,1854,0,0,8192,128,0,16,0,0,0,0,16384,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32768,512,0,64,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32896,16385,30481,0,0,0,0,0,0,0,0,0,0,0,0,0,0,24608,20544,7416,0,0,32768,0,0,0,0,0,512,0,0,0,0,0,8200,0,1024,0,0,8192,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,2048,0,0,0,0,0,32800,0,4096,0,0,32768,384,320,115,0,0,512,6,52229,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1538,1280,460,0,0,0,0,0,0,0,0,128,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8,0,0,0,0,0,8,0,0,0,0,0,0,0,0,0,0,1538,34052,463,0,0,2048,4120,15892,7,0,0,0,0,4096,0,0,0,0,0,64,0,0,0,0,0,1,0,0,0,1,0,0,0,0,0,0,0,0,0,8192,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,32768,0,0,0,0,0,0,0,0,0,0,0,0,0,1024,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,256,0,0,0,1,0,0,0,0,128,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,256,0,0,0,0,128,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8192,8,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,256,0,0,0,0,0,4,0,0,24608,20544,7416,0,0,32768,0,0,0,0,0,8192,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32,0,0,0,0,0,0,256,0,0,0,0,0,0,0,0,0,32768,0,0,0,0,0,16,0,0,0,0,0,0,0,0,0,128,0,0,0,0,0,1792,11,0,0,0,0,0,16384,0,0,0,0,0,256,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8192,0,0,0,8200,0,1024,0,0,8192,128,0,16,0,0,32896,16641,29665,0,0,0,256,0,0,0,0,2048,4120,15892,7,0,0,24608,20544,7416,0,0,0,11,0,0,0,0,512,1030,53125,1,0,0,6152,5136,1854,0,0,32768,0,0,0,0,0,128,2,16384,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32768,384,57665,115,0,0,512,1030,53125,1,0,0,32,0,0,0,0,32768,0,0,0,0,0,32896,16641,29665,0,0,0,4,0,0,0,0,32768,0,0,0,0,0,512,0,0,0,0,32768,384,57665,115,0,0,0,0,0,0,0,0,16,0,0,0,0,0,0,0,0,0,0,32896,16641,29665,0,0,0,32,0,0,0,0,0,0,64,0,0,0,0,1024,0,0,0,0,0,0,0,0,0,512,1030,53125,1,0,0,512,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8192,0,0,0,0,0,0,0,0,0,32,0,0,0,0,0,32,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,16384,4,0,0,0,0,2048,0,0,0,0,0,28672,176,0,0,0,2048,4120,15892,7,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,6152,5136,1854,0,0,8192,16480,63568,28,0,0,0,0,0,0,0,0,0,1,0,0,0,2048,4120,15892,7,0,0,24608,20544,7416,0,0,0,1,0,0,0,0,1024,0,0,0,0,0,16,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8192,0,0,0,0,0,128,0,0,0,0,32768,384,57665,115,0,0,1024,0,0,0,0,0,16,0,0,0,0,0,4,0,0,0,0,0,0,8,0,0,0,1538,34052,463,0,0,0,0,0,0,0,0,24608,20544,7416,0,0,0,8192,0,0,0,0,0,45168,0,0,0,0,16,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,1538,34052,463,0,0,0,0,256,0,0,0,0,0,256,0,0,0,0,0,0,0,0,512,1030,53125,1,0,0,6152,5136,1854,0,0,16384,0,0,0,0,0,256,0,0,0,0,0,1538,34052,463,0,0,2048,4120,15892,7,0,0,0,0,0,0,0,32768,384,57665,115,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+happyExpList = Happy_Data_Array.listArray (0,432) ([0,0,0,0,520,0,0,0,0,8192,8,0,0,0,0,8320,0,0,0,0,0,2,0,0,0,0,512,0,0,0,0,0,8,0,0,0,0,1,0,0,0,0,0,0,16384,0,0,0,0,0,256,0,0,0,0,8,0,0,0,32,0,0,0,0,32768,0,0,0,0,0,0,128,0,0,0,0,0,2,0,0,0,0,1792,11,0,0,0,0,11292,0,0,0,0,0,64,0,0,0,0,0,0,4,0,0,24608,20544,7416,0,0,32768,384,320,115,0,0,512,6,52229,1,0,0,6152,5136,1854,0,0,8192,128,0,16,0,0,0,0,16384,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32768,512,0,64,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32896,16385,30481,0,0,0,0,0,0,0,0,0,0,0,0,0,0,24608,20544,7416,0,0,32768,0,0,0,0,0,512,0,0,0,0,0,8200,0,1024,0,0,8192,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,2048,0,0,0,0,0,32800,0,4096,0,0,32768,384,320,115,0,0,512,6,52229,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1538,1280,460,0,0,0,0,0,0,0,0,128,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8,0,0,0,0,0,8,0,0,0,0,0,0,0,0,0,0,1538,34052,463,0,0,2048,4120,15892,7,0,0,0,0,4096,0,0,0,0,0,64,0,0,0,0,0,1,0,0,0,1,0,0,0,0,0,0,0,0,0,8192,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,32768,0,0,0,0,0,0,0,0,0,0,0,0,0,1024,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,256,0,0,0,1,0,0,0,0,128,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,256,0,0,0,0,128,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8192,8,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,256,0,0,0,0,0,4,0,0,24608,20544,7416,0,0,0,32768,0,0,0,0,8192,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32,0,0,0,0,0,0,256,0,0,0,0,0,0,0,0,0,32768,0,0,0,0,0,16,0,0,0,0,0,0,0,0,0,128,0,0,0,0,0,1792,11,0,0,0,0,0,16384,0,0,0,0,0,256,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8192,0,0,0,8200,0,1024,0,0,8192,128,0,16,0,0,32896,16641,29665,0,0,0,256,0,0,0,0,2048,4120,15892,7,0,0,24608,20544,7416,0,0,0,11,0,0,0,0,512,1030,53125,1,0,0,6152,5136,1854,0,0,32768,0,0,0,0,0,128,2,16384,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32768,384,57665,115,0,0,512,1030,53125,1,0,0,32,0,0,0,0,32768,0,0,0,0,0,32896,16641,29665,0,0,0,4,0,0,0,0,32768,0,0,0,0,0,512,0,0,0,0,32768,384,57665,115,0,0,0,0,0,0,0,0,16,0,0,0,0,0,0,0,0,0,0,32896,16641,29665,0,0,0,32,0,0,0,0,0,0,64,0,0,0,0,1024,0,0,0,0,0,0,0,0,0,512,1030,53125,1,0,0,8,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8192,0,0,0,0,0,0,0,0,0,32,0,0,0,0,0,32,0,0,0,0,0,0,0,0,0,0,512,0,0,0,0,16384,4,0,0,0,0,2048,0,0,0,0,0,28672,176,0,0,0,2048,4120,15892,7,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,6152,5136,1854,0,0,8192,16480,63568,28,0,0,0,0,0,0,0,0,0,1,0,0,0,2048,4120,15892,7,0,0,24608,20544,7416,0,0,0,1,0,0,0,0,1024,0,0,0,0,0,16,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8192,0,0,0,0,0,128,0,0,0,0,32768,384,57665,115,0,0,1024,0,0,0,0,0,16,0,0,0,0,0,4,0,0,0,0,0,0,8,0,0,0,1538,34052,463,0,0,0,0,0,0,0,0,24608,20544,7416,0,0,0,0,0,0,0,0,0,128,0,0,0,0,49152,705,0,0,0,16384,0,0,0,0,0,4096,0,0,0,0,0,0,0,0,0,0,2048,4120,15892,7,0,0,0,0,4,0,0,0,0,0,4,0,0,0,0,0,0,0,0,6152,5136,1854,0,0,8192,16480,63568,28,0,0,256,0,0,0,0,0,4,0,0,0,0,2048,4120,15892,7,0,0,24608,20544,7416,0,0,0,0,0,0,0,0,512,1030,53125,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 	])
 
 {-# NOINLINE happyExpListPerState #-}
@@ -933,10 +934,10 @@ action_98 (46) = happyGoto action_31
 action_98 (47) = happyGoto action_32
 action_98 _ = happyFail (happyExpListPerState 98)
 
-action_99 (50) = happyShift action_69
-action_99 (37) = happyGoto action_67
-action_99 (38) = happyGoto action_149
-action_99 _ = happyReduce_42
+action_99 (66) = happyShift action_81
+action_99 (31) = happyGoto action_79
+action_99 (32) = happyGoto action_149
+action_99 _ = happyReduce_31
 
 action_100 (54) = happyShift action_148
 action_100 _ = happyFail (happyExpListPerState 100)
@@ -1290,8 +1291,10 @@ action_148 (46) = happyGoto action_31
 action_148 (47) = happyGoto action_32
 action_148 _ = happyFail (happyExpListPerState 148)
 
-action_149 (56) = happyShift action_157
-action_149 _ = happyFail (happyExpListPerState 149)
+action_149 (50) = happyShift action_69
+action_149 (37) = happyGoto action_67
+action_149 (38) = happyGoto action_157
+action_149 _ = happyReduce_42
 
 action_150 _ = happyReduce_35
 
@@ -1307,12 +1310,13 @@ action_154 (37) = happyGoto action_67
 action_154 (38) = happyGoto action_155
 action_154 _ = happyReduce_42
 
-action_155 (56) = happyShift action_187
+action_155 (56) = happyShift action_188
 action_155 _ = happyFail (happyExpListPerState 155)
 
 action_156 _ = happyReduce_34
 
-action_157 _ = happyReduce_39
+action_157 (56) = happyShift action_187
+action_157 _ = happyFail (happyExpListPerState 157)
 
 action_158 (51) = happyShift action_185
 action_158 (55) = happyShift action_186
@@ -1457,10 +1461,10 @@ action_175 _ = happyReduce_79
 
 action_176 _ = happyReduce_80
 
-action_177 (52) = happyShift action_197
+action_177 (52) = happyShift action_198
 action_177 _ = happyFail (happyExpListPerState 177)
 
-action_178 (52) = happyShift action_196
+action_178 (52) = happyShift action_197
 action_178 _ = happyFail (happyExpListPerState 178)
 
 action_179 (50) = happyShift action_34
@@ -1481,19 +1485,19 @@ action_179 (26) = happyGoto action_29
 action_179 (45) = happyGoto action_30
 action_179 (46) = happyGoto action_31
 action_179 (47) = happyGoto action_32
-action_179 (48) = happyGoto action_195
+action_179 (48) = happyGoto action_196
 action_179 _ = happyFail (happyExpListPerState 179)
 
-action_180 (51) = happyShift action_194
+action_180 (51) = happyShift action_195
 action_180 _ = happyFail (happyExpListPerState 180)
 
-action_181 (51) = happyShift action_193
+action_181 (51) = happyShift action_194
 action_181 _ = happyFail (happyExpListPerState 181)
 
-action_182 (55) = happyShift action_192
+action_182 (55) = happyShift action_193
 action_182 _ = happyFail (happyExpListPerState 182)
 
-action_183 (78) = happyShift action_191
+action_183 (78) = happyShift action_192
 action_183 _ = happyFail (happyExpListPerState 183)
 
 action_184 (50) = happyShift action_34
@@ -1511,7 +1515,7 @@ action_184 (87) = happyShift action_45
 action_184 (88) = happyShift action_46
 action_184 (89) = happyShift action_24
 action_184 (26) = happyGoto action_29
-action_184 (45) = happyGoto action_190
+action_184 (45) = happyGoto action_191
 action_184 (46) = happyGoto action_31
 action_184 (47) = happyGoto action_32
 action_184 _ = happyFail (happyExpListPerState 184)
@@ -1533,81 +1537,63 @@ action_186 (87) = happyShift action_45
 action_186 (88) = happyShift action_46
 action_186 (89) = happyShift action_24
 action_186 (26) = happyGoto action_29
-action_186 (45) = happyGoto action_189
+action_186 (45) = happyGoto action_190
 action_186 (46) = happyGoto action_31
 action_186 (47) = happyGoto action_32
 action_186 _ = happyFail (happyExpListPerState 186)
 
-action_187 (64) = happyShift action_65
-action_187 (39) = happyGoto action_63
-action_187 (40) = happyGoto action_188
-action_187 _ = happyReduce_45
+action_187 _ = happyReduce_39
 
-action_188 (61) = happyShift action_56
-action_188 (62) = happyShift action_57
-action_188 (63) = happyShift action_58
-action_188 (69) = happyShift action_59
-action_188 (70) = happyShift action_60
-action_188 (72) = happyShift action_61
-action_188 (41) = happyGoto action_54
-action_188 (42) = happyGoto action_205
-action_188 _ = happyReduce_53
+action_188 (64) = happyShift action_65
+action_188 (39) = happyGoto action_63
+action_188 (40) = happyGoto action_189
+action_188 _ = happyReduce_45
 
-action_189 (51) = happyShift action_204
-action_189 _ = happyFail (happyExpListPerState 189)
+action_189 (61) = happyShift action_56
+action_189 (62) = happyShift action_57
+action_189 (63) = happyShift action_58
+action_189 (69) = happyShift action_59
+action_189 (70) = happyShift action_60
+action_189 (72) = happyShift action_61
+action_189 (41) = happyGoto action_54
+action_189 (42) = happyGoto action_206
+action_189 _ = happyReduce_53
 
-action_190 (55) = happyShift action_203
+action_190 (51) = happyShift action_205
 action_190 _ = happyFail (happyExpListPerState 190)
 
-action_191 _ = happyReduce_49
+action_191 (55) = happyShift action_204
+action_191 _ = happyFail (happyExpListPerState 191)
 
-action_192 (50) = happyShift action_34
-action_192 (58) = happyShift action_35
-action_192 (59) = happyShift action_36
-action_192 (67) = happyShift action_37
-action_192 (73) = happyShift action_38
-action_192 (75) = happyShift action_39
-action_192 (80) = happyShift action_40
-action_192 (81) = happyShift action_41
-action_192 (82) = happyShift action_42
-action_192 (83) = happyShift action_43
-action_192 (84) = happyShift action_44
-action_192 (87) = happyShift action_45
-action_192 (88) = happyShift action_46
-action_192 (89) = happyShift action_24
-action_192 (26) = happyGoto action_29
-action_192 (45) = happyGoto action_202
-action_192 (46) = happyGoto action_31
-action_192 (47) = happyGoto action_32
-action_192 _ = happyFail (happyExpListPerState 192)
+action_192 _ = happyReduce_49
 
-action_193 (79) = happyShift action_201
+action_193 (50) = happyShift action_34
+action_193 (58) = happyShift action_35
+action_193 (59) = happyShift action_36
+action_193 (67) = happyShift action_37
+action_193 (73) = happyShift action_38
+action_193 (75) = happyShift action_39
+action_193 (80) = happyShift action_40
+action_193 (81) = happyShift action_41
+action_193 (82) = happyShift action_42
+action_193 (83) = happyShift action_43
+action_193 (84) = happyShift action_44
+action_193 (87) = happyShift action_45
+action_193 (88) = happyShift action_46
+action_193 (89) = happyShift action_24
+action_193 (26) = happyGoto action_29
+action_193 (45) = happyGoto action_203
+action_193 (46) = happyGoto action_31
+action_193 (47) = happyGoto action_32
 action_193 _ = happyFail (happyExpListPerState 193)
 
-action_194 (85) = happyShift action_200
+action_194 (79) = happyShift action_202
 action_194 _ = happyFail (happyExpListPerState 194)
 
-action_195 _ = happyReduce_64
+action_195 (85) = happyShift action_201
+action_195 _ = happyFail (happyExpListPerState 195)
 
-action_196 (50) = happyShift action_34
-action_196 (58) = happyShift action_35
-action_196 (59) = happyShift action_36
-action_196 (67) = happyShift action_37
-action_196 (73) = happyShift action_38
-action_196 (75) = happyShift action_39
-action_196 (80) = happyShift action_40
-action_196 (81) = happyShift action_41
-action_196 (82) = happyShift action_42
-action_196 (83) = happyShift action_43
-action_196 (84) = happyShift action_44
-action_196 (87) = happyShift action_45
-action_196 (88) = happyShift action_46
-action_196 (89) = happyShift action_24
-action_196 (26) = happyGoto action_29
-action_196 (45) = happyGoto action_199
-action_196 (46) = happyGoto action_31
-action_196 (47) = happyGoto action_32
-action_196 _ = happyFail (happyExpListPerState 196)
+action_196 _ = happyReduce_64
 
 action_197 (50) = happyShift action_34
 action_197 (58) = happyShift action_35
@@ -1624,36 +1610,35 @@ action_197 (87) = happyShift action_45
 action_197 (88) = happyShift action_46
 action_197 (89) = happyShift action_24
 action_197 (26) = happyGoto action_29
-action_197 (45) = happyGoto action_198
+action_197 (45) = happyGoto action_200
 action_197 (46) = happyGoto action_31
 action_197 (47) = happyGoto action_32
 action_197 _ = happyFail (happyExpListPerState 197)
 
-action_198 (51) = happyShift action_210
+action_198 (50) = happyShift action_34
+action_198 (58) = happyShift action_35
+action_198 (59) = happyShift action_36
+action_198 (67) = happyShift action_37
+action_198 (73) = happyShift action_38
+action_198 (75) = happyShift action_39
+action_198 (80) = happyShift action_40
+action_198 (81) = happyShift action_41
+action_198 (82) = happyShift action_42
+action_198 (83) = happyShift action_43
+action_198 (84) = happyShift action_44
+action_198 (87) = happyShift action_45
+action_198 (88) = happyShift action_46
+action_198 (89) = happyShift action_24
+action_198 (26) = happyGoto action_29
+action_198 (45) = happyGoto action_199
+action_198 (46) = happyGoto action_31
+action_198 (47) = happyGoto action_32
 action_198 _ = happyFail (happyExpListPerState 198)
 
-action_199 (51) = happyShift action_209
+action_199 (51) = happyShift action_211
 action_199 _ = happyFail (happyExpListPerState 199)
 
-action_200 (50) = happyShift action_34
-action_200 (58) = happyShift action_35
-action_200 (59) = happyShift action_36
-action_200 (67) = happyShift action_37
-action_200 (73) = happyShift action_38
-action_200 (75) = happyShift action_39
-action_200 (80) = happyShift action_40
-action_200 (81) = happyShift action_41
-action_200 (82) = happyShift action_42
-action_200 (83) = happyShift action_43
-action_200 (84) = happyShift action_44
-action_200 (87) = happyShift action_45
-action_200 (88) = happyShift action_46
-action_200 (89) = happyShift action_24
-action_200 (26) = happyGoto action_29
-action_200 (45) = happyGoto action_30
-action_200 (46) = happyGoto action_31
-action_200 (47) = happyGoto action_32
-action_200 (48) = happyGoto action_208
+action_200 (51) = happyShift action_210
 action_200 _ = happyFail (happyExpListPerState 200)
 
 action_201 (50) = happyShift action_34
@@ -1674,44 +1659,65 @@ action_201 (26) = happyGoto action_29
 action_201 (45) = happyGoto action_30
 action_201 (46) = happyGoto action_31
 action_201 (47) = happyGoto action_32
-action_201 (48) = happyGoto action_207
+action_201 (48) = happyGoto action_209
 action_201 _ = happyFail (happyExpListPerState 201)
 
-action_202 _ = happyReduce_47
+action_202 (50) = happyShift action_34
+action_202 (58) = happyShift action_35
+action_202 (59) = happyShift action_36
+action_202 (67) = happyShift action_37
+action_202 (73) = happyShift action_38
+action_202 (75) = happyShift action_39
+action_202 (80) = happyShift action_40
+action_202 (81) = happyShift action_41
+action_202 (82) = happyShift action_42
+action_202 (83) = happyShift action_43
+action_202 (84) = happyShift action_44
+action_202 (87) = happyShift action_45
+action_202 (88) = happyShift action_46
+action_202 (89) = happyShift action_24
+action_202 (26) = happyGoto action_29
+action_202 (45) = happyGoto action_30
+action_202 (46) = happyGoto action_31
+action_202 (47) = happyGoto action_32
+action_202 (48) = happyGoto action_208
+action_202 _ = happyFail (happyExpListPerState 202)
 
-action_203 (50) = happyShift action_34
-action_203 (58) = happyShift action_35
-action_203 (59) = happyShift action_36
-action_203 (67) = happyShift action_37
-action_203 (73) = happyShift action_38
-action_203 (75) = happyShift action_39
-action_203 (80) = happyShift action_40
-action_203 (81) = happyShift action_41
-action_203 (82) = happyShift action_42
-action_203 (83) = happyShift action_43
-action_203 (84) = happyShift action_44
-action_203 (87) = happyShift action_45
-action_203 (88) = happyShift action_46
-action_203 (89) = happyShift action_24
-action_203 (26) = happyGoto action_29
-action_203 (45) = happyGoto action_206
-action_203 (46) = happyGoto action_31
-action_203 (47) = happyGoto action_32
-action_203 _ = happyFail (happyExpListPerState 203)
+action_203 _ = happyReduce_47
 
-action_204 _ = happyReduce_41
+action_204 (50) = happyShift action_34
+action_204 (58) = happyShift action_35
+action_204 (59) = happyShift action_36
+action_204 (67) = happyShift action_37
+action_204 (73) = happyShift action_38
+action_204 (75) = happyShift action_39
+action_204 (80) = happyShift action_40
+action_204 (81) = happyShift action_41
+action_204 (82) = happyShift action_42
+action_204 (83) = happyShift action_43
+action_204 (84) = happyShift action_44
+action_204 (87) = happyShift action_45
+action_204 (88) = happyShift action_46
+action_204 (89) = happyShift action_24
+action_204 (26) = happyGoto action_29
+action_204 (45) = happyGoto action_207
+action_204 (46) = happyGoto action_31
+action_204 (47) = happyGoto action_32
+action_204 _ = happyFail (happyExpListPerState 204)
 
-action_205 _ = happyReduce_29
+action_205 _ = happyReduce_41
 
-action_206 _ = happyReduce_48
+action_206 _ = happyReduce_29
 
-action_207 _ = happyReduce_62
+action_207 _ = happyReduce_48
 
-action_208 _ = happyReduce_61
+action_208 _ = happyReduce_62
 
-action_209 _ = happyReduce_78
+action_209 _ = happyReduce_61
 
-action_210 _ = happyReduce_76
+action_210 _ = happyReduce_78
+
+action_211 _ = happyReduce_76
 
 happyReduce_23 = happySpecReduce_1  26 happyReduction_23
 happyReduction_23 (HappyTerminal happy_var_1)
@@ -1834,14 +1840,15 @@ happyReduction_38 (HappyAbsSyn35  happy_var_3)
 	)
 happyReduction_38 _ _ _  = notHappyAtAll 
 
-happyReduce_39 = happyReduce 4 36 happyReduction_39
+happyReduce_39 = happyReduce 5 36 happyReduction_39
 happyReduction_39 (_ `HappyStk`
-	(HappyAbsSyn38  happy_var_3) `HappyStk`
+	(HappyAbsSyn38  happy_var_4) `HappyStk`
+	(HappyAbsSyn32  happy_var_3) `HappyStk`
 	(HappyAbsSyn26  happy_var_2) `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
 	 = HappyAbsSyn36
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.ATelescope (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_3))
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.ATelescope (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_3) (snd happy_var_4))
 	) `HappyStk` happyRest
 
 happyReduce_40 = happyReduce 5 37 happyReduction_40

--- a/haskell/mltt/src/Language/MLTT/Syntax/Print.hs
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Print.hs
@@ -180,7 +180,7 @@ instance Print [Language.MLTT.Syntax.Abs.Fixed' a] where
 
 instance Print (Language.MLTT.Syntax.Abs.TelescopeDecl' a) where
   prt i = \case
-    Language.MLTT.Syntax.Abs.ATelescope _ varident params -> prPrec i 0 (concatD [doc (showString "telescope"), prt 0 varident, prt 0 params, doc (showString ";")])
+    Language.MLTT.Syntax.Abs.ATelescope _ varident includes params -> prPrec i 0 (concatD [doc (showString "telescope"), prt 0 varident, prt 0 includes, prt 0 params, doc (showString ";")])
 
 instance Print (Language.MLTT.Syntax.Abs.Param' a) where
   prt i = \case

--- a/haskell/mltt/test/Language/MLTT/IncludeSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/IncludeSpec.hs
@@ -124,6 +124,66 @@ spec = do
       -- the law, in telescope order. There is no interpretation step.
       failures (run theoryAndInstance) `shouldBe` []
 
+  describe "a telescope that includes a telescope" $ do
+    it "puts the included fields first, so a theory extends a poorer one" $
+      -- The monoid block is the semigroup block with a unit after it, and a
+      -- declaration in it is discharged in that order.
+      run (unlines
+            [ "telescope Semigroup (A : 𝕌) (mul : A → A → A)"
+            , "telescope Monoid include Semigroup (unit : A)"
+            , "module M include Monoid"
+            , "def scaled : A → A := λ x ⇒ mul unit x" ])
+        `shouldSatisfy` (Defined "scaled" ["A", "mul", "unit"] `elem`)
+
+    it "expands a chain of includes, dependencies first" $
+      -- Sterling's hierarchy, in miniature: Magma, Semigroup, Monoid.
+      run (unlines
+            [ "telescope Magma (A : 𝕌) (mul : A → A → A)"
+            , "telescope Semigroup include Magma (e : A)"
+            , "telescope Monoid include Semigroup (z : A)"
+            , "module M include Monoid"
+            , "def pick : A := mul e z" ])
+        `shouldSatisfy` (Defined "pick" ["A", "mul", "e", "z"] `elem`)
+
+    it "may include a telescope declared after it" $
+      -- Telescopes are expanded in dependency order, not source order.
+      failures (run (unlines
+            [ "telescope Monoid include Semigroup (unit : A)"
+            , "telescope Semigroup (A : 𝕌) (mul : A → A → A)"
+            , "module M include Monoid"
+            , "def u : A := unit" ]))
+        `shouldBe` []
+
+    it "composes with refinement, since refining yields a parameter list" $
+      run (unlines
+            [ "telescope Semigroup (A : 𝕌) (mul : A → A → A)"
+            , "telescope Pointed include Semigroup / {A := 𝟙} (p : A)"
+            , "module M include Pointed"
+            , "def pick : A := p" ])
+        `shouldSatisfy` (Defined "pick" ["p"] `elem`)
+
+    it "reports a cycle by naming it" $
+      failures (run (unlines
+            [ "telescope A include B (x : 𝕌)"
+            , "telescope B include A (y : 𝕌)"
+            , "module M include A"
+            , "def u : 𝟙 := tt" ]))
+        `shouldBe` ["telescopes include each other in a cycle: A -> B -> A"]
+
+    it "reports a self-include as the smallest cycle" $
+      failures (run (unlines
+            [ "telescope T include T (x : 𝕌)"
+            , "module M include T"
+            , "def u : 𝟙 := tt" ]))
+        `shouldBe` ["telescopes include each other in a cycle: T -> T"]
+
+    it "reports a missing telescope in a telescope's include" $
+      failures (run (unlines
+            [ "telescope T include Nope (x : 𝕌)"
+            , "module M include T"
+            , "def u : 𝟙 := tt" ]))
+        `shouldBe` ["no telescope named Nope is declared"]
+
   describe "refining an include" $ do
     it "makes a fixed field manifest, so nothing is discharged over it" $
       -- `A` is fixed, so `square` takes the operation and not the carrier.


### PR DESCRIPTION
A theory could not extend a poorer theory: only a module could include a telescope, so a hierarchy in the manner of Pollack or Sterling could not be written, and `theories.mltt` said so where it would otherwise mislead.

`telescope Monoid include Semigroup (unit : A) …` now works. Telescope includes are expanded before any module's, in dependency order over the declared telescopes with a cycle reported by name — the same shape as the build order over modules. A refined include composes unchanged, since refining a parameter list yields a parameter list, and nothing downstream changes: by the time a module includes a telescope, it is a plain block.

The theories example now runs Semigroup, Monoid, CommMonoid, Group by inclusion.