### PR TITLE
MLTT: multi-binder sugar for λ and Π

### DIFF
--- a/haskell/mltt/README.md
+++ b/haskell/mltt/README.md
@@ -26,7 +26,10 @@ The core is deliberately small.
   `A × B`.
 - Top-level definitions, unfolded by δ-reduction.
 
-λ is written `λ x ⇒ e`. Not `λ x . e`, because a dot inside an identifier is
+λ is written `λ x ⇒ e`, and binders come in groups: `λ a b c ⇒ e` is sugar
+for the nested λs, and `Π (a b c : Nat) → B` for the nested Πs with the type
+repeated. Both desugar in the parser, so the abstract syntax — and the printed
+form a content hash is taken over — never records which spelling was written. Not `λ x . e`, because a dot inside an identifier is
 part of the identifier — `Nat.zero` is one token, so the parser never has to
 decide whether a dot qualifies a name or separates a binder from a body. And
 not `λ x → e`, so that the arrow of a λ-abstraction is not read as the arrow

--- a/haskell/mltt/examples/theories.mltt
+++ b/haskell/mltt/examples/theories.mltt
@@ -14,7 +14,7 @@
 telescope Semigroup
   (A : 𝕌)
   (mul : A → A → A)
-  (assoc : Π (x : A) → Π (y : A) → Π (z : A) → Id(A, mul (mul x y) z, mul x (mul y z)))
+  (assoc : Π (x y z : A) → Id(A, mul (mul x y) z, mul x (mul y z)))
 
 -- A monoid is a semigroup with a unit and its laws: the include puts the
 -- semigroup's fields first, and the unit's types may mention them.
@@ -49,7 +49,7 @@ def unitSquare over (A, mul, unit, unitL)
 -- Each of these is a theory in its own right, built on Monoid by inclusion,
 -- and can itself be included by a further telescope or worked in by a module.
 telescope CommMonoid include Monoid
-  (comm : Π (x : A) → Π (y : A) → Id(A, mul x y, mul y x))
+  (comm : Π (x y : A) → Id(A, mul x y, mul y x))
 
 telescope Group include Monoid
   (inv : A → A)
@@ -73,24 +73,22 @@ def cancelSquare over (A, mul, unit, inv, invL)
 -- discharged by `refl`. The unit laws need η, which `nf` contracts.
 module Church
 def Nat : 𝕌 := Π (A : 𝕌) → (A → A) → A → A
-def zero : Nat := λ A ⇒ λ f ⇒ λ x ⇒ x
-def succ : Nat → Nat := λ n ⇒ λ A ⇒ λ f ⇒ λ x ⇒ f (n A f x)
+def zero : Nat := λ A f x ⇒ x
+def succ : Nat → Nat := λ n A f x ⇒ f (n A f x)
 def one : Nat := succ zero
 def two : Nat := succ one
 def three : Nat := succ two
 
-def plus : Nat → Nat → Nat := λ m ⇒ λ n ⇒ λ A ⇒ λ f ⇒ λ x ⇒ m A f (n A f x)
-def times : Nat → Nat → Nat := λ m ⇒ λ n ⇒ λ A ⇒ λ f ⇒ m A (n A f)
+def plus : Nat → Nat → Nat := λ m n A f x ⇒ m A f (n A f x)
+def times : Nat → Nat → Nat := λ m n A f ⇒ m A (n A f)
 
-def plusAssoc : Π (a : Nat) → Π (b : Nat) → Π (c : Nat)
-              → Id(Nat, plus (plus a b) c, plus a (plus b c))
-  := λ a ⇒ λ b ⇒ λ c ⇒ refl (plus (plus a b) c)
+def plusAssoc : Π (a b c : Nat) → Id(Nat, plus (plus a b) c, plus a (plus b c))
+  := λ a b c ⇒ refl (plus (plus a b) c)
 def plusUnitL : Π (a : Nat) → Id(Nat, plus zero a, a) := λ a ⇒ refl (a)
 def plusUnitR : Π (a : Nat) → Id(Nat, plus a zero, a) := λ a ⇒ refl (a)
 
-def timesAssoc : Π (a : Nat) → Π (b : Nat) → Π (c : Nat)
-               → Id(Nat, times (times a b) c, times a (times b c))
-  := λ a ⇒ λ b ⇒ λ c ⇒ refl (times (times a b) c)
+def timesAssoc : Π (a b c : Nat) → Id(Nat, times (times a b) c, times a (times b c))
+  := λ a b c ⇒ refl (times (times a b) c)
 def timesUnitL : Π (a : Nat) → Id(Nat, times one a, a) := λ a ⇒ refl (a)
 def timesUnitR : Π (a : Nat) → Id(Nat, times a one, a) := λ a ⇒ refl (a)
 

--- a/haskell/mltt/grammar/MLTT/Syntax.cf
+++ b/haskell/mltt/grammar/MLTT/Syntax.cf
@@ -111,6 +111,34 @@ Pi.       Term ::= "Π" "(" Pattern ":" Term ")" "→" ScopedTerm ;
 Sigma.    Term ::= "Σ" "(" Pattern ":" Term ")" "×" ScopedTerm ;
 Lam.      Term ::= "λ" Pattern "⇒" ScopedTerm ;
 Let.      Term ::= "let" Pattern "=" Term "in" ScopedTerm ;
+
+-- Multi-binder sugar. The rules below are `define`s: they construct nested
+-- `Lam` and `Pi` nodes at parse time, so the abstract syntax — and with it
+-- everything free foil's Template Haskell generates — is exactly as if the
+-- binders had been written out one by one. The printer prints the desugared
+-- form, so a content hash does not depend on which spelling was written.
+--
+-- `λ a b c ⇒ e` is `λ a ⇒ λ b ⇒ λ c ⇒ e`, at any number of binders. The
+-- category ScopedTerm9 shares the type of ScopedTerm, which is what lets the
+-- recursion produce plain scoped terms.
+lamMulti.    Term ::= "λ" Pattern Pattern ScopedTerm9 ;
+define lamMulti p q r = Lam p (AScopedTerm (Lam q r)) ;
+lamRestDone. ScopedTerm9 ::= "⇒" Term ;
+define lamRestDone t = AScopedTerm t ;
+lamRestMore. ScopedTerm9 ::= Pattern ScopedTerm9 ;
+define lamRestMore p r = AScopedTerm (Lam p r) ;
+
+-- `Π (a b c : T) → e` is `Π (a : T) → Π (b : T) → Π (c : T) → e`, up to four
+-- binders in the group, the type repeated for each. A `define` cannot fold
+-- over a list, so the arities are written out.
+piTwo.   Term ::= "Π" "(" Pattern Pattern ":" Term ")" "→" ScopedTerm ;
+define piTwo p q ty t = Pi p ty (AScopedTerm (Pi q ty t)) ;
+piThree. Term ::= "Π" "(" Pattern Pattern Pattern ":" Term ")" "→" ScopedTerm ;
+define piThree p q r ty t =
+  Pi p ty (AScopedTerm (Pi q ty (AScopedTerm (Pi r ty t)))) ;
+piFour.  Term ::= "Π" "(" Pattern Pattern Pattern Pattern ":" Term ")" "→" ScopedTerm ;
+define piFour p q r s ty t =
+  Pi p ty (AScopedTerm (Pi q ty (AScopedTerm (Pi r ty (AScopedTerm (Pi s ty t)))))) ;
 Arrow.    Term ::= Term1 "→" Term ;
 Product.  Term ::= Term1 "×" Term ;
 

--- a/haskell/mltt/mltt.cabal
+++ b/haskell/mltt/mltt.cabal
@@ -147,6 +147,7 @@ test-suite spec
       Language.MLTT.ParametersSpec
       Language.MLTT.ReplImportSpec
       Language.MLTT.ReplSpec
+      Language.MLTT.SugarSpec
       Language.MLTT.TelescopeSpec
       SpecHook
       Paths_mltt

--- a/haskell/mltt/src/Language/MLTT/Syntax/Abs.hs
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Abs.hs
@@ -111,6 +111,24 @@ data Pattern' a
     | PatternPair a (Pattern' a) (Pattern' a)
   deriving (C.Eq, C.Ord, C.Show, C.Read, C.Functor, C.Foldable, C.Traversable, C.Data, C.Typeable, C.Generic)
 
+lamMulti :: a -> Pattern' a -> Pattern' a -> ScopedTerm' a -> Term' a
+lamMulti = \ _a p q r -> Lam _a p (AScopedTerm _a (Lam _a q r))
+
+lamRestDone :: a -> Term' a -> ScopedTerm' a
+lamRestDone = \ _a t -> AScopedTerm _a t
+
+lamRestMore :: a -> Pattern' a -> ScopedTerm' a -> ScopedTerm' a
+lamRestMore = \ _a p r -> AScopedTerm _a (Lam _a p r)
+
+piTwo :: a -> Pattern' a -> Pattern' a -> Term' a -> ScopedTerm' a -> Term' a
+piTwo = \ _a p q ty t -> Pi _a p ty (AScopedTerm _a (Pi _a q ty t))
+
+piThree :: a -> Pattern' a -> Pattern' a -> Pattern' a -> Term' a -> ScopedTerm' a -> Term' a
+piThree = \ _a p q r ty t -> Pi _a p ty (AScopedTerm _a (Pi _a q ty (AScopedTerm _a (Pi _a r ty t))))
+
+piFour :: a -> Pattern' a -> Pattern' a -> Pattern' a -> Pattern' a -> Term' a -> ScopedTerm' a -> Term' a
+piFour = \ _a p q r s ty t -> Pi _a p ty (AScopedTerm _a (Pi _a q ty (AScopedTerm _a (Pi _a r ty (AScopedTerm _a (Pi _a s ty t))))))
+
 newtype VarIdent = VarIdent String
   deriving (C.Eq, C.Ord, C.Show, C.Read, C.Data, C.Typeable, C.Generic, Data.String.IsString)
 

--- a/haskell/mltt/src/Language/MLTT/Syntax/Doc.txt
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Doc.txt
@@ -84,9 +84,15 @@ All other symbols are terminals.
   |  |  **|**  | ``Σ`` ``(`` //Pattern// ``:`` //Term// ``)`` ``×`` //ScopedTerm//
   |  |  **|**  | ``λ`` //Pattern// ``⇒`` //ScopedTerm//
   |  |  **|**  | ``let`` //Pattern// ``=`` //Term// ``in`` //ScopedTerm//
+  |  |  **|**  | ``λ`` //Pattern// //Pattern// //ScopedTerm9//
+  |  |  **|**  | ``Π`` ``(`` //Pattern// //Pattern// ``:`` //Term// ``)`` ``→`` //ScopedTerm//
+  |  |  **|**  | ``Π`` ``(`` //Pattern// //Pattern// //Pattern// ``:`` //Term// ``)`` ``→`` //ScopedTerm//
+  |  |  **|**  | ``Π`` ``(`` //Pattern// //Pattern// //Pattern// //Pattern// ``:`` //Term// ``)`` ``→`` //ScopedTerm//
   |  |  **|**  | //Term1// ``→`` //Term//
   |  |  **|**  | //Term1// ``×`` //Term//
   |  |  **|**  | //Term1//
+  | //ScopedTerm9// | -> | ``⇒`` //Term//
+  |  |  **|**  | //Pattern// //ScopedTerm9//
   | //Term1// | -> | //Term1// //Term2//
   |  |  **|**  | //Term2//
   | //Term2// | -> | ``π₁`` //Term2//

--- a/haskell/mltt/src/Language/MLTT/Syntax/Par.hs
+++ b/haskell/mltt/src/Language/MLTT/Syntax/Par.hs
@@ -24,6 +24,7 @@ module Language.MLTT.Syntax.Par
   , pDischarge
   , pListVarIdent
   , pTerm
+  , pScopedTerm9
   , pTerm1
   , pTerm2
   , pScopedTerm
@@ -44,28 +45,28 @@ import Control.Monad (ap)
 data HappyAbsSyn 
 	= HappyTerminal (Token)
 	| HappyErrorToken Prelude.Int
-	| HappyAbsSyn26 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.VarIdent))
-	| HappyAbsSyn27 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Program))
-	| HappyAbsSyn28 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Unit]))
-	| HappyAbsSyn29 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Unit))
-	| HappyAbsSyn30 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Module))
-	| HappyAbsSyn31 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Include))
-	| HappyAbsSyn32 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Include]))
-	| HappyAbsSyn33 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Refinement))
-	| HappyAbsSyn34 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Fixed))
-	| HappyAbsSyn35 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Fixed]))
-	| HappyAbsSyn36 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.TelescopeDecl))
-	| HappyAbsSyn37 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Param))
-	| HappyAbsSyn38 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Param]))
-	| HappyAbsSyn39 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Import))
-	| HappyAbsSyn40 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Import]))
-	| HappyAbsSyn41 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Decl))
-	| HappyAbsSyn42 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Decl]))
-	| HappyAbsSyn43 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Discharge))
-	| HappyAbsSyn44 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.VarIdent]))
-	| HappyAbsSyn45 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Term))
-	| HappyAbsSyn48 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.ScopedTerm))
-	| HappyAbsSyn49 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Pattern))
+	| HappyAbsSyn27 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.VarIdent))
+	| HappyAbsSyn28 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Program))
+	| HappyAbsSyn29 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Unit]))
+	| HappyAbsSyn30 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Unit))
+	| HappyAbsSyn31 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Module))
+	| HappyAbsSyn32 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Include))
+	| HappyAbsSyn33 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Include]))
+	| HappyAbsSyn34 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Refinement))
+	| HappyAbsSyn35 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Fixed))
+	| HappyAbsSyn36 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Fixed]))
+	| HappyAbsSyn37 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.TelescopeDecl))
+	| HappyAbsSyn38 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Param))
+	| HappyAbsSyn39 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Param]))
+	| HappyAbsSyn40 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Import))
+	| HappyAbsSyn41 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Import]))
+	| HappyAbsSyn42 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Decl))
+	| HappyAbsSyn43 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.Decl]))
+	| HappyAbsSyn44 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Discharge))
+	| HappyAbsSyn45 ((Language.MLTT.Syntax.Abs.BNFC'Position, [Language.MLTT.Syntax.Abs.VarIdent]))
+	| HappyAbsSyn46 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Term))
+	| HappyAbsSyn47 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.ScopedTerm))
+	| HappyAbsSyn51 ((Language.MLTT.Syntax.Abs.BNFC'Position, Language.MLTT.Syntax.Abs.Pattern))
 
 {- to allow type-synonyms as our monads (likely
  - with explicitly-specified bind and return)
@@ -293,7 +294,33 @@ action_0,
  action_208,
  action_209,
  action_210,
- action_211 :: () => Prelude.Int -> ({-HappyReduction (Err) = -}
+ action_211,
+ action_212,
+ action_213,
+ action_214,
+ action_215,
+ action_216,
+ action_217,
+ action_218,
+ action_219,
+ action_220,
+ action_221,
+ action_222,
+ action_223,
+ action_224,
+ action_225,
+ action_226,
+ action_227,
+ action_228,
+ action_229,
+ action_230,
+ action_231,
+ action_232,
+ action_233,
+ action_234,
+ action_235,
+ action_236,
+ action_237 :: () => Prelude.Int -> ({-HappyReduction (Err) = -}
 	   Prelude.Int 
 	-> (Token)
 	-> HappyState (Token) (HappyStk HappyAbsSyn -> [(Token)] -> (Err) HappyAbsSyn)
@@ -301,8 +328,7 @@ action_0,
 	-> HappyStk HappyAbsSyn 
 	-> [(Token)] -> (Err) HappyAbsSyn)
 
-happyReduce_23,
- happyReduce_24,
+happyReduce_24,
  happyReduce_25,
  happyReduce_26,
  happyReduce_27,
@@ -363,7 +389,14 @@ happyReduce_23,
  happyReduce_82,
  happyReduce_83,
  happyReduce_84,
- happyReduce_85 :: () => ({-HappyReduction (Err) = -}
+ happyReduce_85,
+ happyReduce_86,
+ happyReduce_87,
+ happyReduce_88,
+ happyReduce_89,
+ happyReduce_90,
+ happyReduce_91,
+ happyReduce_92 :: () => ({-HappyReduction (Err) = -}
 	   Prelude.Int 
 	-> (Token)
 	-> HappyState (Token) (HappyStk HappyAbsSyn -> [(Token)] -> (Err) HappyAbsSyn)
@@ -372,1951 +405,2257 @@ happyReduce_23,
 	-> [(Token)] -> (Err) HappyAbsSyn)
 
 happyExpList :: Happy_Data_Array.Array Prelude.Int Prelude.Int
-happyExpList = Happy_Data_Array.listArray (0,432) ([0,0,0,0,520,0,0,0,0,8192,8,0,0,0,0,8320,0,0,0,0,0,2,0,0,0,0,512,0,0,0,0,0,8,0,0,0,0,1,0,0,0,0,0,0,16384,0,0,0,0,0,256,0,0,0,0,8,0,0,0,32,0,0,0,0,32768,0,0,0,0,0,0,128,0,0,0,0,0,2,0,0,0,0,1792,11,0,0,0,0,11292,0,0,0,0,0,64,0,0,0,0,0,0,4,0,0,24608,20544,7416,0,0,32768,384,320,115,0,0,512,6,52229,1,0,0,6152,5136,1854,0,0,8192,128,0,16,0,0,0,0,16384,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32768,512,0,64,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32896,16385,30481,0,0,0,0,0,0,0,0,0,0,0,0,0,0,24608,20544,7416,0,0,32768,0,0,0,0,0,512,0,0,0,0,0,8200,0,1024,0,0,8192,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,2048,0,0,0,0,0,32800,0,4096,0,0,32768,384,320,115,0,0,512,6,52229,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1538,1280,460,0,0,0,0,0,0,0,0,128,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8,0,0,0,0,0,8,0,0,0,0,0,0,0,0,0,0,1538,34052,463,0,0,2048,4120,15892,7,0,0,0,0,4096,0,0,0,0,0,64,0,0,0,0,0,1,0,0,0,1,0,0,0,0,0,0,0,0,0,8192,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,32768,0,0,0,0,0,0,0,0,0,0,0,0,0,1024,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,256,0,0,0,1,0,0,0,0,128,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,256,0,0,0,0,128,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8192,8,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,256,0,0,0,0,0,4,0,0,24608,20544,7416,0,0,0,32768,0,0,0,0,8192,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32,0,0,0,0,0,0,256,0,0,0,0,0,0,0,0,0,32768,0,0,0,0,0,16,0,0,0,0,0,0,0,0,0,128,0,0,0,0,0,1792,11,0,0,0,0,0,16384,0,0,0,0,0,256,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8192,0,0,0,8200,0,1024,0,0,8192,128,0,16,0,0,32896,16641,29665,0,0,0,256,0,0,0,0,2048,4120,15892,7,0,0,24608,20544,7416,0,0,0,11,0,0,0,0,512,1030,53125,1,0,0,6152,5136,1854,0,0,32768,0,0,0,0,0,128,2,16384,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32768,384,57665,115,0,0,512,1030,53125,1,0,0,32,0,0,0,0,32768,0,0,0,0,0,32896,16641,29665,0,0,0,4,0,0,0,0,32768,0,0,0,0,0,512,0,0,0,0,32768,384,57665,115,0,0,0,0,0,0,0,0,16,0,0,0,0,0,0,0,0,0,0,32896,16641,29665,0,0,0,32,0,0,0,0,0,0,64,0,0,0,0,1024,0,0,0,0,0,0,0,0,0,512,1030,53125,1,0,0,8,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8192,0,0,0,0,0,0,0,0,0,32,0,0,0,0,0,32,0,0,0,0,0,0,0,0,0,0,512,0,0,0,0,16384,4,0,0,0,0,2048,0,0,0,0,0,28672,176,0,0,0,2048,4120,15892,7,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,6152,5136,1854,0,0,8192,16480,63568,28,0,0,0,0,0,0,0,0,0,1,0,0,0,2048,4120,15892,7,0,0,24608,20544,7416,0,0,0,1,0,0,0,0,1024,0,0,0,0,0,16,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8192,0,0,0,0,0,128,0,0,0,0,32768,384,57665,115,0,0,1024,0,0,0,0,0,16,0,0,0,0,0,4,0,0,0,0,0,0,8,0,0,0,1538,34052,463,0,0,0,0,0,0,0,0,24608,20544,7416,0,0,0,0,0,0,0,0,0,128,0,0,0,0,49152,705,0,0,0,16384,0,0,0,0,0,4096,0,0,0,0,0,0,0,0,0,0,2048,4120,15892,7,0,0,0,0,4,0,0,0,0,0,4,0,0,0,0,0,0,0,0,6152,5136,1854,0,0,8192,16480,63568,28,0,0,256,0,0,0,0,0,4,0,0,0,0,2048,4120,15892,7,0,0,24608,20544,7416,0,0,0,0,0,0,0,0,512,1030,53125,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+happyExpList = Happy_Data_Array.listArray (0,511) ([0,0,0,0,2080,0,0,0,0,0,130,0,0,0,0,8192,8,0,0,0,0,512,0,0,0,0,0,8,0,0,0,0,32768,0,0,0,0,16384,0,0,0,0,0,0,0,16384,0,0,0,0,0,1024,0,0,0,0,128,0,0,0,2048,0,0,0,0,0,128,0,0,0,0,0,0,2,0,0,0,0,8192,0,0,0,0,0,49600,2,0,0,0,0,11292,0,0,0,0,0,256,0,0,0,0,0,0,64,0,0,2048,4120,15892,7,0,0,128,2,18432,0,0,0,6152,5120,1840,0,0,32768,384,320,115,0,0,2048,4120,15892,7,0,0,128,2,16384,0,0,0,0,0,1024,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8200,0,1024,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,6152,5120,1905,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32896,16641,29665,0,0,0,8,0,0,0,0,32768,0,0,0,0,0,2048,32,0,4,0,0,128,0,0,0,0,0,0,0,0,0,0,32768,0,0,0,0,0,2048,0,0,0,0,0,128,2,16384,0,0,0,6152,5120,1840,0,0,32768,384,320,115,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32768,384,320,115,0,0,0,0,0,0,0,0,128,2,18432,0,0,0,6152,5136,1854,0,0,0,0,0,0,0,0,8192,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32768,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,6152,5136,1854,0,0,32768,384,57665,115,0,0,0,0,0,4,0,0,0,0,16384,0,0,0,0,0,1024,0,0,0,4096,0,0,0,0,0,0,0,0,0,0,8192,0,0,0,0,0,0,0,0,0,0,0,0,0,64,0,0,0,0,0,0,0,0,128,0,0,0,0,0,0,0,0,0,0,0,0,0,64,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1024,0,0,0,16,0,0,0,0,8192,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,64,0,0,0,0,128,0,0,0,0,0,0,0,0,0,0,0,0,64,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1024,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,130,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32768,0,0,0,0,16384,0,0,0,0,0,0,0,0,0,0,0,0,0,1024,0,0,0,0,0,64,0,0,2048,4120,15892,7,0,0,0,128,0,0,0,0,128,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32,0,0,0,0,0,0,1024,0,0,0,0,0,0,0,0,0,0,32,0,0,0,0,4096,0,0,0,0,0,0,0,0,0,0,8,0,0,0,0,0,49600,2,0,0,0,0,0,16384,0,0,0,0,0,1024,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2048,32,32768,4,0,0,128,2,16384,0,0,0,8200,0,1024,0,0,32768,384,57665,115,0,0,0,4,0,0,0,0,32896,16641,29665,0,0,0,6152,5136,1854,0,0,0,11,0,0,0,0,2048,4120,15892,7,0,0,32896,16641,29665,0,0,0,32,0,0,0,0,32768,512,0,64,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32768,384,57665,115,0,0,2048,4120,15892,7,0,0,512,0,0,0,0,0,32,0,0,0,0,32768,384,57665,115,0,0,4096,0,0,0,0,0,2176,2,16384,0,0,0,128,0,0,0,0,32768,512,0,72,0,0,2048,4120,15892,7,0,0,0,0,0,0,0,0,16,0,0,0,0,0,0,0,0,0,0,2048,4120,15892,7,0,0,2048,0,0,0,0,0,0,16384,0,0,0,0,0,16,0,0,0,0,0,0,0,0,0,32896,16641,29665,0,0,0,8,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,0,32768,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,512,0,0,0,0,0,17,0,0,0,0,32768,0,0,0,0,0,0,11292,0,0,0,0,6152,5136,1854,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32768,384,57665,115,0,0,34816,32,0,4,0,0,32896,16641,29665,0,0,0,0,0,0,0,0,0,16384,0,0,0,0,2048,4120,15892,7,0,0,32896,16641,29665,0,0,0,16,0,0,0,0,0,1,0,0,0,0,4096,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8192,0,0,0,0,0,512,0,0,0,0,0,6152,5136,1854,0,0,0,1,0,0,0,0,34816,32,0,4,0,0,32896,16641,29665,0,0,0,16,0,0,0,0,0,16,0,0,0,0,0,0,128,0,0,0,32896,16641,29665,0,0,0,0,0,0,0,0,32768,384,57665,115,0,0,0,0,0,0,0,0,0,32,0,0,0,0,49152,705,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,6152,5136,1854,0,0,0,0,4096,0,0,0,4096,0,0,0,0,0,2048,0,0,0,0,0,6152,5136,1854,0,0,0,0,0,4,0,0,0,0,0,0,0,0,32896,16641,29665,0,0,0,6152,5136,1854,0,0,0,1,0,0,0,0,4096,0,0,0,0,0,32896,16641,29665,0,0,0,16,0,0,0,0,32768,384,57665,115,0,0,0,0,16384,0,0,0,32896,16641,29665,0,0,0,0,0,0,0,0,32768,384,57665,115,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2048,4120,15892,7,0,0,256,0,0,0,0,0,0,0,64,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,6152,5136,1854,0,0,0,0,0,4,0,0,0,0,0,0,0,0,32896,16641,29665,0,0,0,0,0,0,0,0,0,0,0,0,0
 	])
 
 {-# NOINLINE happyExpListPerState #-}
 happyExpListPerState st =
     token_strs_expected
-  where token_strs = ["error","%dummy","%start_pProgram_internal","%start_pListUnit_internal","%start_pUnit_internal","%start_pModule_internal","%start_pInclude_internal","%start_pListInclude_internal","%start_pRefinement_internal","%start_pFixed_internal","%start_pListFixed_internal","%start_pTelescopeDecl_internal","%start_pParam_internal","%start_pListParam_internal","%start_pImport_internal","%start_pListImport_internal","%start_pDecl_internal","%start_pListDecl_internal","%start_pDischarge_internal","%start_pListVarIdent_internal","%start_pTerm_internal","%start_pTerm1_internal","%start_pTerm2_internal","%start_pScopedTerm_internal","%start_pPattern_internal","VarIdent","Program","ListUnit","Unit","Module","Include","ListInclude","Refinement","Fixed","ListFixed","TelescopeDecl","Param","ListParam","Import","ListImport","Decl","ListDecl","Discharge","ListVarIdent","Term","Term1","Term2","ScopedTerm","Pattern","'('","')'","','","'/'","':'","':='","';'","'='","'Id'","'J'","'_'","'check'","'compute'","'def'","'import'","'in'","'include'","'let'","'module'","'namespace'","'open'","'over'","'private'","'refl'","'telescope'","'tt'","'where'","'{'","'}'","'\215'","'\928'","'\931'","'\955'","'\960\8321'","'\960\8322'","'\8594'","'\8658'","'\120140'","'\120793'","L_VarIdent","%eof"]
-        bit_start = st Prelude.* 90
-        bit_end = (st Prelude.+ 1) Prelude.* 90
+  where token_strs = ["error","%dummy","%start_pProgram_internal","%start_pListUnit_internal","%start_pUnit_internal","%start_pModule_internal","%start_pInclude_internal","%start_pListInclude_internal","%start_pRefinement_internal","%start_pFixed_internal","%start_pListFixed_internal","%start_pTelescopeDecl_internal","%start_pParam_internal","%start_pListParam_internal","%start_pImport_internal","%start_pListImport_internal","%start_pDecl_internal","%start_pListDecl_internal","%start_pDischarge_internal","%start_pListVarIdent_internal","%start_pTerm_internal","%start_pScopedTerm9_internal","%start_pTerm1_internal","%start_pTerm2_internal","%start_pScopedTerm_internal","%start_pPattern_internal","VarIdent","Program","ListUnit","Unit","Module","Include","ListInclude","Refinement","Fixed","ListFixed","TelescopeDecl","Param","ListParam","Import","ListImport","Decl","ListDecl","Discharge","ListVarIdent","Term","ScopedTerm9","Term1","Term2","ScopedTerm","Pattern","'('","')'","','","'/'","':'","':='","';'","'='","'Id'","'J'","'_'","'check'","'compute'","'def'","'import'","'in'","'include'","'let'","'module'","'namespace'","'open'","'over'","'private'","'refl'","'telescope'","'tt'","'where'","'{'","'}'","'\215'","'\928'","'\931'","'\955'","'\960\8321'","'\960\8322'","'\8594'","'\8658'","'\120140'","'\120793'","L_VarIdent","%eof"]
+        bit_start = st Prelude.* 92
+        bit_end = (st Prelude.+ 1) Prelude.* 92
         read_bit = readArrayBit happyExpList
         bits = Prelude.map read_bit [bit_start..bit_end Prelude.- 1]
-        bits_indexed = Prelude.zip bits [0..89]
+        bits_indexed = Prelude.zip bits [0..91]
         token_strs_expected = Prelude.concatMap f bits_indexed
         f (Prelude.False, _) = []
         f (Prelude.True, nr) = [token_strs Prelude.!! nr]
 
-action_0 (68) = happyShift action_84
-action_0 (74) = happyShift action_72
-action_0 (27) = happyGoto action_90
-action_0 (28) = happyGoto action_91
-action_0 (29) = happyGoto action_89
-action_0 (30) = happyGoto action_86
-action_0 (36) = happyGoto action_87
-action_0 _ = happyReduce_25
+action_0 (70) = happyShift action_88
+action_0 (76) = happyShift action_76
+action_0 (28) = happyGoto action_94
+action_0 (29) = happyGoto action_95
+action_0 (30) = happyGoto action_93
+action_0 (31) = happyGoto action_90
+action_0 (37) = happyGoto action_91
+action_0 _ = happyReduce_26
 
-action_1 (68) = happyShift action_84
-action_1 (74) = happyShift action_72
-action_1 (28) = happyGoto action_88
-action_1 (29) = happyGoto action_89
-action_1 (30) = happyGoto action_86
-action_1 (36) = happyGoto action_87
-action_1 _ = happyReduce_25
+action_1 (70) = happyShift action_88
+action_1 (76) = happyShift action_76
+action_1 (29) = happyGoto action_92
+action_1 (30) = happyGoto action_93
+action_1 (31) = happyGoto action_90
+action_1 (37) = happyGoto action_91
+action_1 _ = happyReduce_26
 
-action_2 (68) = happyShift action_84
-action_2 (74) = happyShift action_72
-action_2 (29) = happyGoto action_85
-action_2 (30) = happyGoto action_86
-action_2 (36) = happyGoto action_87
+action_2 (70) = happyShift action_88
+action_2 (76) = happyShift action_76
+action_2 (30) = happyGoto action_89
+action_2 (31) = happyGoto action_90
+action_2 (37) = happyGoto action_91
 action_2 _ = happyFail (happyExpListPerState 2)
 
-action_3 (68) = happyShift action_84
-action_3 (30) = happyGoto action_83
+action_3 (70) = happyShift action_88
+action_3 (31) = happyGoto action_87
 action_3 _ = happyFail (happyExpListPerState 3)
 
-action_4 (66) = happyShift action_81
-action_4 (31) = happyGoto action_82
+action_4 (68) = happyShift action_85
+action_4 (32) = happyGoto action_86
 action_4 _ = happyFail (happyExpListPerState 4)
 
-action_5 (66) = happyShift action_81
-action_5 (31) = happyGoto action_79
-action_5 (32) = happyGoto action_80
-action_5 _ = happyReduce_31
+action_5 (68) = happyShift action_85
+action_5 (32) = happyGoto action_83
+action_5 (33) = happyGoto action_84
+action_5 _ = happyReduce_32
 
-action_6 (53) = happyShift action_78
-action_6 (33) = happyGoto action_77
-action_6 _ = happyReduce_33
+action_6 (55) = happyShift action_82
+action_6 (34) = happyGoto action_81
+action_6 _ = happyReduce_34
 
-action_7 (89) = happyShift action_24
-action_7 (26) = happyGoto action_73
-action_7 (34) = happyGoto action_76
+action_7 (91) = happyShift action_25
+action_7 (27) = happyGoto action_77
+action_7 (35) = happyGoto action_80
 action_7 _ = happyFail (happyExpListPerState 7)
 
-action_8 (89) = happyShift action_24
-action_8 (26) = happyGoto action_73
-action_8 (34) = happyGoto action_74
-action_8 (35) = happyGoto action_75
-action_8 _ = happyReduce_36
+action_8 (91) = happyShift action_25
+action_8 (27) = happyGoto action_77
+action_8 (35) = happyGoto action_78
+action_8 (36) = happyGoto action_79
+action_8 _ = happyReduce_37
 
-action_9 (74) = happyShift action_72
-action_9 (36) = happyGoto action_71
+action_9 (76) = happyShift action_76
+action_9 (37) = happyGoto action_75
 action_9 _ = happyFail (happyExpListPerState 9)
 
-action_10 (50) = happyShift action_69
-action_10 (37) = happyGoto action_70
+action_10 (52) = happyShift action_73
+action_10 (38) = happyGoto action_74
 action_10 _ = happyFail (happyExpListPerState 10)
 
-action_11 (50) = happyShift action_69
-action_11 (37) = happyGoto action_67
-action_11 (38) = happyGoto action_68
-action_11 _ = happyReduce_42
+action_11 (52) = happyShift action_73
+action_11 (38) = happyGoto action_71
+action_11 (39) = happyGoto action_72
+action_11 _ = happyReduce_43
 
-action_12 (64) = happyShift action_65
-action_12 (39) = happyGoto action_66
+action_12 (66) = happyShift action_69
+action_12 (40) = happyGoto action_70
 action_12 _ = happyFail (happyExpListPerState 12)
 
-action_13 (64) = happyShift action_65
-action_13 (39) = happyGoto action_63
-action_13 (40) = happyGoto action_64
-action_13 _ = happyReduce_45
+action_13 (66) = happyShift action_69
+action_13 (40) = happyGoto action_67
+action_13 (41) = happyGoto action_68
+action_13 _ = happyReduce_46
 
-action_14 (61) = happyShift action_56
-action_14 (62) = happyShift action_57
-action_14 (63) = happyShift action_58
-action_14 (69) = happyShift action_59
-action_14 (70) = happyShift action_60
-action_14 (72) = happyShift action_61
-action_14 (41) = happyGoto action_62
+action_14 (63) = happyShift action_60
+action_14 (64) = happyShift action_61
+action_14 (65) = happyShift action_62
+action_14 (71) = happyShift action_63
+action_14 (72) = happyShift action_64
+action_14 (74) = happyShift action_65
+action_14 (42) = happyGoto action_66
 action_14 _ = happyFail (happyExpListPerState 14)
 
-action_15 (61) = happyShift action_56
-action_15 (62) = happyShift action_57
-action_15 (63) = happyShift action_58
-action_15 (69) = happyShift action_59
-action_15 (70) = happyShift action_60
-action_15 (72) = happyShift action_61
-action_15 (41) = happyGoto action_54
-action_15 (42) = happyGoto action_55
-action_15 _ = happyReduce_53
+action_15 (63) = happyShift action_60
+action_15 (64) = happyShift action_61
+action_15 (65) = happyShift action_62
+action_15 (71) = happyShift action_63
+action_15 (72) = happyShift action_64
+action_15 (74) = happyShift action_65
+action_15 (42) = happyGoto action_58
+action_15 (43) = happyGoto action_59
+action_15 _ = happyReduce_54
 
-action_16 (71) = happyShift action_53
-action_16 (43) = happyGoto action_52
-action_16 _ = happyReduce_56
+action_16 (73) = happyShift action_57
+action_16 (44) = happyGoto action_56
+action_16 _ = happyReduce_57
 
-action_17 (89) = happyShift action_24
-action_17 (26) = happyGoto action_50
-action_17 (44) = happyGoto action_51
-action_17 _ = happyReduce_58
+action_17 (91) = happyShift action_25
+action_17 (27) = happyGoto action_54
+action_17 (45) = happyGoto action_55
+action_17 _ = happyReduce_59
 
-action_18 (50) = happyShift action_34
-action_18 (58) = happyShift action_35
-action_18 (59) = happyShift action_36
-action_18 (67) = happyShift action_37
-action_18 (73) = happyShift action_38
+action_18 (52) = happyShift action_35
+action_18 (60) = happyShift action_36
+action_18 (61) = happyShift action_37
+action_18 (69) = happyShift action_38
 action_18 (75) = happyShift action_39
-action_18 (80) = happyShift action_40
-action_18 (81) = happyShift action_41
-action_18 (82) = happyShift action_42
-action_18 (83) = happyShift action_43
-action_18 (84) = happyShift action_44
-action_18 (87) = happyShift action_45
-action_18 (88) = happyShift action_46
-action_18 (89) = happyShift action_24
-action_18 (26) = happyGoto action_29
-action_18 (45) = happyGoto action_49
-action_18 (46) = happyGoto action_31
-action_18 (47) = happyGoto action_32
+action_18 (77) = happyShift action_40
+action_18 (82) = happyShift action_41
+action_18 (83) = happyShift action_42
+action_18 (84) = happyShift action_43
+action_18 (85) = happyShift action_44
+action_18 (86) = happyShift action_45
+action_18 (89) = happyShift action_46
+action_18 (90) = happyShift action_47
+action_18 (91) = happyShift action_25
+action_18 (27) = happyGoto action_30
+action_18 (46) = happyGoto action_53
+action_18 (48) = happyGoto action_32
+action_18 (49) = happyGoto action_33
 action_18 _ = happyFail (happyExpListPerState 18)
 
-action_19 (50) = happyShift action_34
-action_19 (58) = happyShift action_35
-action_19 (59) = happyShift action_36
-action_19 (73) = happyShift action_38
-action_19 (75) = happyShift action_39
-action_19 (83) = happyShift action_43
-action_19 (84) = happyShift action_44
-action_19 (87) = happyShift action_45
-action_19 (88) = happyShift action_46
-action_19 (89) = happyShift action_24
-action_19 (26) = happyGoto action_29
-action_19 (46) = happyGoto action_48
-action_19 (47) = happyGoto action_32
+action_19 (52) = happyShift action_28
+action_19 (62) = happyShift action_29
+action_19 (88) = happyShift action_52
+action_19 (91) = happyShift action_25
+action_19 (27) = happyGoto action_26
+action_19 (47) = happyGoto action_50
+action_19 (51) = happyGoto action_51
 action_19 _ = happyFail (happyExpListPerState 19)
 
-action_20 (50) = happyShift action_34
-action_20 (58) = happyShift action_35
-action_20 (59) = happyShift action_36
-action_20 (73) = happyShift action_38
+action_20 (52) = happyShift action_35
+action_20 (60) = happyShift action_36
+action_20 (61) = happyShift action_37
 action_20 (75) = happyShift action_39
-action_20 (83) = happyShift action_43
-action_20 (84) = happyShift action_44
-action_20 (87) = happyShift action_45
-action_20 (88) = happyShift action_46
-action_20 (89) = happyShift action_24
-action_20 (26) = happyGoto action_29
-action_20 (47) = happyGoto action_47
+action_20 (77) = happyShift action_40
+action_20 (85) = happyShift action_44
+action_20 (86) = happyShift action_45
+action_20 (89) = happyShift action_46
+action_20 (90) = happyShift action_47
+action_20 (91) = happyShift action_25
+action_20 (27) = happyGoto action_30
+action_20 (48) = happyGoto action_49
+action_20 (49) = happyGoto action_33
 action_20 _ = happyFail (happyExpListPerState 20)
 
-action_21 (50) = happyShift action_34
-action_21 (58) = happyShift action_35
-action_21 (59) = happyShift action_36
-action_21 (67) = happyShift action_37
-action_21 (73) = happyShift action_38
+action_21 (52) = happyShift action_35
+action_21 (60) = happyShift action_36
+action_21 (61) = happyShift action_37
 action_21 (75) = happyShift action_39
-action_21 (80) = happyShift action_40
-action_21 (81) = happyShift action_41
-action_21 (82) = happyShift action_42
-action_21 (83) = happyShift action_43
-action_21 (84) = happyShift action_44
-action_21 (87) = happyShift action_45
-action_21 (88) = happyShift action_46
-action_21 (89) = happyShift action_24
-action_21 (26) = happyGoto action_29
-action_21 (45) = happyGoto action_30
-action_21 (46) = happyGoto action_31
-action_21 (47) = happyGoto action_32
-action_21 (48) = happyGoto action_33
+action_21 (77) = happyShift action_40
+action_21 (85) = happyShift action_44
+action_21 (86) = happyShift action_45
+action_21 (89) = happyShift action_46
+action_21 (90) = happyShift action_47
+action_21 (91) = happyShift action_25
+action_21 (27) = happyGoto action_30
+action_21 (49) = happyGoto action_48
 action_21 _ = happyFail (happyExpListPerState 21)
 
-action_22 (50) = happyShift action_27
-action_22 (60) = happyShift action_28
-action_22 (89) = happyShift action_24
-action_22 (26) = happyGoto action_25
-action_22 (49) = happyGoto action_26
+action_22 (52) = happyShift action_35
+action_22 (60) = happyShift action_36
+action_22 (61) = happyShift action_37
+action_22 (69) = happyShift action_38
+action_22 (75) = happyShift action_39
+action_22 (77) = happyShift action_40
+action_22 (82) = happyShift action_41
+action_22 (83) = happyShift action_42
+action_22 (84) = happyShift action_43
+action_22 (85) = happyShift action_44
+action_22 (86) = happyShift action_45
+action_22 (89) = happyShift action_46
+action_22 (90) = happyShift action_47
+action_22 (91) = happyShift action_25
+action_22 (27) = happyGoto action_30
+action_22 (46) = happyGoto action_31
+action_22 (48) = happyGoto action_32
+action_22 (49) = happyGoto action_33
+action_22 (50) = happyGoto action_34
 action_22 _ = happyFail (happyExpListPerState 22)
 
-action_23 (89) = happyShift action_24
+action_23 (52) = happyShift action_28
+action_23 (62) = happyShift action_29
+action_23 (91) = happyShift action_25
+action_23 (27) = happyGoto action_26
+action_23 (51) = happyGoto action_27
 action_23 _ = happyFail (happyExpListPerState 23)
 
-action_24 _ = happyReduce_23
+action_24 (91) = happyShift action_25
+action_24 _ = happyFail (happyExpListPerState 24)
 
-action_25 _ = happyReduce_84
+action_25 _ = happyReduce_24
 
-action_26 (90) = happyAccept
-action_26 _ = happyFail (happyExpListPerState 26)
+action_26 _ = happyReduce_91
 
-action_27 (50) = happyShift action_27
-action_27 (60) = happyShift action_28
-action_27 (89) = happyShift action_24
-action_27 (26) = happyGoto action_25
-action_27 (49) = happyGoto action_126
+action_27 (92) = happyAccept
 action_27 _ = happyFail (happyExpListPerState 27)
 
-action_28 _ = happyReduce_83
+action_28 (52) = happyShift action_28
+action_28 (62) = happyShift action_29
+action_28 (91) = happyShift action_25
+action_28 (27) = happyGoto action_26
+action_28 (51) = happyGoto action_132
+action_28 _ = happyFail (happyExpListPerState 28)
 
-action_29 _ = happyReduce_75
+action_29 _ = happyReduce_90
 
 action_30 _ = happyReduce_82
 
-action_31 (50) = happyShift action_34
-action_31 (58) = happyShift action_35
-action_31 (59) = happyShift action_36
-action_31 (73) = happyShift action_38
-action_31 (75) = happyShift action_39
-action_31 (79) = happyShift action_124
-action_31 (83) = happyShift action_43
-action_31 (84) = happyShift action_44
-action_31 (85) = happyShift action_125
-action_31 (87) = happyShift action_45
-action_31 (88) = happyShift action_46
-action_31 (89) = happyShift action_24
-action_31 (26) = happyGoto action_29
-action_31 (47) = happyGoto action_113
-action_31 _ = happyReduce_67
+action_31 _ = happyReduce_89
 
-action_32 _ = happyReduce_69
+action_32 (52) = happyShift action_35
+action_32 (60) = happyShift action_36
+action_32 (61) = happyShift action_37
+action_32 (75) = happyShift action_39
+action_32 (77) = happyShift action_40
+action_32 (81) = happyShift action_130
+action_32 (85) = happyShift action_44
+action_32 (86) = happyShift action_45
+action_32 (87) = happyShift action_131
+action_32 (89) = happyShift action_46
+action_32 (90) = happyShift action_47
+action_32 (91) = happyShift action_25
+action_32 (27) = happyGoto action_30
+action_32 (49) = happyGoto action_119
+action_32 _ = happyReduce_72
 
-action_33 (90) = happyAccept
-action_33 _ = happyFail (happyExpListPerState 33)
+action_33 _ = happyReduce_76
 
-action_34 (50) = happyShift action_34
-action_34 (58) = happyShift action_35
-action_34 (59) = happyShift action_36
-action_34 (67) = happyShift action_37
-action_34 (73) = happyShift action_38
-action_34 (75) = happyShift action_39
-action_34 (80) = happyShift action_40
-action_34 (81) = happyShift action_41
-action_34 (82) = happyShift action_42
-action_34 (83) = happyShift action_43
-action_34 (84) = happyShift action_44
-action_34 (87) = happyShift action_45
-action_34 (88) = happyShift action_46
-action_34 (89) = happyShift action_24
-action_34 (26) = happyGoto action_29
-action_34 (45) = happyGoto action_123
-action_34 (46) = happyGoto action_31
-action_34 (47) = happyGoto action_32
+action_34 (92) = happyAccept
 action_34 _ = happyFail (happyExpListPerState 34)
 
-action_35 (50) = happyShift action_122
+action_35 (52) = happyShift action_35
+action_35 (60) = happyShift action_36
+action_35 (61) = happyShift action_37
+action_35 (69) = happyShift action_38
+action_35 (75) = happyShift action_39
+action_35 (77) = happyShift action_40
+action_35 (82) = happyShift action_41
+action_35 (83) = happyShift action_42
+action_35 (84) = happyShift action_43
+action_35 (85) = happyShift action_44
+action_35 (86) = happyShift action_45
+action_35 (89) = happyShift action_46
+action_35 (90) = happyShift action_47
+action_35 (91) = happyShift action_25
+action_35 (27) = happyGoto action_30
+action_35 (46) = happyGoto action_129
+action_35 (48) = happyGoto action_32
+action_35 (49) = happyGoto action_33
 action_35 _ = happyFail (happyExpListPerState 35)
 
-action_36 (50) = happyShift action_121
+action_36 (52) = happyShift action_128
 action_36 _ = happyFail (happyExpListPerState 36)
 
-action_37 (50) = happyShift action_27
-action_37 (60) = happyShift action_28
-action_37 (89) = happyShift action_24
-action_37 (26) = happyGoto action_25
-action_37 (49) = happyGoto action_120
+action_37 (52) = happyShift action_127
 action_37 _ = happyFail (happyExpListPerState 37)
 
-action_38 (50) = happyShift action_119
+action_38 (52) = happyShift action_28
+action_38 (62) = happyShift action_29
+action_38 (91) = happyShift action_25
+action_38 (27) = happyGoto action_26
+action_38 (51) = happyGoto action_126
 action_38 _ = happyFail (happyExpListPerState 38)
 
-action_39 _ = happyReduce_74
+action_39 (52) = happyShift action_125
+action_39 _ = happyFail (happyExpListPerState 39)
 
-action_40 (50) = happyShift action_118
-action_40 _ = happyFail (happyExpListPerState 40)
+action_40 _ = happyReduce_81
 
-action_41 (50) = happyShift action_117
+action_41 (52) = happyShift action_124
 action_41 _ = happyFail (happyExpListPerState 41)
 
-action_42 (50) = happyShift action_27
-action_42 (60) = happyShift action_28
-action_42 (89) = happyShift action_24
-action_42 (26) = happyGoto action_25
-action_42 (49) = happyGoto action_116
+action_42 (52) = happyShift action_123
 action_42 _ = happyFail (happyExpListPerState 42)
 
-action_43 (50) = happyShift action_34
-action_43 (58) = happyShift action_35
-action_43 (59) = happyShift action_36
-action_43 (73) = happyShift action_38
-action_43 (75) = happyShift action_39
-action_43 (83) = happyShift action_43
-action_43 (84) = happyShift action_44
-action_43 (87) = happyShift action_45
-action_43 (88) = happyShift action_46
-action_43 (89) = happyShift action_24
-action_43 (26) = happyGoto action_29
-action_43 (47) = happyGoto action_115
+action_43 (52) = happyShift action_28
+action_43 (62) = happyShift action_29
+action_43 (91) = happyShift action_25
+action_43 (27) = happyGoto action_26
+action_43 (51) = happyGoto action_122
 action_43 _ = happyFail (happyExpListPerState 43)
 
-action_44 (50) = happyShift action_34
-action_44 (58) = happyShift action_35
-action_44 (59) = happyShift action_36
-action_44 (73) = happyShift action_38
+action_44 (52) = happyShift action_35
+action_44 (60) = happyShift action_36
+action_44 (61) = happyShift action_37
 action_44 (75) = happyShift action_39
-action_44 (83) = happyShift action_43
-action_44 (84) = happyShift action_44
-action_44 (87) = happyShift action_45
-action_44 (88) = happyShift action_46
-action_44 (89) = happyShift action_24
-action_44 (26) = happyGoto action_29
-action_44 (47) = happyGoto action_114
+action_44 (77) = happyShift action_40
+action_44 (85) = happyShift action_44
+action_44 (86) = happyShift action_45
+action_44 (89) = happyShift action_46
+action_44 (90) = happyShift action_47
+action_44 (91) = happyShift action_25
+action_44 (27) = happyGoto action_30
+action_44 (49) = happyGoto action_121
 action_44 _ = happyFail (happyExpListPerState 44)
 
-action_45 _ = happyReduce_72
+action_45 (52) = happyShift action_35
+action_45 (60) = happyShift action_36
+action_45 (61) = happyShift action_37
+action_45 (75) = happyShift action_39
+action_45 (77) = happyShift action_40
+action_45 (85) = happyShift action_44
+action_45 (86) = happyShift action_45
+action_45 (89) = happyShift action_46
+action_45 (90) = happyShift action_47
+action_45 (91) = happyShift action_25
+action_45 (27) = happyGoto action_30
+action_45 (49) = happyGoto action_120
+action_45 _ = happyFail (happyExpListPerState 45)
 
-action_46 _ = happyReduce_73
+action_46 _ = happyReduce_79
 
-action_47 (90) = happyAccept
-action_47 _ = happyFail (happyExpListPerState 47)
+action_47 _ = happyReduce_80
 
-action_48 (50) = happyShift action_34
-action_48 (58) = happyShift action_35
-action_48 (59) = happyShift action_36
-action_48 (73) = happyShift action_38
-action_48 (75) = happyShift action_39
-action_48 (83) = happyShift action_43
-action_48 (84) = happyShift action_44
-action_48 (87) = happyShift action_45
-action_48 (88) = happyShift action_46
-action_48 (89) = happyShift action_24
-action_48 (90) = happyAccept
-action_48 (26) = happyGoto action_29
-action_48 (47) = happyGoto action_113
+action_48 (92) = happyAccept
 action_48 _ = happyFail (happyExpListPerState 48)
 
-action_49 (90) = happyAccept
+action_49 (52) = happyShift action_35
+action_49 (60) = happyShift action_36
+action_49 (61) = happyShift action_37
+action_49 (75) = happyShift action_39
+action_49 (77) = happyShift action_40
+action_49 (85) = happyShift action_44
+action_49 (86) = happyShift action_45
+action_49 (89) = happyShift action_46
+action_49 (90) = happyShift action_47
+action_49 (91) = happyShift action_25
+action_49 (92) = happyAccept
+action_49 (27) = happyGoto action_30
+action_49 (49) = happyGoto action_119
 action_49 _ = happyFail (happyExpListPerState 49)
 
-action_50 (52) = happyShift action_112
-action_50 _ = happyReduce_59
+action_50 (92) = happyAccept
+action_50 _ = happyFail (happyExpListPerState 50)
 
-action_51 (90) = happyAccept
+action_51 (52) = happyShift action_28
+action_51 (62) = happyShift action_29
+action_51 (88) = happyShift action_52
+action_51 (91) = happyShift action_25
+action_51 (27) = happyGoto action_26
+action_51 (47) = happyGoto action_118
+action_51 (51) = happyGoto action_51
 action_51 _ = happyFail (happyExpListPerState 51)
 
-action_52 (90) = happyAccept
+action_52 (52) = happyShift action_35
+action_52 (60) = happyShift action_36
+action_52 (61) = happyShift action_37
+action_52 (69) = happyShift action_38
+action_52 (75) = happyShift action_39
+action_52 (77) = happyShift action_40
+action_52 (82) = happyShift action_41
+action_52 (83) = happyShift action_42
+action_52 (84) = happyShift action_43
+action_52 (85) = happyShift action_44
+action_52 (86) = happyShift action_45
+action_52 (89) = happyShift action_46
+action_52 (90) = happyShift action_47
+action_52 (91) = happyShift action_25
+action_52 (27) = happyGoto action_30
+action_52 (46) = happyGoto action_117
+action_52 (48) = happyGoto action_32
+action_52 (49) = happyGoto action_33
 action_52 _ = happyFail (happyExpListPerState 52)
 
-action_53 (50) = happyShift action_111
+action_53 (92) = happyAccept
 action_53 _ = happyFail (happyExpListPerState 53)
 
-action_54 (56) = happyShift action_110
-action_54 _ = happyReduce_54
+action_54 (54) = happyShift action_116
+action_54 _ = happyReduce_60
 
-action_55 (90) = happyAccept
+action_55 (92) = happyAccept
 action_55 _ = happyFail (happyExpListPerState 55)
 
-action_56 (50) = happyShift action_34
-action_56 (58) = happyShift action_35
-action_56 (59) = happyShift action_36
-action_56 (67) = happyShift action_37
-action_56 (73) = happyShift action_38
-action_56 (75) = happyShift action_39
-action_56 (80) = happyShift action_40
-action_56 (81) = happyShift action_41
-action_56 (82) = happyShift action_42
-action_56 (83) = happyShift action_43
-action_56 (84) = happyShift action_44
-action_56 (87) = happyShift action_45
-action_56 (88) = happyShift action_46
-action_56 (89) = happyShift action_24
-action_56 (26) = happyGoto action_29
-action_56 (45) = happyGoto action_109
-action_56 (46) = happyGoto action_31
-action_56 (47) = happyGoto action_32
+action_56 (92) = happyAccept
 action_56 _ = happyFail (happyExpListPerState 56)
 
-action_57 (50) = happyShift action_34
-action_57 (58) = happyShift action_35
-action_57 (59) = happyShift action_36
-action_57 (67) = happyShift action_37
-action_57 (73) = happyShift action_38
-action_57 (75) = happyShift action_39
-action_57 (80) = happyShift action_40
-action_57 (81) = happyShift action_41
-action_57 (82) = happyShift action_42
-action_57 (83) = happyShift action_43
-action_57 (84) = happyShift action_44
-action_57 (87) = happyShift action_45
-action_57 (88) = happyShift action_46
-action_57 (89) = happyShift action_24
-action_57 (26) = happyGoto action_29
-action_57 (45) = happyGoto action_108
-action_57 (46) = happyGoto action_31
-action_57 (47) = happyGoto action_32
+action_57 (52) = happyShift action_115
 action_57 _ = happyFail (happyExpListPerState 57)
 
-action_58 (89) = happyShift action_24
-action_58 (26) = happyGoto action_107
-action_58 _ = happyFail (happyExpListPerState 58)
+action_58 (58) = happyShift action_114
+action_58 _ = happyReduce_55
 
-action_59 (89) = happyShift action_24
-action_59 (26) = happyGoto action_106
+action_59 (92) = happyAccept
 action_59 _ = happyFail (happyExpListPerState 59)
 
-action_60 (89) = happyShift action_24
-action_60 (26) = happyGoto action_105
+action_60 (52) = happyShift action_35
+action_60 (60) = happyShift action_36
+action_60 (61) = happyShift action_37
+action_60 (69) = happyShift action_38
+action_60 (75) = happyShift action_39
+action_60 (77) = happyShift action_40
+action_60 (82) = happyShift action_41
+action_60 (83) = happyShift action_42
+action_60 (84) = happyShift action_43
+action_60 (85) = happyShift action_44
+action_60 (86) = happyShift action_45
+action_60 (89) = happyShift action_46
+action_60 (90) = happyShift action_47
+action_60 (91) = happyShift action_25
+action_60 (27) = happyGoto action_30
+action_60 (46) = happyGoto action_113
+action_60 (48) = happyGoto action_32
+action_60 (49) = happyGoto action_33
 action_60 _ = happyFail (happyExpListPerState 60)
 
-action_61 (63) = happyShift action_104
+action_61 (52) = happyShift action_35
+action_61 (60) = happyShift action_36
+action_61 (61) = happyShift action_37
+action_61 (69) = happyShift action_38
+action_61 (75) = happyShift action_39
+action_61 (77) = happyShift action_40
+action_61 (82) = happyShift action_41
+action_61 (83) = happyShift action_42
+action_61 (84) = happyShift action_43
+action_61 (85) = happyShift action_44
+action_61 (86) = happyShift action_45
+action_61 (89) = happyShift action_46
+action_61 (90) = happyShift action_47
+action_61 (91) = happyShift action_25
+action_61 (27) = happyGoto action_30
+action_61 (46) = happyGoto action_112
+action_61 (48) = happyGoto action_32
+action_61 (49) = happyGoto action_33
 action_61 _ = happyFail (happyExpListPerState 61)
 
-action_62 (90) = happyAccept
+action_62 (91) = happyShift action_25
+action_62 (27) = happyGoto action_111
 action_62 _ = happyFail (happyExpListPerState 62)
 
-action_63 (56) = happyShift action_103
+action_63 (91) = happyShift action_25
+action_63 (27) = happyGoto action_110
 action_63 _ = happyFail (happyExpListPerState 63)
 
-action_64 (90) = happyAccept
+action_64 (91) = happyShift action_25
+action_64 (27) = happyGoto action_109
 action_64 _ = happyFail (happyExpListPerState 64)
 
-action_65 (89) = happyShift action_24
-action_65 (26) = happyGoto action_102
+action_65 (65) = happyShift action_108
 action_65 _ = happyFail (happyExpListPerState 65)
 
-action_66 (90) = happyAccept
+action_66 (92) = happyAccept
 action_66 _ = happyFail (happyExpListPerState 66)
 
-action_67 (50) = happyShift action_69
-action_67 (37) = happyGoto action_67
-action_67 (38) = happyGoto action_101
-action_67 _ = happyReduce_42
+action_67 (58) = happyShift action_107
+action_67 _ = happyFail (happyExpListPerState 67)
 
-action_68 (90) = happyAccept
+action_68 (92) = happyAccept
 action_68 _ = happyFail (happyExpListPerState 68)
 
-action_69 (89) = happyShift action_24
-action_69 (26) = happyGoto action_100
+action_69 (91) = happyShift action_25
+action_69 (27) = happyGoto action_106
 action_69 _ = happyFail (happyExpListPerState 69)
 
-action_70 (90) = happyAccept
+action_70 (92) = happyAccept
 action_70 _ = happyFail (happyExpListPerState 70)
 
-action_71 (90) = happyAccept
-action_71 _ = happyFail (happyExpListPerState 71)
+action_71 (52) = happyShift action_73
+action_71 (38) = happyGoto action_71
+action_71 (39) = happyGoto action_105
+action_71 _ = happyReduce_43
 
-action_72 (89) = happyShift action_24
-action_72 (26) = happyGoto action_99
+action_72 (92) = happyAccept
 action_72 _ = happyFail (happyExpListPerState 72)
 
-action_73 (55) = happyShift action_98
+action_73 (91) = happyShift action_25
+action_73 (27) = happyGoto action_104
 action_73 _ = happyFail (happyExpListPerState 73)
 
-action_74 (52) = happyShift action_97
-action_74 _ = happyReduce_37
+action_74 (92) = happyAccept
+action_74 _ = happyFail (happyExpListPerState 74)
 
-action_75 (90) = happyAccept
+action_75 (92) = happyAccept
 action_75 _ = happyFail (happyExpListPerState 75)
 
-action_76 (90) = happyAccept
+action_76 (91) = happyShift action_25
+action_76 (27) = happyGoto action_103
 action_76 _ = happyFail (happyExpListPerState 76)
 
-action_77 (90) = happyAccept
+action_77 (57) = happyShift action_102
 action_77 _ = happyFail (happyExpListPerState 77)
 
-action_78 (77) = happyShift action_96
-action_78 _ = happyFail (happyExpListPerState 78)
+action_78 (54) = happyShift action_101
+action_78 _ = happyReduce_38
 
-action_79 (66) = happyShift action_81
-action_79 (31) = happyGoto action_79
-action_79 (32) = happyGoto action_95
-action_79 _ = happyReduce_31
+action_79 (92) = happyAccept
+action_79 _ = happyFail (happyExpListPerState 79)
 
-action_80 (90) = happyAccept
+action_80 (92) = happyAccept
 action_80 _ = happyFail (happyExpListPerState 80)
 
-action_81 (89) = happyShift action_24
-action_81 (26) = happyGoto action_94
+action_81 (92) = happyAccept
 action_81 _ = happyFail (happyExpListPerState 81)
 
-action_82 (90) = happyAccept
+action_82 (79) = happyShift action_100
 action_82 _ = happyFail (happyExpListPerState 82)
 
-action_83 (90) = happyAccept
-action_83 _ = happyFail (happyExpListPerState 83)
+action_83 (68) = happyShift action_85
+action_83 (32) = happyGoto action_83
+action_83 (33) = happyGoto action_99
+action_83 _ = happyReduce_32
 
-action_84 (89) = happyShift action_24
-action_84 (26) = happyGoto action_93
+action_84 (92) = happyAccept
 action_84 _ = happyFail (happyExpListPerState 84)
 
-action_85 (90) = happyAccept
+action_85 (91) = happyShift action_25
+action_85 (27) = happyGoto action_98
 action_85 _ = happyFail (happyExpListPerState 85)
 
-action_86 _ = happyReduce_27
+action_86 (92) = happyAccept
+action_86 _ = happyFail (happyExpListPerState 86)
 
-action_87 _ = happyReduce_28
+action_87 (92) = happyAccept
+action_87 _ = happyFail (happyExpListPerState 87)
 
-action_88 (90) = happyAccept
+action_88 (91) = happyShift action_25
+action_88 (27) = happyGoto action_97
 action_88 _ = happyFail (happyExpListPerState 88)
 
-action_89 (68) = happyShift action_84
-action_89 (74) = happyShift action_72
-action_89 (28) = happyGoto action_92
-action_89 (29) = happyGoto action_89
-action_89 (30) = happyGoto action_86
-action_89 (36) = happyGoto action_87
-action_89 _ = happyReduce_25
+action_89 (92) = happyAccept
+action_89 _ = happyFail (happyExpListPerState 89)
 
-action_90 (90) = happyAccept
-action_90 _ = happyFail (happyExpListPerState 90)
+action_90 _ = happyReduce_28
 
-action_91 _ = happyReduce_24
+action_91 _ = happyReduce_29
 
-action_92 _ = happyReduce_26
+action_92 (92) = happyAccept
+action_92 _ = happyFail (happyExpListPerState 92)
 
-action_93 (66) = happyShift action_81
-action_93 (31) = happyGoto action_79
-action_93 (32) = happyGoto action_154
-action_93 _ = happyReduce_31
+action_93 (70) = happyShift action_88
+action_93 (76) = happyShift action_76
+action_93 (29) = happyGoto action_96
+action_93 (30) = happyGoto action_93
+action_93 (31) = happyGoto action_90
+action_93 (37) = happyGoto action_91
+action_93 _ = happyReduce_26
 
-action_94 (53) = happyShift action_78
-action_94 (33) = happyGoto action_153
-action_94 _ = happyReduce_33
+action_94 (92) = happyAccept
+action_94 _ = happyFail (happyExpListPerState 94)
 
-action_95 _ = happyReduce_32
+action_95 _ = happyReduce_25
 
-action_96 (89) = happyShift action_24
-action_96 (26) = happyGoto action_73
-action_96 (34) = happyGoto action_74
-action_96 (35) = happyGoto action_152
-action_96 _ = happyReduce_36
+action_96 _ = happyReduce_27
 
-action_97 (89) = happyShift action_24
-action_97 (26) = happyGoto action_73
-action_97 (34) = happyGoto action_74
-action_97 (35) = happyGoto action_151
-action_97 _ = happyReduce_36
+action_97 (68) = happyShift action_85
+action_97 (32) = happyGoto action_83
+action_97 (33) = happyGoto action_161
+action_97 _ = happyReduce_32
 
-action_98 (50) = happyShift action_34
-action_98 (58) = happyShift action_35
-action_98 (59) = happyShift action_36
-action_98 (67) = happyShift action_37
-action_98 (73) = happyShift action_38
-action_98 (75) = happyShift action_39
-action_98 (80) = happyShift action_40
-action_98 (81) = happyShift action_41
-action_98 (82) = happyShift action_42
-action_98 (83) = happyShift action_43
-action_98 (84) = happyShift action_44
-action_98 (87) = happyShift action_45
-action_98 (88) = happyShift action_46
-action_98 (89) = happyShift action_24
-action_98 (26) = happyGoto action_29
-action_98 (45) = happyGoto action_150
-action_98 (46) = happyGoto action_31
-action_98 (47) = happyGoto action_32
-action_98 _ = happyFail (happyExpListPerState 98)
+action_98 (55) = happyShift action_82
+action_98 (34) = happyGoto action_160
+action_98 _ = happyReduce_34
 
-action_99 (66) = happyShift action_81
-action_99 (31) = happyGoto action_79
-action_99 (32) = happyGoto action_149
-action_99 _ = happyReduce_31
+action_99 _ = happyReduce_33
 
-action_100 (54) = happyShift action_148
-action_100 _ = happyFail (happyExpListPerState 100)
+action_100 (91) = happyShift action_25
+action_100 (27) = happyGoto action_77
+action_100 (35) = happyGoto action_78
+action_100 (36) = happyGoto action_159
+action_100 _ = happyReduce_37
 
-action_101 _ = happyReduce_43
+action_101 (91) = happyShift action_25
+action_101 (27) = happyGoto action_77
+action_101 (35) = happyGoto action_78
+action_101 (36) = happyGoto action_158
+action_101 _ = happyReduce_37
 
-action_102 _ = happyReduce_44
+action_102 (52) = happyShift action_35
+action_102 (60) = happyShift action_36
+action_102 (61) = happyShift action_37
+action_102 (69) = happyShift action_38
+action_102 (75) = happyShift action_39
+action_102 (77) = happyShift action_40
+action_102 (82) = happyShift action_41
+action_102 (83) = happyShift action_42
+action_102 (84) = happyShift action_43
+action_102 (85) = happyShift action_44
+action_102 (86) = happyShift action_45
+action_102 (89) = happyShift action_46
+action_102 (90) = happyShift action_47
+action_102 (91) = happyShift action_25
+action_102 (27) = happyGoto action_30
+action_102 (46) = happyGoto action_157
+action_102 (48) = happyGoto action_32
+action_102 (49) = happyGoto action_33
+action_102 _ = happyFail (happyExpListPerState 102)
 
-action_103 (64) = happyShift action_65
-action_103 (39) = happyGoto action_63
-action_103 (40) = happyGoto action_147
-action_103 _ = happyReduce_45
+action_103 (68) = happyShift action_85
+action_103 (32) = happyGoto action_83
+action_103 (33) = happyGoto action_156
+action_103 _ = happyReduce_32
 
-action_104 (89) = happyShift action_24
-action_104 (26) = happyGoto action_146
+action_104 (56) = happyShift action_155
 action_104 _ = happyFail (happyExpListPerState 104)
 
-action_105 _ = happyReduce_50
+action_105 _ = happyReduce_44
 
-action_106 (76) = happyShift action_145
-action_106 _ = happyFail (happyExpListPerState 106)
+action_106 _ = happyReduce_45
 
-action_107 (71) = happyShift action_53
-action_107 (43) = happyGoto action_144
-action_107 _ = happyReduce_56
+action_107 (66) = happyShift action_69
+action_107 (40) = happyGoto action_67
+action_107 (41) = happyGoto action_154
+action_107 _ = happyReduce_46
 
-action_108 _ = happyReduce_52
+action_108 (91) = happyShift action_25
+action_108 (27) = happyGoto action_153
+action_108 _ = happyFail (happyExpListPerState 108)
 
-action_109 (54) = happyShift action_143
-action_109 _ = happyFail (happyExpListPerState 109)
+action_109 _ = happyReduce_51
 
-action_110 (61) = happyShift action_56
-action_110 (62) = happyShift action_57
-action_110 (63) = happyShift action_58
-action_110 (69) = happyShift action_59
-action_110 (70) = happyShift action_60
-action_110 (72) = happyShift action_61
-action_110 (41) = happyGoto action_54
-action_110 (42) = happyGoto action_142
-action_110 _ = happyReduce_53
+action_110 (78) = happyShift action_152
+action_110 _ = happyFail (happyExpListPerState 110)
 
-action_111 (89) = happyShift action_24
-action_111 (26) = happyGoto action_50
-action_111 (44) = happyGoto action_141
-action_111 _ = happyReduce_58
+action_111 (73) = happyShift action_57
+action_111 (44) = happyGoto action_151
+action_111 _ = happyReduce_57
 
-action_112 (89) = happyShift action_24
-action_112 (26) = happyGoto action_50
-action_112 (44) = happyGoto action_140
-action_112 _ = happyReduce_58
+action_112 _ = happyReduce_53
 
-action_113 _ = happyReduce_68
+action_113 (56) = happyShift action_150
+action_113 _ = happyFail (happyExpListPerState 113)
 
-action_114 _ = happyReduce_71
+action_114 (63) = happyShift action_60
+action_114 (64) = happyShift action_61
+action_114 (65) = happyShift action_62
+action_114 (71) = happyShift action_63
+action_114 (72) = happyShift action_64
+action_114 (74) = happyShift action_65
+action_114 (42) = happyGoto action_58
+action_114 (43) = happyGoto action_149
+action_114 _ = happyReduce_54
 
-action_115 _ = happyReduce_70
+action_115 (91) = happyShift action_25
+action_115 (27) = happyGoto action_54
+action_115 (45) = happyGoto action_148
+action_115 _ = happyReduce_59
 
-action_116 (86) = happyShift action_139
-action_116 _ = happyFail (happyExpListPerState 116)
+action_116 (91) = happyShift action_25
+action_116 (27) = happyGoto action_54
+action_116 (45) = happyGoto action_147
+action_116 _ = happyReduce_59
 
-action_117 (50) = happyShift action_27
-action_117 (60) = happyShift action_28
-action_117 (89) = happyShift action_24
-action_117 (26) = happyGoto action_25
-action_117 (49) = happyGoto action_138
-action_117 _ = happyFail (happyExpListPerState 117)
+action_117 _ = happyReduce_73
 
-action_118 (50) = happyShift action_27
-action_118 (60) = happyShift action_28
-action_118 (89) = happyShift action_24
-action_118 (26) = happyGoto action_25
-action_118 (49) = happyGoto action_137
-action_118 _ = happyFail (happyExpListPerState 118)
+action_118 _ = happyReduce_74
 
-action_119 (50) = happyShift action_34
-action_119 (58) = happyShift action_35
-action_119 (59) = happyShift action_36
-action_119 (67) = happyShift action_37
-action_119 (73) = happyShift action_38
-action_119 (75) = happyShift action_39
-action_119 (80) = happyShift action_40
-action_119 (81) = happyShift action_41
-action_119 (82) = happyShift action_42
-action_119 (83) = happyShift action_43
-action_119 (84) = happyShift action_44
-action_119 (87) = happyShift action_45
-action_119 (88) = happyShift action_46
-action_119 (89) = happyShift action_24
-action_119 (26) = happyGoto action_29
-action_119 (45) = happyGoto action_136
-action_119 (46) = happyGoto action_31
-action_119 (47) = happyGoto action_32
-action_119 _ = happyFail (happyExpListPerState 119)
+action_119 _ = happyReduce_75
 
-action_120 (57) = happyShift action_135
-action_120 _ = happyFail (happyExpListPerState 120)
+action_120 _ = happyReduce_78
 
-action_121 (50) = happyShift action_34
-action_121 (58) = happyShift action_35
-action_121 (59) = happyShift action_36
-action_121 (67) = happyShift action_37
-action_121 (73) = happyShift action_38
-action_121 (75) = happyShift action_39
-action_121 (80) = happyShift action_40
-action_121 (81) = happyShift action_41
-action_121 (82) = happyShift action_42
-action_121 (83) = happyShift action_43
-action_121 (84) = happyShift action_44
-action_121 (87) = happyShift action_45
-action_121 (88) = happyShift action_46
-action_121 (89) = happyShift action_24
-action_121 (26) = happyGoto action_29
-action_121 (45) = happyGoto action_134
-action_121 (46) = happyGoto action_31
-action_121 (47) = happyGoto action_32
-action_121 _ = happyFail (happyExpListPerState 121)
+action_121 _ = happyReduce_77
 
-action_122 (50) = happyShift action_34
-action_122 (58) = happyShift action_35
-action_122 (59) = happyShift action_36
-action_122 (67) = happyShift action_37
-action_122 (73) = happyShift action_38
-action_122 (75) = happyShift action_39
-action_122 (80) = happyShift action_40
-action_122 (81) = happyShift action_41
-action_122 (82) = happyShift action_42
-action_122 (83) = happyShift action_43
-action_122 (84) = happyShift action_44
-action_122 (87) = happyShift action_45
-action_122 (88) = happyShift action_46
-action_122 (89) = happyShift action_24
-action_122 (26) = happyGoto action_29
-action_122 (45) = happyGoto action_133
-action_122 (46) = happyGoto action_31
-action_122 (47) = happyGoto action_32
+action_122 (52) = happyShift action_28
+action_122 (62) = happyShift action_29
+action_122 (88) = happyShift action_146
+action_122 (91) = happyShift action_25
+action_122 (27) = happyGoto action_26
+action_122 (51) = happyGoto action_145
 action_122 _ = happyFail (happyExpListPerState 122)
 
-action_123 (51) = happyShift action_130
-action_123 (52) = happyShift action_131
-action_123 (54) = happyShift action_132
+action_123 (52) = happyShift action_28
+action_123 (62) = happyShift action_29
+action_123 (91) = happyShift action_25
+action_123 (27) = happyGoto action_26
+action_123 (51) = happyGoto action_144
 action_123 _ = happyFail (happyExpListPerState 123)
 
-action_124 (50) = happyShift action_34
-action_124 (58) = happyShift action_35
-action_124 (59) = happyShift action_36
-action_124 (67) = happyShift action_37
-action_124 (73) = happyShift action_38
-action_124 (75) = happyShift action_39
-action_124 (80) = happyShift action_40
-action_124 (81) = happyShift action_41
-action_124 (82) = happyShift action_42
-action_124 (83) = happyShift action_43
-action_124 (84) = happyShift action_44
-action_124 (87) = happyShift action_45
-action_124 (88) = happyShift action_46
-action_124 (89) = happyShift action_24
-action_124 (26) = happyGoto action_29
-action_124 (45) = happyGoto action_129
-action_124 (46) = happyGoto action_31
-action_124 (47) = happyGoto action_32
+action_124 (52) = happyShift action_28
+action_124 (62) = happyShift action_29
+action_124 (91) = happyShift action_25
+action_124 (27) = happyGoto action_26
+action_124 (51) = happyGoto action_143
 action_124 _ = happyFail (happyExpListPerState 124)
 
-action_125 (50) = happyShift action_34
-action_125 (58) = happyShift action_35
-action_125 (59) = happyShift action_36
-action_125 (67) = happyShift action_37
-action_125 (73) = happyShift action_38
+action_125 (52) = happyShift action_35
+action_125 (60) = happyShift action_36
+action_125 (61) = happyShift action_37
+action_125 (69) = happyShift action_38
 action_125 (75) = happyShift action_39
-action_125 (80) = happyShift action_40
-action_125 (81) = happyShift action_41
-action_125 (82) = happyShift action_42
-action_125 (83) = happyShift action_43
-action_125 (84) = happyShift action_44
-action_125 (87) = happyShift action_45
-action_125 (88) = happyShift action_46
-action_125 (89) = happyShift action_24
-action_125 (26) = happyGoto action_29
-action_125 (45) = happyGoto action_128
-action_125 (46) = happyGoto action_31
-action_125 (47) = happyGoto action_32
+action_125 (77) = happyShift action_40
+action_125 (82) = happyShift action_41
+action_125 (83) = happyShift action_42
+action_125 (84) = happyShift action_43
+action_125 (85) = happyShift action_44
+action_125 (86) = happyShift action_45
+action_125 (89) = happyShift action_46
+action_125 (90) = happyShift action_47
+action_125 (91) = happyShift action_25
+action_125 (27) = happyGoto action_30
+action_125 (46) = happyGoto action_142
+action_125 (48) = happyGoto action_32
+action_125 (49) = happyGoto action_33
 action_125 _ = happyFail (happyExpListPerState 125)
 
-action_126 (52) = happyShift action_127
+action_126 (59) = happyShift action_141
 action_126 _ = happyFail (happyExpListPerState 126)
 
-action_127 (50) = happyShift action_27
-action_127 (60) = happyShift action_28
-action_127 (89) = happyShift action_24
-action_127 (26) = happyGoto action_25
-action_127 (49) = happyGoto action_173
+action_127 (52) = happyShift action_35
+action_127 (60) = happyShift action_36
+action_127 (61) = happyShift action_37
+action_127 (69) = happyShift action_38
+action_127 (75) = happyShift action_39
+action_127 (77) = happyShift action_40
+action_127 (82) = happyShift action_41
+action_127 (83) = happyShift action_42
+action_127 (84) = happyShift action_43
+action_127 (85) = happyShift action_44
+action_127 (86) = happyShift action_45
+action_127 (89) = happyShift action_46
+action_127 (90) = happyShift action_47
+action_127 (91) = happyShift action_25
+action_127 (27) = happyGoto action_30
+action_127 (46) = happyGoto action_140
+action_127 (48) = happyGoto action_32
+action_127 (49) = happyGoto action_33
 action_127 _ = happyFail (happyExpListPerState 127)
 
-action_128 _ = happyReduce_65
+action_128 (52) = happyShift action_35
+action_128 (60) = happyShift action_36
+action_128 (61) = happyShift action_37
+action_128 (69) = happyShift action_38
+action_128 (75) = happyShift action_39
+action_128 (77) = happyShift action_40
+action_128 (82) = happyShift action_41
+action_128 (83) = happyShift action_42
+action_128 (84) = happyShift action_43
+action_128 (85) = happyShift action_44
+action_128 (86) = happyShift action_45
+action_128 (89) = happyShift action_46
+action_128 (90) = happyShift action_47
+action_128 (91) = happyShift action_25
+action_128 (27) = happyGoto action_30
+action_128 (46) = happyGoto action_139
+action_128 (48) = happyGoto action_32
+action_128 (49) = happyGoto action_33
+action_128 _ = happyFail (happyExpListPerState 128)
 
-action_129 _ = happyReduce_66
+action_129 (53) = happyShift action_136
+action_129 (54) = happyShift action_137
+action_129 (56) = happyShift action_138
+action_129 _ = happyFail (happyExpListPerState 129)
 
-action_130 _ = happyReduce_81
+action_130 (52) = happyShift action_35
+action_130 (60) = happyShift action_36
+action_130 (61) = happyShift action_37
+action_130 (69) = happyShift action_38
+action_130 (75) = happyShift action_39
+action_130 (77) = happyShift action_40
+action_130 (82) = happyShift action_41
+action_130 (83) = happyShift action_42
+action_130 (84) = happyShift action_43
+action_130 (85) = happyShift action_44
+action_130 (86) = happyShift action_45
+action_130 (89) = happyShift action_46
+action_130 (90) = happyShift action_47
+action_130 (91) = happyShift action_25
+action_130 (27) = happyGoto action_30
+action_130 (46) = happyGoto action_135
+action_130 (48) = happyGoto action_32
+action_130 (49) = happyGoto action_33
+action_130 _ = happyFail (happyExpListPerState 130)
 
-action_131 (50) = happyShift action_34
-action_131 (58) = happyShift action_35
-action_131 (59) = happyShift action_36
-action_131 (67) = happyShift action_37
-action_131 (73) = happyShift action_38
+action_131 (52) = happyShift action_35
+action_131 (60) = happyShift action_36
+action_131 (61) = happyShift action_37
+action_131 (69) = happyShift action_38
 action_131 (75) = happyShift action_39
-action_131 (80) = happyShift action_40
-action_131 (81) = happyShift action_41
-action_131 (82) = happyShift action_42
-action_131 (83) = happyShift action_43
-action_131 (84) = happyShift action_44
-action_131 (87) = happyShift action_45
-action_131 (88) = happyShift action_46
-action_131 (89) = happyShift action_24
-action_131 (26) = happyGoto action_29
-action_131 (45) = happyGoto action_172
-action_131 (46) = happyGoto action_31
-action_131 (47) = happyGoto action_32
+action_131 (77) = happyShift action_40
+action_131 (82) = happyShift action_41
+action_131 (83) = happyShift action_42
+action_131 (84) = happyShift action_43
+action_131 (85) = happyShift action_44
+action_131 (86) = happyShift action_45
+action_131 (89) = happyShift action_46
+action_131 (90) = happyShift action_47
+action_131 (91) = happyShift action_25
+action_131 (27) = happyGoto action_30
+action_131 (46) = happyGoto action_134
+action_131 (48) = happyGoto action_32
+action_131 (49) = happyGoto action_33
 action_131 _ = happyFail (happyExpListPerState 131)
 
-action_132 (50) = happyShift action_34
-action_132 (58) = happyShift action_35
-action_132 (59) = happyShift action_36
-action_132 (67) = happyShift action_37
-action_132 (73) = happyShift action_38
-action_132 (75) = happyShift action_39
-action_132 (80) = happyShift action_40
-action_132 (81) = happyShift action_41
-action_132 (82) = happyShift action_42
-action_132 (83) = happyShift action_43
-action_132 (84) = happyShift action_44
-action_132 (87) = happyShift action_45
-action_132 (88) = happyShift action_46
-action_132 (89) = happyShift action_24
-action_132 (26) = happyGoto action_29
-action_132 (45) = happyGoto action_171
-action_132 (46) = happyGoto action_31
-action_132 (47) = happyGoto action_32
+action_132 (54) = happyShift action_133
 action_132 _ = happyFail (happyExpListPerState 132)
 
-action_133 (52) = happyShift action_170
+action_133 (52) = happyShift action_28
+action_133 (62) = happyShift action_29
+action_133 (91) = happyShift action_25
+action_133 (27) = happyGoto action_26
+action_133 (51) = happyGoto action_182
 action_133 _ = happyFail (happyExpListPerState 133)
 
-action_134 (52) = happyShift action_169
-action_134 _ = happyFail (happyExpListPerState 134)
+action_134 _ = happyReduce_70
 
-action_135 (50) = happyShift action_34
-action_135 (58) = happyShift action_35
-action_135 (59) = happyShift action_36
-action_135 (67) = happyShift action_37
-action_135 (73) = happyShift action_38
-action_135 (75) = happyShift action_39
-action_135 (80) = happyShift action_40
-action_135 (81) = happyShift action_41
-action_135 (82) = happyShift action_42
-action_135 (83) = happyShift action_43
-action_135 (84) = happyShift action_44
-action_135 (87) = happyShift action_45
-action_135 (88) = happyShift action_46
-action_135 (89) = happyShift action_24
-action_135 (26) = happyGoto action_29
-action_135 (45) = happyGoto action_168
-action_135 (46) = happyGoto action_31
-action_135 (47) = happyGoto action_32
-action_135 _ = happyFail (happyExpListPerState 135)
+action_135 _ = happyReduce_71
 
-action_136 (51) = happyShift action_167
-action_136 _ = happyFail (happyExpListPerState 136)
+action_136 _ = happyReduce_88
 
-action_137 (54) = happyShift action_166
+action_137 (52) = happyShift action_35
+action_137 (60) = happyShift action_36
+action_137 (61) = happyShift action_37
+action_137 (69) = happyShift action_38
+action_137 (75) = happyShift action_39
+action_137 (77) = happyShift action_40
+action_137 (82) = happyShift action_41
+action_137 (83) = happyShift action_42
+action_137 (84) = happyShift action_43
+action_137 (85) = happyShift action_44
+action_137 (86) = happyShift action_45
+action_137 (89) = happyShift action_46
+action_137 (90) = happyShift action_47
+action_137 (91) = happyShift action_25
+action_137 (27) = happyGoto action_30
+action_137 (46) = happyGoto action_181
+action_137 (48) = happyGoto action_32
+action_137 (49) = happyGoto action_33
 action_137 _ = happyFail (happyExpListPerState 137)
 
-action_138 (54) = happyShift action_165
+action_138 (52) = happyShift action_35
+action_138 (60) = happyShift action_36
+action_138 (61) = happyShift action_37
+action_138 (69) = happyShift action_38
+action_138 (75) = happyShift action_39
+action_138 (77) = happyShift action_40
+action_138 (82) = happyShift action_41
+action_138 (83) = happyShift action_42
+action_138 (84) = happyShift action_43
+action_138 (85) = happyShift action_44
+action_138 (86) = happyShift action_45
+action_138 (89) = happyShift action_46
+action_138 (90) = happyShift action_47
+action_138 (91) = happyShift action_25
+action_138 (27) = happyGoto action_30
+action_138 (46) = happyGoto action_180
+action_138 (48) = happyGoto action_32
+action_138 (49) = happyGoto action_33
 action_138 _ = happyFail (happyExpListPerState 138)
 
-action_139 (50) = happyShift action_34
-action_139 (58) = happyShift action_35
-action_139 (59) = happyShift action_36
-action_139 (67) = happyShift action_37
-action_139 (73) = happyShift action_38
-action_139 (75) = happyShift action_39
-action_139 (80) = happyShift action_40
-action_139 (81) = happyShift action_41
-action_139 (82) = happyShift action_42
-action_139 (83) = happyShift action_43
-action_139 (84) = happyShift action_44
-action_139 (87) = happyShift action_45
-action_139 (88) = happyShift action_46
-action_139 (89) = happyShift action_24
-action_139 (26) = happyGoto action_29
-action_139 (45) = happyGoto action_30
-action_139 (46) = happyGoto action_31
-action_139 (47) = happyGoto action_32
-action_139 (48) = happyGoto action_164
+action_139 (54) = happyShift action_179
 action_139 _ = happyFail (happyExpListPerState 139)
 
-action_140 _ = happyReduce_60
+action_140 (54) = happyShift action_178
+action_140 _ = happyFail (happyExpListPerState 140)
 
-action_141 (51) = happyShift action_163
+action_141 (52) = happyShift action_35
+action_141 (60) = happyShift action_36
+action_141 (61) = happyShift action_37
+action_141 (69) = happyShift action_38
+action_141 (75) = happyShift action_39
+action_141 (77) = happyShift action_40
+action_141 (82) = happyShift action_41
+action_141 (83) = happyShift action_42
+action_141 (84) = happyShift action_43
+action_141 (85) = happyShift action_44
+action_141 (86) = happyShift action_45
+action_141 (89) = happyShift action_46
+action_141 (90) = happyShift action_47
+action_141 (91) = happyShift action_25
+action_141 (27) = happyGoto action_30
+action_141 (46) = happyGoto action_177
+action_141 (48) = happyGoto action_32
+action_141 (49) = happyGoto action_33
 action_141 _ = happyFail (happyExpListPerState 141)
 
-action_142 _ = happyReduce_55
+action_142 (53) = happyShift action_176
+action_142 _ = happyFail (happyExpListPerState 142)
 
-action_143 (50) = happyShift action_34
-action_143 (58) = happyShift action_35
-action_143 (59) = happyShift action_36
-action_143 (67) = happyShift action_37
-action_143 (73) = happyShift action_38
-action_143 (75) = happyShift action_39
-action_143 (80) = happyShift action_40
-action_143 (81) = happyShift action_41
-action_143 (82) = happyShift action_42
-action_143 (83) = happyShift action_43
-action_143 (84) = happyShift action_44
-action_143 (87) = happyShift action_45
-action_143 (88) = happyShift action_46
-action_143 (89) = happyShift action_24
-action_143 (26) = happyGoto action_29
-action_143 (45) = happyGoto action_162
-action_143 (46) = happyGoto action_31
-action_143 (47) = happyGoto action_32
+action_143 (52) = happyShift action_28
+action_143 (56) = happyShift action_175
+action_143 (62) = happyShift action_29
+action_143 (91) = happyShift action_25
+action_143 (27) = happyGoto action_26
+action_143 (51) = happyGoto action_174
 action_143 _ = happyFail (happyExpListPerState 143)
 
-action_144 (54) = happyShift action_161
+action_144 (56) = happyShift action_173
 action_144 _ = happyFail (happyExpListPerState 144)
 
-action_145 (77) = happyShift action_160
+action_145 (52) = happyShift action_28
+action_145 (62) = happyShift action_29
+action_145 (88) = happyShift action_52
+action_145 (91) = happyShift action_25
+action_145 (27) = happyGoto action_26
+action_145 (47) = happyGoto action_172
+action_145 (51) = happyGoto action_51
 action_145 _ = happyFail (happyExpListPerState 145)
 
-action_146 (71) = happyShift action_53
-action_146 (43) = happyGoto action_159
-action_146 _ = happyReduce_56
+action_146 (52) = happyShift action_35
+action_146 (60) = happyShift action_36
+action_146 (61) = happyShift action_37
+action_146 (69) = happyShift action_38
+action_146 (75) = happyShift action_39
+action_146 (77) = happyShift action_40
+action_146 (82) = happyShift action_41
+action_146 (83) = happyShift action_42
+action_146 (84) = happyShift action_43
+action_146 (85) = happyShift action_44
+action_146 (86) = happyShift action_45
+action_146 (89) = happyShift action_46
+action_146 (90) = happyShift action_47
+action_146 (91) = happyShift action_25
+action_146 (27) = happyGoto action_30
+action_146 (46) = happyGoto action_31
+action_146 (48) = happyGoto action_32
+action_146 (49) = happyGoto action_33
+action_146 (50) = happyGoto action_171
+action_146 _ = happyFail (happyExpListPerState 146)
 
-action_147 _ = happyReduce_46
+action_147 _ = happyReduce_61
 
-action_148 (50) = happyShift action_34
-action_148 (58) = happyShift action_35
-action_148 (59) = happyShift action_36
-action_148 (67) = happyShift action_37
-action_148 (73) = happyShift action_38
-action_148 (75) = happyShift action_39
-action_148 (80) = happyShift action_40
-action_148 (81) = happyShift action_41
-action_148 (82) = happyShift action_42
-action_148 (83) = happyShift action_43
-action_148 (84) = happyShift action_44
-action_148 (87) = happyShift action_45
-action_148 (88) = happyShift action_46
-action_148 (89) = happyShift action_24
-action_148 (26) = happyGoto action_29
-action_148 (45) = happyGoto action_158
-action_148 (46) = happyGoto action_31
-action_148 (47) = happyGoto action_32
+action_148 (53) = happyShift action_170
 action_148 _ = happyFail (happyExpListPerState 148)
 
-action_149 (50) = happyShift action_69
-action_149 (37) = happyGoto action_67
-action_149 (38) = happyGoto action_157
-action_149 _ = happyReduce_42
+action_149 _ = happyReduce_56
 
-action_150 _ = happyReduce_35
+action_150 (52) = happyShift action_35
+action_150 (60) = happyShift action_36
+action_150 (61) = happyShift action_37
+action_150 (69) = happyShift action_38
+action_150 (75) = happyShift action_39
+action_150 (77) = happyShift action_40
+action_150 (82) = happyShift action_41
+action_150 (83) = happyShift action_42
+action_150 (84) = happyShift action_43
+action_150 (85) = happyShift action_44
+action_150 (86) = happyShift action_45
+action_150 (89) = happyShift action_46
+action_150 (90) = happyShift action_47
+action_150 (91) = happyShift action_25
+action_150 (27) = happyGoto action_30
+action_150 (46) = happyGoto action_169
+action_150 (48) = happyGoto action_32
+action_150 (49) = happyGoto action_33
+action_150 _ = happyFail (happyExpListPerState 150)
 
-action_151 _ = happyReduce_38
+action_151 (56) = happyShift action_168
+action_151 _ = happyFail (happyExpListPerState 151)
 
-action_152 (78) = happyShift action_156
+action_152 (79) = happyShift action_167
 action_152 _ = happyFail (happyExpListPerState 152)
 
-action_153 _ = happyReduce_30
+action_153 (73) = happyShift action_57
+action_153 (44) = happyGoto action_166
+action_153 _ = happyReduce_57
 
-action_154 (50) = happyShift action_69
-action_154 (37) = happyGoto action_67
-action_154 (38) = happyGoto action_155
-action_154 _ = happyReduce_42
+action_154 _ = happyReduce_47
 
-action_155 (56) = happyShift action_188
+action_155 (52) = happyShift action_35
+action_155 (60) = happyShift action_36
+action_155 (61) = happyShift action_37
+action_155 (69) = happyShift action_38
+action_155 (75) = happyShift action_39
+action_155 (77) = happyShift action_40
+action_155 (82) = happyShift action_41
+action_155 (83) = happyShift action_42
+action_155 (84) = happyShift action_43
+action_155 (85) = happyShift action_44
+action_155 (86) = happyShift action_45
+action_155 (89) = happyShift action_46
+action_155 (90) = happyShift action_47
+action_155 (91) = happyShift action_25
+action_155 (27) = happyGoto action_30
+action_155 (46) = happyGoto action_165
+action_155 (48) = happyGoto action_32
+action_155 (49) = happyGoto action_33
 action_155 _ = happyFail (happyExpListPerState 155)
 
-action_156 _ = happyReduce_34
+action_156 (52) = happyShift action_73
+action_156 (38) = happyGoto action_71
+action_156 (39) = happyGoto action_164
+action_156 _ = happyReduce_43
 
-action_157 (56) = happyShift action_187
-action_157 _ = happyFail (happyExpListPerState 157)
+action_157 _ = happyReduce_36
 
-action_158 (51) = happyShift action_185
-action_158 (55) = happyShift action_186
-action_158 _ = happyFail (happyExpListPerState 158)
+action_158 _ = happyReduce_39
 
-action_159 (54) = happyShift action_184
+action_159 (80) = happyShift action_163
 action_159 _ = happyFail (happyExpListPerState 159)
 
-action_160 (61) = happyShift action_56
-action_160 (62) = happyShift action_57
-action_160 (63) = happyShift action_58
-action_160 (69) = happyShift action_59
-action_160 (70) = happyShift action_60
-action_160 (72) = happyShift action_61
-action_160 (41) = happyGoto action_54
-action_160 (42) = happyGoto action_183
-action_160 _ = happyReduce_53
+action_160 _ = happyReduce_31
 
-action_161 (50) = happyShift action_34
-action_161 (58) = happyShift action_35
-action_161 (59) = happyShift action_36
-action_161 (67) = happyShift action_37
-action_161 (73) = happyShift action_38
-action_161 (75) = happyShift action_39
-action_161 (80) = happyShift action_40
-action_161 (81) = happyShift action_41
-action_161 (82) = happyShift action_42
-action_161 (83) = happyShift action_43
-action_161 (84) = happyShift action_44
-action_161 (87) = happyShift action_45
-action_161 (88) = happyShift action_46
-action_161 (89) = happyShift action_24
-action_161 (26) = happyGoto action_29
-action_161 (45) = happyGoto action_182
-action_161 (46) = happyGoto action_31
-action_161 (47) = happyGoto action_32
-action_161 _ = happyFail (happyExpListPerState 161)
+action_161 (52) = happyShift action_73
+action_161 (38) = happyGoto action_71
+action_161 (39) = happyGoto action_162
+action_161 _ = happyReduce_43
 
-action_162 _ = happyReduce_51
+action_162 (58) = happyShift action_199
+action_162 _ = happyFail (happyExpListPerState 162)
 
-action_163 _ = happyReduce_57
+action_163 _ = happyReduce_35
 
-action_164 _ = happyReduce_63
+action_164 (58) = happyShift action_198
+action_164 _ = happyFail (happyExpListPerState 164)
 
-action_165 (50) = happyShift action_34
-action_165 (58) = happyShift action_35
-action_165 (59) = happyShift action_36
-action_165 (67) = happyShift action_37
-action_165 (73) = happyShift action_38
-action_165 (75) = happyShift action_39
-action_165 (80) = happyShift action_40
-action_165 (81) = happyShift action_41
-action_165 (82) = happyShift action_42
-action_165 (83) = happyShift action_43
-action_165 (84) = happyShift action_44
-action_165 (87) = happyShift action_45
-action_165 (88) = happyShift action_46
-action_165 (89) = happyShift action_24
-action_165 (26) = happyGoto action_29
-action_165 (45) = happyGoto action_181
-action_165 (46) = happyGoto action_31
-action_165 (47) = happyGoto action_32
+action_165 (53) = happyShift action_196
+action_165 (57) = happyShift action_197
 action_165 _ = happyFail (happyExpListPerState 165)
 
-action_166 (50) = happyShift action_34
-action_166 (58) = happyShift action_35
-action_166 (59) = happyShift action_36
-action_166 (67) = happyShift action_37
-action_166 (73) = happyShift action_38
-action_166 (75) = happyShift action_39
-action_166 (80) = happyShift action_40
-action_166 (81) = happyShift action_41
-action_166 (82) = happyShift action_42
-action_166 (83) = happyShift action_43
-action_166 (84) = happyShift action_44
-action_166 (87) = happyShift action_45
-action_166 (88) = happyShift action_46
-action_166 (89) = happyShift action_24
-action_166 (26) = happyGoto action_29
-action_166 (45) = happyGoto action_180
-action_166 (46) = happyGoto action_31
-action_166 (47) = happyGoto action_32
+action_166 (56) = happyShift action_195
 action_166 _ = happyFail (happyExpListPerState 166)
 
-action_167 _ = happyReduce_77
+action_167 (63) = happyShift action_60
+action_167 (64) = happyShift action_61
+action_167 (65) = happyShift action_62
+action_167 (71) = happyShift action_63
+action_167 (72) = happyShift action_64
+action_167 (74) = happyShift action_65
+action_167 (42) = happyGoto action_58
+action_167 (43) = happyGoto action_194
+action_167 _ = happyReduce_54
 
-action_168 (65) = happyShift action_179
+action_168 (52) = happyShift action_35
+action_168 (60) = happyShift action_36
+action_168 (61) = happyShift action_37
+action_168 (69) = happyShift action_38
+action_168 (75) = happyShift action_39
+action_168 (77) = happyShift action_40
+action_168 (82) = happyShift action_41
+action_168 (83) = happyShift action_42
+action_168 (84) = happyShift action_43
+action_168 (85) = happyShift action_44
+action_168 (86) = happyShift action_45
+action_168 (89) = happyShift action_46
+action_168 (90) = happyShift action_47
+action_168 (91) = happyShift action_25
+action_168 (27) = happyGoto action_30
+action_168 (46) = happyGoto action_193
+action_168 (48) = happyGoto action_32
+action_168 (49) = happyGoto action_33
 action_168 _ = happyFail (happyExpListPerState 168)
 
-action_169 (50) = happyShift action_34
-action_169 (58) = happyShift action_35
-action_169 (59) = happyShift action_36
-action_169 (67) = happyShift action_37
-action_169 (73) = happyShift action_38
-action_169 (75) = happyShift action_39
-action_169 (80) = happyShift action_40
-action_169 (81) = happyShift action_41
-action_169 (82) = happyShift action_42
-action_169 (83) = happyShift action_43
-action_169 (84) = happyShift action_44
-action_169 (87) = happyShift action_45
-action_169 (88) = happyShift action_46
-action_169 (89) = happyShift action_24
-action_169 (26) = happyGoto action_29
-action_169 (45) = happyGoto action_178
-action_169 (46) = happyGoto action_31
-action_169 (47) = happyGoto action_32
-action_169 _ = happyFail (happyExpListPerState 169)
+action_169 _ = happyReduce_52
 
-action_170 (50) = happyShift action_34
-action_170 (58) = happyShift action_35
-action_170 (59) = happyShift action_36
-action_170 (67) = happyShift action_37
-action_170 (73) = happyShift action_38
-action_170 (75) = happyShift action_39
-action_170 (80) = happyShift action_40
-action_170 (81) = happyShift action_41
-action_170 (82) = happyShift action_42
-action_170 (83) = happyShift action_43
-action_170 (84) = happyShift action_44
-action_170 (87) = happyShift action_45
-action_170 (88) = happyShift action_46
-action_170 (89) = happyShift action_24
-action_170 (26) = happyGoto action_29
-action_170 (45) = happyGoto action_177
-action_170 (46) = happyGoto action_31
-action_170 (47) = happyGoto action_32
-action_170 _ = happyFail (happyExpListPerState 170)
+action_170 _ = happyReduce_58
 
-action_171 (51) = happyShift action_176
-action_171 _ = happyFail (happyExpListPerState 171)
+action_171 _ = happyReduce_64
 
-action_172 (51) = happyShift action_175
-action_172 _ = happyFail (happyExpListPerState 172)
+action_172 _ = happyReduce_66
 
-action_173 (51) = happyShift action_174
+action_173 (52) = happyShift action_35
+action_173 (60) = happyShift action_36
+action_173 (61) = happyShift action_37
+action_173 (69) = happyShift action_38
+action_173 (75) = happyShift action_39
+action_173 (77) = happyShift action_40
+action_173 (82) = happyShift action_41
+action_173 (83) = happyShift action_42
+action_173 (84) = happyShift action_43
+action_173 (85) = happyShift action_44
+action_173 (86) = happyShift action_45
+action_173 (89) = happyShift action_46
+action_173 (90) = happyShift action_47
+action_173 (91) = happyShift action_25
+action_173 (27) = happyGoto action_30
+action_173 (46) = happyGoto action_192
+action_173 (48) = happyGoto action_32
+action_173 (49) = happyGoto action_33
 action_173 _ = happyFail (happyExpListPerState 173)
 
-action_174 _ = happyReduce_85
+action_174 (52) = happyShift action_28
+action_174 (56) = happyShift action_191
+action_174 (62) = happyShift action_29
+action_174 (91) = happyShift action_25
+action_174 (27) = happyGoto action_26
+action_174 (51) = happyGoto action_190
+action_174 _ = happyFail (happyExpListPerState 174)
 
-action_175 _ = happyReduce_79
+action_175 (52) = happyShift action_35
+action_175 (60) = happyShift action_36
+action_175 (61) = happyShift action_37
+action_175 (69) = happyShift action_38
+action_175 (75) = happyShift action_39
+action_175 (77) = happyShift action_40
+action_175 (82) = happyShift action_41
+action_175 (83) = happyShift action_42
+action_175 (84) = happyShift action_43
+action_175 (85) = happyShift action_44
+action_175 (86) = happyShift action_45
+action_175 (89) = happyShift action_46
+action_175 (90) = happyShift action_47
+action_175 (91) = happyShift action_25
+action_175 (27) = happyGoto action_30
+action_175 (46) = happyGoto action_189
+action_175 (48) = happyGoto action_32
+action_175 (49) = happyGoto action_33
+action_175 _ = happyFail (happyExpListPerState 175)
 
-action_176 _ = happyReduce_80
+action_176 _ = happyReduce_84
 
-action_177 (52) = happyShift action_198
+action_177 (67) = happyShift action_188
 action_177 _ = happyFail (happyExpListPerState 177)
 
-action_178 (52) = happyShift action_197
+action_178 (52) = happyShift action_35
+action_178 (60) = happyShift action_36
+action_178 (61) = happyShift action_37
+action_178 (69) = happyShift action_38
+action_178 (75) = happyShift action_39
+action_178 (77) = happyShift action_40
+action_178 (82) = happyShift action_41
+action_178 (83) = happyShift action_42
+action_178 (84) = happyShift action_43
+action_178 (85) = happyShift action_44
+action_178 (86) = happyShift action_45
+action_178 (89) = happyShift action_46
+action_178 (90) = happyShift action_47
+action_178 (91) = happyShift action_25
+action_178 (27) = happyGoto action_30
+action_178 (46) = happyGoto action_187
+action_178 (48) = happyGoto action_32
+action_178 (49) = happyGoto action_33
 action_178 _ = happyFail (happyExpListPerState 178)
 
-action_179 (50) = happyShift action_34
-action_179 (58) = happyShift action_35
-action_179 (59) = happyShift action_36
-action_179 (67) = happyShift action_37
-action_179 (73) = happyShift action_38
+action_179 (52) = happyShift action_35
+action_179 (60) = happyShift action_36
+action_179 (61) = happyShift action_37
+action_179 (69) = happyShift action_38
 action_179 (75) = happyShift action_39
-action_179 (80) = happyShift action_40
-action_179 (81) = happyShift action_41
-action_179 (82) = happyShift action_42
-action_179 (83) = happyShift action_43
-action_179 (84) = happyShift action_44
-action_179 (87) = happyShift action_45
-action_179 (88) = happyShift action_46
-action_179 (89) = happyShift action_24
-action_179 (26) = happyGoto action_29
-action_179 (45) = happyGoto action_30
-action_179 (46) = happyGoto action_31
-action_179 (47) = happyGoto action_32
-action_179 (48) = happyGoto action_196
+action_179 (77) = happyShift action_40
+action_179 (82) = happyShift action_41
+action_179 (83) = happyShift action_42
+action_179 (84) = happyShift action_43
+action_179 (85) = happyShift action_44
+action_179 (86) = happyShift action_45
+action_179 (89) = happyShift action_46
+action_179 (90) = happyShift action_47
+action_179 (91) = happyShift action_25
+action_179 (27) = happyGoto action_30
+action_179 (46) = happyGoto action_186
+action_179 (48) = happyGoto action_32
+action_179 (49) = happyGoto action_33
 action_179 _ = happyFail (happyExpListPerState 179)
 
-action_180 (51) = happyShift action_195
+action_180 (53) = happyShift action_185
 action_180 _ = happyFail (happyExpListPerState 180)
 
-action_181 (51) = happyShift action_194
+action_181 (53) = happyShift action_184
 action_181 _ = happyFail (happyExpListPerState 181)
 
-action_182 (55) = happyShift action_193
+action_182 (53) = happyShift action_183
 action_182 _ = happyFail (happyExpListPerState 182)
 
-action_183 (78) = happyShift action_192
-action_183 _ = happyFail (happyExpListPerState 183)
+action_183 _ = happyReduce_92
 
-action_184 (50) = happyShift action_34
-action_184 (58) = happyShift action_35
-action_184 (59) = happyShift action_36
-action_184 (67) = happyShift action_37
-action_184 (73) = happyShift action_38
-action_184 (75) = happyShift action_39
-action_184 (80) = happyShift action_40
-action_184 (81) = happyShift action_41
-action_184 (82) = happyShift action_42
-action_184 (83) = happyShift action_43
-action_184 (84) = happyShift action_44
-action_184 (87) = happyShift action_45
-action_184 (88) = happyShift action_46
-action_184 (89) = happyShift action_24
-action_184 (26) = happyGoto action_29
-action_184 (45) = happyGoto action_191
-action_184 (46) = happyGoto action_31
-action_184 (47) = happyGoto action_32
-action_184 _ = happyFail (happyExpListPerState 184)
+action_184 _ = happyReduce_86
 
-action_185 _ = happyReduce_40
+action_185 _ = happyReduce_87
 
-action_186 (50) = happyShift action_34
-action_186 (58) = happyShift action_35
-action_186 (59) = happyShift action_36
-action_186 (67) = happyShift action_37
-action_186 (73) = happyShift action_38
-action_186 (75) = happyShift action_39
-action_186 (80) = happyShift action_40
-action_186 (81) = happyShift action_41
-action_186 (82) = happyShift action_42
-action_186 (83) = happyShift action_43
-action_186 (84) = happyShift action_44
-action_186 (87) = happyShift action_45
-action_186 (88) = happyShift action_46
-action_186 (89) = happyShift action_24
-action_186 (26) = happyGoto action_29
-action_186 (45) = happyGoto action_190
-action_186 (46) = happyGoto action_31
-action_186 (47) = happyGoto action_32
+action_186 (54) = happyShift action_212
 action_186 _ = happyFail (happyExpListPerState 186)
 
-action_187 _ = happyReduce_39
+action_187 (54) = happyShift action_211
+action_187 _ = happyFail (happyExpListPerState 187)
 
-action_188 (64) = happyShift action_65
-action_188 (39) = happyGoto action_63
-action_188 (40) = happyGoto action_189
-action_188 _ = happyReduce_45
+action_188 (52) = happyShift action_35
+action_188 (60) = happyShift action_36
+action_188 (61) = happyShift action_37
+action_188 (69) = happyShift action_38
+action_188 (75) = happyShift action_39
+action_188 (77) = happyShift action_40
+action_188 (82) = happyShift action_41
+action_188 (83) = happyShift action_42
+action_188 (84) = happyShift action_43
+action_188 (85) = happyShift action_44
+action_188 (86) = happyShift action_45
+action_188 (89) = happyShift action_46
+action_188 (90) = happyShift action_47
+action_188 (91) = happyShift action_25
+action_188 (27) = happyGoto action_30
+action_188 (46) = happyGoto action_31
+action_188 (48) = happyGoto action_32
+action_188 (49) = happyGoto action_33
+action_188 (50) = happyGoto action_210
+action_188 _ = happyFail (happyExpListPerState 188)
 
-action_189 (61) = happyShift action_56
-action_189 (62) = happyShift action_57
-action_189 (63) = happyShift action_58
-action_189 (69) = happyShift action_59
-action_189 (70) = happyShift action_60
-action_189 (72) = happyShift action_61
-action_189 (41) = happyGoto action_54
-action_189 (42) = happyGoto action_206
-action_189 _ = happyReduce_53
+action_189 (53) = happyShift action_209
+action_189 _ = happyFail (happyExpListPerState 189)
 
-action_190 (51) = happyShift action_205
+action_190 (52) = happyShift action_28
+action_190 (56) = happyShift action_208
+action_190 (62) = happyShift action_29
+action_190 (91) = happyShift action_25
+action_190 (27) = happyGoto action_26
+action_190 (51) = happyGoto action_207
 action_190 _ = happyFail (happyExpListPerState 190)
 
-action_191 (55) = happyShift action_204
+action_191 (52) = happyShift action_35
+action_191 (60) = happyShift action_36
+action_191 (61) = happyShift action_37
+action_191 (69) = happyShift action_38
+action_191 (75) = happyShift action_39
+action_191 (77) = happyShift action_40
+action_191 (82) = happyShift action_41
+action_191 (83) = happyShift action_42
+action_191 (84) = happyShift action_43
+action_191 (85) = happyShift action_44
+action_191 (86) = happyShift action_45
+action_191 (89) = happyShift action_46
+action_191 (90) = happyShift action_47
+action_191 (91) = happyShift action_25
+action_191 (27) = happyGoto action_30
+action_191 (46) = happyGoto action_206
+action_191 (48) = happyGoto action_32
+action_191 (49) = happyGoto action_33
 action_191 _ = happyFail (happyExpListPerState 191)
 
-action_192 _ = happyReduce_49
+action_192 (53) = happyShift action_205
+action_192 _ = happyFail (happyExpListPerState 192)
 
-action_193 (50) = happyShift action_34
-action_193 (58) = happyShift action_35
-action_193 (59) = happyShift action_36
-action_193 (67) = happyShift action_37
-action_193 (73) = happyShift action_38
-action_193 (75) = happyShift action_39
-action_193 (80) = happyShift action_40
-action_193 (81) = happyShift action_41
-action_193 (82) = happyShift action_42
-action_193 (83) = happyShift action_43
-action_193 (84) = happyShift action_44
-action_193 (87) = happyShift action_45
-action_193 (88) = happyShift action_46
-action_193 (89) = happyShift action_24
-action_193 (26) = happyGoto action_29
-action_193 (45) = happyGoto action_203
-action_193 (46) = happyGoto action_31
-action_193 (47) = happyGoto action_32
+action_193 (57) = happyShift action_204
 action_193 _ = happyFail (happyExpListPerState 193)
 
-action_194 (79) = happyShift action_202
+action_194 (80) = happyShift action_203
 action_194 _ = happyFail (happyExpListPerState 194)
 
-action_195 (85) = happyShift action_201
+action_195 (52) = happyShift action_35
+action_195 (60) = happyShift action_36
+action_195 (61) = happyShift action_37
+action_195 (69) = happyShift action_38
+action_195 (75) = happyShift action_39
+action_195 (77) = happyShift action_40
+action_195 (82) = happyShift action_41
+action_195 (83) = happyShift action_42
+action_195 (84) = happyShift action_43
+action_195 (85) = happyShift action_44
+action_195 (86) = happyShift action_45
+action_195 (89) = happyShift action_46
+action_195 (90) = happyShift action_47
+action_195 (91) = happyShift action_25
+action_195 (27) = happyGoto action_30
+action_195 (46) = happyGoto action_202
+action_195 (48) = happyGoto action_32
+action_195 (49) = happyGoto action_33
 action_195 _ = happyFail (happyExpListPerState 195)
 
-action_196 _ = happyReduce_64
+action_196 _ = happyReduce_41
 
-action_197 (50) = happyShift action_34
-action_197 (58) = happyShift action_35
-action_197 (59) = happyShift action_36
-action_197 (67) = happyShift action_37
-action_197 (73) = happyShift action_38
+action_197 (52) = happyShift action_35
+action_197 (60) = happyShift action_36
+action_197 (61) = happyShift action_37
+action_197 (69) = happyShift action_38
 action_197 (75) = happyShift action_39
-action_197 (80) = happyShift action_40
-action_197 (81) = happyShift action_41
-action_197 (82) = happyShift action_42
-action_197 (83) = happyShift action_43
-action_197 (84) = happyShift action_44
-action_197 (87) = happyShift action_45
-action_197 (88) = happyShift action_46
-action_197 (89) = happyShift action_24
-action_197 (26) = happyGoto action_29
-action_197 (45) = happyGoto action_200
-action_197 (46) = happyGoto action_31
-action_197 (47) = happyGoto action_32
+action_197 (77) = happyShift action_40
+action_197 (82) = happyShift action_41
+action_197 (83) = happyShift action_42
+action_197 (84) = happyShift action_43
+action_197 (85) = happyShift action_44
+action_197 (86) = happyShift action_45
+action_197 (89) = happyShift action_46
+action_197 (90) = happyShift action_47
+action_197 (91) = happyShift action_25
+action_197 (27) = happyGoto action_30
+action_197 (46) = happyGoto action_201
+action_197 (48) = happyGoto action_32
+action_197 (49) = happyGoto action_33
 action_197 _ = happyFail (happyExpListPerState 197)
 
-action_198 (50) = happyShift action_34
-action_198 (58) = happyShift action_35
-action_198 (59) = happyShift action_36
-action_198 (67) = happyShift action_37
-action_198 (73) = happyShift action_38
-action_198 (75) = happyShift action_39
-action_198 (80) = happyShift action_40
-action_198 (81) = happyShift action_41
-action_198 (82) = happyShift action_42
-action_198 (83) = happyShift action_43
-action_198 (84) = happyShift action_44
-action_198 (87) = happyShift action_45
-action_198 (88) = happyShift action_46
-action_198 (89) = happyShift action_24
-action_198 (26) = happyGoto action_29
-action_198 (45) = happyGoto action_199
-action_198 (46) = happyGoto action_31
-action_198 (47) = happyGoto action_32
-action_198 _ = happyFail (happyExpListPerState 198)
+action_198 _ = happyReduce_40
 
-action_199 (51) = happyShift action_211
-action_199 _ = happyFail (happyExpListPerState 199)
+action_199 (66) = happyShift action_69
+action_199 (40) = happyGoto action_67
+action_199 (41) = happyGoto action_200
+action_199 _ = happyReduce_46
 
-action_200 (51) = happyShift action_210
-action_200 _ = happyFail (happyExpListPerState 200)
+action_200 (63) = happyShift action_60
+action_200 (64) = happyShift action_61
+action_200 (65) = happyShift action_62
+action_200 (71) = happyShift action_63
+action_200 (72) = happyShift action_64
+action_200 (74) = happyShift action_65
+action_200 (42) = happyGoto action_58
+action_200 (43) = happyGoto action_223
+action_200 _ = happyReduce_54
 
-action_201 (50) = happyShift action_34
-action_201 (58) = happyShift action_35
-action_201 (59) = happyShift action_36
-action_201 (67) = happyShift action_37
-action_201 (73) = happyShift action_38
-action_201 (75) = happyShift action_39
-action_201 (80) = happyShift action_40
-action_201 (81) = happyShift action_41
-action_201 (82) = happyShift action_42
-action_201 (83) = happyShift action_43
-action_201 (84) = happyShift action_44
-action_201 (87) = happyShift action_45
-action_201 (88) = happyShift action_46
-action_201 (89) = happyShift action_24
-action_201 (26) = happyGoto action_29
-action_201 (45) = happyGoto action_30
-action_201 (46) = happyGoto action_31
-action_201 (47) = happyGoto action_32
-action_201 (48) = happyGoto action_209
+action_201 (53) = happyShift action_222
 action_201 _ = happyFail (happyExpListPerState 201)
 
-action_202 (50) = happyShift action_34
-action_202 (58) = happyShift action_35
-action_202 (59) = happyShift action_36
-action_202 (67) = happyShift action_37
-action_202 (73) = happyShift action_38
-action_202 (75) = happyShift action_39
-action_202 (80) = happyShift action_40
-action_202 (81) = happyShift action_41
-action_202 (82) = happyShift action_42
-action_202 (83) = happyShift action_43
-action_202 (84) = happyShift action_44
-action_202 (87) = happyShift action_45
-action_202 (88) = happyShift action_46
-action_202 (89) = happyShift action_24
-action_202 (26) = happyGoto action_29
-action_202 (45) = happyGoto action_30
-action_202 (46) = happyGoto action_31
-action_202 (47) = happyGoto action_32
-action_202 (48) = happyGoto action_208
+action_202 (57) = happyShift action_221
 action_202 _ = happyFail (happyExpListPerState 202)
 
-action_203 _ = happyReduce_47
+action_203 _ = happyReduce_50
 
-action_204 (50) = happyShift action_34
-action_204 (58) = happyShift action_35
-action_204 (59) = happyShift action_36
-action_204 (67) = happyShift action_37
-action_204 (73) = happyShift action_38
+action_204 (52) = happyShift action_35
+action_204 (60) = happyShift action_36
+action_204 (61) = happyShift action_37
+action_204 (69) = happyShift action_38
 action_204 (75) = happyShift action_39
-action_204 (80) = happyShift action_40
-action_204 (81) = happyShift action_41
-action_204 (82) = happyShift action_42
-action_204 (83) = happyShift action_43
-action_204 (84) = happyShift action_44
-action_204 (87) = happyShift action_45
-action_204 (88) = happyShift action_46
-action_204 (89) = happyShift action_24
-action_204 (26) = happyGoto action_29
-action_204 (45) = happyGoto action_207
-action_204 (46) = happyGoto action_31
-action_204 (47) = happyGoto action_32
+action_204 (77) = happyShift action_40
+action_204 (82) = happyShift action_41
+action_204 (83) = happyShift action_42
+action_204 (84) = happyShift action_43
+action_204 (85) = happyShift action_44
+action_204 (86) = happyShift action_45
+action_204 (89) = happyShift action_46
+action_204 (90) = happyShift action_47
+action_204 (91) = happyShift action_25
+action_204 (27) = happyGoto action_30
+action_204 (46) = happyGoto action_220
+action_204 (48) = happyGoto action_32
+action_204 (49) = happyGoto action_33
 action_204 _ = happyFail (happyExpListPerState 204)
 
-action_205 _ = happyReduce_41
+action_205 (81) = happyShift action_219
+action_205 _ = happyFail (happyExpListPerState 205)
 
-action_206 _ = happyReduce_29
+action_206 (53) = happyShift action_218
+action_206 _ = happyFail (happyExpListPerState 206)
 
-action_207 _ = happyReduce_48
+action_207 (56) = happyShift action_217
+action_207 _ = happyFail (happyExpListPerState 207)
 
-action_208 _ = happyReduce_62
+action_208 (52) = happyShift action_35
+action_208 (60) = happyShift action_36
+action_208 (61) = happyShift action_37
+action_208 (69) = happyShift action_38
+action_208 (75) = happyShift action_39
+action_208 (77) = happyShift action_40
+action_208 (82) = happyShift action_41
+action_208 (83) = happyShift action_42
+action_208 (84) = happyShift action_43
+action_208 (85) = happyShift action_44
+action_208 (86) = happyShift action_45
+action_208 (89) = happyShift action_46
+action_208 (90) = happyShift action_47
+action_208 (91) = happyShift action_25
+action_208 (27) = happyGoto action_30
+action_208 (46) = happyGoto action_216
+action_208 (48) = happyGoto action_32
+action_208 (49) = happyGoto action_33
+action_208 _ = happyFail (happyExpListPerState 208)
 
-action_209 _ = happyReduce_61
+action_209 (87) = happyShift action_215
+action_209 _ = happyFail (happyExpListPerState 209)
 
-action_210 _ = happyReduce_78
+action_210 _ = happyReduce_65
 
-action_211 _ = happyReduce_76
+action_211 (52) = happyShift action_35
+action_211 (60) = happyShift action_36
+action_211 (61) = happyShift action_37
+action_211 (69) = happyShift action_38
+action_211 (75) = happyShift action_39
+action_211 (77) = happyShift action_40
+action_211 (82) = happyShift action_41
+action_211 (83) = happyShift action_42
+action_211 (84) = happyShift action_43
+action_211 (85) = happyShift action_44
+action_211 (86) = happyShift action_45
+action_211 (89) = happyShift action_46
+action_211 (90) = happyShift action_47
+action_211 (91) = happyShift action_25
+action_211 (27) = happyGoto action_30
+action_211 (46) = happyGoto action_214
+action_211 (48) = happyGoto action_32
+action_211 (49) = happyGoto action_33
+action_211 _ = happyFail (happyExpListPerState 211)
 
-happyReduce_23 = happySpecReduce_1  26 happyReduction_23
-happyReduction_23 (HappyTerminal happy_var_1)
-	 =  HappyAbsSyn26
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.VarIdent (tokenText happy_var_1))
-	)
-happyReduction_23 _  = notHappyAtAll 
+action_212 (52) = happyShift action_35
+action_212 (60) = happyShift action_36
+action_212 (61) = happyShift action_37
+action_212 (69) = happyShift action_38
+action_212 (75) = happyShift action_39
+action_212 (77) = happyShift action_40
+action_212 (82) = happyShift action_41
+action_212 (83) = happyShift action_42
+action_212 (84) = happyShift action_43
+action_212 (85) = happyShift action_44
+action_212 (86) = happyShift action_45
+action_212 (89) = happyShift action_46
+action_212 (90) = happyShift action_47
+action_212 (91) = happyShift action_25
+action_212 (27) = happyGoto action_30
+action_212 (46) = happyGoto action_213
+action_212 (48) = happyGoto action_32
+action_212 (49) = happyGoto action_33
+action_212 _ = happyFail (happyExpListPerState 212)
+
+action_213 (53) = happyShift action_231
+action_213 _ = happyFail (happyExpListPerState 213)
+
+action_214 (53) = happyShift action_230
+action_214 _ = happyFail (happyExpListPerState 214)
+
+action_215 (52) = happyShift action_35
+action_215 (60) = happyShift action_36
+action_215 (61) = happyShift action_37
+action_215 (69) = happyShift action_38
+action_215 (75) = happyShift action_39
+action_215 (77) = happyShift action_40
+action_215 (82) = happyShift action_41
+action_215 (83) = happyShift action_42
+action_215 (84) = happyShift action_43
+action_215 (85) = happyShift action_44
+action_215 (86) = happyShift action_45
+action_215 (89) = happyShift action_46
+action_215 (90) = happyShift action_47
+action_215 (91) = happyShift action_25
+action_215 (27) = happyGoto action_30
+action_215 (46) = happyGoto action_31
+action_215 (48) = happyGoto action_32
+action_215 (49) = happyGoto action_33
+action_215 (50) = happyGoto action_229
+action_215 _ = happyFail (happyExpListPerState 215)
+
+action_216 (53) = happyShift action_228
+action_216 _ = happyFail (happyExpListPerState 216)
+
+action_217 (52) = happyShift action_35
+action_217 (60) = happyShift action_36
+action_217 (61) = happyShift action_37
+action_217 (69) = happyShift action_38
+action_217 (75) = happyShift action_39
+action_217 (77) = happyShift action_40
+action_217 (82) = happyShift action_41
+action_217 (83) = happyShift action_42
+action_217 (84) = happyShift action_43
+action_217 (85) = happyShift action_44
+action_217 (86) = happyShift action_45
+action_217 (89) = happyShift action_46
+action_217 (90) = happyShift action_47
+action_217 (91) = happyShift action_25
+action_217 (27) = happyGoto action_30
+action_217 (46) = happyGoto action_227
+action_217 (48) = happyGoto action_32
+action_217 (49) = happyGoto action_33
+action_217 _ = happyFail (happyExpListPerState 217)
+
+action_218 (87) = happyShift action_226
+action_218 _ = happyFail (happyExpListPerState 218)
+
+action_219 (52) = happyShift action_35
+action_219 (60) = happyShift action_36
+action_219 (61) = happyShift action_37
+action_219 (69) = happyShift action_38
+action_219 (75) = happyShift action_39
+action_219 (77) = happyShift action_40
+action_219 (82) = happyShift action_41
+action_219 (83) = happyShift action_42
+action_219 (84) = happyShift action_43
+action_219 (85) = happyShift action_44
+action_219 (86) = happyShift action_45
+action_219 (89) = happyShift action_46
+action_219 (90) = happyShift action_47
+action_219 (91) = happyShift action_25
+action_219 (27) = happyGoto action_30
+action_219 (46) = happyGoto action_31
+action_219 (48) = happyGoto action_32
+action_219 (49) = happyGoto action_33
+action_219 (50) = happyGoto action_225
+action_219 _ = happyFail (happyExpListPerState 219)
+
+action_220 _ = happyReduce_48
+
+action_221 (52) = happyShift action_35
+action_221 (60) = happyShift action_36
+action_221 (61) = happyShift action_37
+action_221 (69) = happyShift action_38
+action_221 (75) = happyShift action_39
+action_221 (77) = happyShift action_40
+action_221 (82) = happyShift action_41
+action_221 (83) = happyShift action_42
+action_221 (84) = happyShift action_43
+action_221 (85) = happyShift action_44
+action_221 (86) = happyShift action_45
+action_221 (89) = happyShift action_46
+action_221 (90) = happyShift action_47
+action_221 (91) = happyShift action_25
+action_221 (27) = happyGoto action_30
+action_221 (46) = happyGoto action_224
+action_221 (48) = happyGoto action_32
+action_221 (49) = happyGoto action_33
+action_221 _ = happyFail (happyExpListPerState 221)
+
+action_222 _ = happyReduce_42
+
+action_223 _ = happyReduce_30
+
+action_224 _ = happyReduce_49
+
+action_225 _ = happyReduce_63
+
+action_226 (52) = happyShift action_35
+action_226 (60) = happyShift action_36
+action_226 (61) = happyShift action_37
+action_226 (69) = happyShift action_38
+action_226 (75) = happyShift action_39
+action_226 (77) = happyShift action_40
+action_226 (82) = happyShift action_41
+action_226 (83) = happyShift action_42
+action_226 (84) = happyShift action_43
+action_226 (85) = happyShift action_44
+action_226 (86) = happyShift action_45
+action_226 (89) = happyShift action_46
+action_226 (90) = happyShift action_47
+action_226 (91) = happyShift action_25
+action_226 (27) = happyGoto action_30
+action_226 (46) = happyGoto action_31
+action_226 (48) = happyGoto action_32
+action_226 (49) = happyGoto action_33
+action_226 (50) = happyGoto action_234
+action_226 _ = happyFail (happyExpListPerState 226)
+
+action_227 (53) = happyShift action_233
+action_227 _ = happyFail (happyExpListPerState 227)
+
+action_228 (87) = happyShift action_232
+action_228 _ = happyFail (happyExpListPerState 228)
+
+action_229 _ = happyReduce_62
+
+action_230 _ = happyReduce_85
+
+action_231 _ = happyReduce_83
+
+action_232 (52) = happyShift action_35
+action_232 (60) = happyShift action_36
+action_232 (61) = happyShift action_37
+action_232 (69) = happyShift action_38
+action_232 (75) = happyShift action_39
+action_232 (77) = happyShift action_40
+action_232 (82) = happyShift action_41
+action_232 (83) = happyShift action_42
+action_232 (84) = happyShift action_43
+action_232 (85) = happyShift action_44
+action_232 (86) = happyShift action_45
+action_232 (89) = happyShift action_46
+action_232 (90) = happyShift action_47
+action_232 (91) = happyShift action_25
+action_232 (27) = happyGoto action_30
+action_232 (46) = happyGoto action_31
+action_232 (48) = happyGoto action_32
+action_232 (49) = happyGoto action_33
+action_232 (50) = happyGoto action_236
+action_232 _ = happyFail (happyExpListPerState 232)
+
+action_233 (87) = happyShift action_235
+action_233 _ = happyFail (happyExpListPerState 233)
+
+action_234 _ = happyReduce_67
+
+action_235 (52) = happyShift action_35
+action_235 (60) = happyShift action_36
+action_235 (61) = happyShift action_37
+action_235 (69) = happyShift action_38
+action_235 (75) = happyShift action_39
+action_235 (77) = happyShift action_40
+action_235 (82) = happyShift action_41
+action_235 (83) = happyShift action_42
+action_235 (84) = happyShift action_43
+action_235 (85) = happyShift action_44
+action_235 (86) = happyShift action_45
+action_235 (89) = happyShift action_46
+action_235 (90) = happyShift action_47
+action_235 (91) = happyShift action_25
+action_235 (27) = happyGoto action_30
+action_235 (46) = happyGoto action_31
+action_235 (48) = happyGoto action_32
+action_235 (49) = happyGoto action_33
+action_235 (50) = happyGoto action_237
+action_235 _ = happyFail (happyExpListPerState 235)
+
+action_236 _ = happyReduce_68
+
+action_237 _ = happyReduce_69
 
 happyReduce_24 = happySpecReduce_1  27 happyReduction_24
-happyReduction_24 (HappyAbsSyn28  happy_var_1)
+happyReduction_24 (HappyTerminal happy_var_1)
 	 =  HappyAbsSyn27
-		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.AProgram (fst happy_var_1) (snd happy_var_1))
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.VarIdent (tokenText happy_var_1))
 	)
 happyReduction_24 _  = notHappyAtAll 
 
-happyReduce_25 = happySpecReduce_0  28 happyReduction_25
-happyReduction_25  =  HappyAbsSyn28
+happyReduce_25 = happySpecReduce_1  28 happyReduction_25
+happyReduction_25 (HappyAbsSyn29  happy_var_1)
+	 =  HappyAbsSyn28
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.AProgram (fst happy_var_1) (snd happy_var_1))
+	)
+happyReduction_25 _  = notHappyAtAll 
+
+happyReduce_26 = happySpecReduce_0  29 happyReduction_26
+happyReduction_26  =  HappyAbsSyn29
 		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
 	)
 
-happyReduce_26 = happySpecReduce_2  28 happyReduction_26
-happyReduction_26 (HappyAbsSyn28  happy_var_2)
-	(HappyAbsSyn29  happy_var_1)
-	 =  HappyAbsSyn28
+happyReduce_27 = happySpecReduce_2  29 happyReduction_27
+happyReduction_27 (HappyAbsSyn29  happy_var_2)
+	(HappyAbsSyn30  happy_var_1)
+	 =  HappyAbsSyn29
 		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_2))
 	)
-happyReduction_26 _ _  = notHappyAtAll 
+happyReduction_27 _ _  = notHappyAtAll 
 
-happyReduce_27 = happySpecReduce_1  29 happyReduction_27
-happyReduction_27 (HappyAbsSyn30  happy_var_1)
-	 =  HappyAbsSyn29
+happyReduce_28 = happySpecReduce_1  30 happyReduction_28
+happyReduction_28 (HappyAbsSyn31  happy_var_1)
+	 =  HappyAbsSyn30
 		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.UnitModule (fst happy_var_1) (snd happy_var_1))
-	)
-happyReduction_27 _  = notHappyAtAll 
-
-happyReduce_28 = happySpecReduce_1  29 happyReduction_28
-happyReduction_28 (HappyAbsSyn36  happy_var_1)
-	 =  HappyAbsSyn29
-		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.UnitTelescope (fst happy_var_1) (snd happy_var_1))
 	)
 happyReduction_28 _  = notHappyAtAll 
 
-happyReduce_29 = happyReduce 7 30 happyReduction_29
-happyReduction_29 ((HappyAbsSyn42  happy_var_7) `HappyStk`
-	(HappyAbsSyn40  happy_var_6) `HappyStk`
+happyReduce_29 = happySpecReduce_1  30 happyReduction_29
+happyReduction_29 (HappyAbsSyn37  happy_var_1)
+	 =  HappyAbsSyn30
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.UnitTelescope (fst happy_var_1) (snd happy_var_1))
+	)
+happyReduction_29 _  = notHappyAtAll 
+
+happyReduce_30 = happyReduce 7 31 happyReduction_30
+happyReduction_30 ((HappyAbsSyn43  happy_var_7) `HappyStk`
+	(HappyAbsSyn41  happy_var_6) `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn38  happy_var_4) `HappyStk`
-	(HappyAbsSyn32  happy_var_3) `HappyStk`
-	(HappyAbsSyn26  happy_var_2) `HappyStk`
+	(HappyAbsSyn39  happy_var_4) `HappyStk`
+	(HappyAbsSyn33  happy_var_3) `HappyStk`
+	(HappyAbsSyn27  happy_var_2) `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
-	 = HappyAbsSyn30
+	 = HappyAbsSyn31
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.AModule (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_3) (snd happy_var_4) (snd happy_var_6) (snd happy_var_7))
 	) `HappyStk` happyRest
 
-happyReduce_30 = happySpecReduce_3  31 happyReduction_30
-happyReduction_30 (HappyAbsSyn33  happy_var_3)
-	(HappyAbsSyn26  happy_var_2)
+happyReduce_31 = happySpecReduce_3  32 happyReduction_31
+happyReduction_31 (HappyAbsSyn34  happy_var_3)
+	(HappyAbsSyn27  happy_var_2)
 	(HappyTerminal happy_var_1)
-	 =  HappyAbsSyn31
+	 =  HappyAbsSyn32
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.AnInclude (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_3))
 	)
-happyReduction_30 _ _ _  = notHappyAtAll 
+happyReduction_31 _ _ _  = notHappyAtAll 
 
-happyReduce_31 = happySpecReduce_0  32 happyReduction_31
-happyReduction_31  =  HappyAbsSyn32
+happyReduce_32 = happySpecReduce_0  33 happyReduction_32
+happyReduction_32  =  HappyAbsSyn33
 		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
 	)
 
-happyReduce_32 = happySpecReduce_2  32 happyReduction_32
-happyReduction_32 (HappyAbsSyn32  happy_var_2)
-	(HappyAbsSyn31  happy_var_1)
-	 =  HappyAbsSyn32
+happyReduce_33 = happySpecReduce_2  33 happyReduction_33
+happyReduction_33 (HappyAbsSyn33  happy_var_2)
+	(HappyAbsSyn32  happy_var_1)
+	 =  HappyAbsSyn33
 		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_2))
 	)
-happyReduction_32 _ _  = notHappyAtAll 
+happyReduction_33 _ _  = notHappyAtAll 
 
-happyReduce_33 = happySpecReduce_0  33 happyReduction_33
-happyReduction_33  =  HappyAbsSyn33
+happyReduce_34 = happySpecReduce_0  34 happyReduction_34
+happyReduction_34  =  HappyAbsSyn34
 		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, Language.MLTT.Syntax.Abs.NoRefinement Language.MLTT.Syntax.Abs.BNFC'NoPosition)
 	)
 
-happyReduce_34 = happyReduce 4 33 happyReduction_34
-happyReduction_34 (_ `HappyStk`
-	(HappyAbsSyn35  happy_var_3) `HappyStk`
+happyReduce_35 = happyReduce 4 34 happyReduction_35
+happyReduction_35 (_ `HappyStk`
+	(HappyAbsSyn36  happy_var_3) `HappyStk`
 	_ `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
-	 = HappyAbsSyn33
+	 = HappyAbsSyn34
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.ARefinement (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3))
 	) `HappyStk` happyRest
 
-happyReduce_35 = happySpecReduce_3  34 happyReduction_35
-happyReduction_35 (HappyAbsSyn45  happy_var_3)
+happyReduce_36 = happySpecReduce_3  35 happyReduction_36
+happyReduction_36 (HappyAbsSyn46  happy_var_3)
 	_
-	(HappyAbsSyn26  happy_var_1)
-	 =  HappyAbsSyn34
+	(HappyAbsSyn27  happy_var_1)
+	 =  HappyAbsSyn35
 		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.AFixed (fst happy_var_1) (snd happy_var_1) (snd happy_var_3))
 	)
-happyReduction_35 _ _ _  = notHappyAtAll 
+happyReduction_36 _ _ _  = notHappyAtAll 
 
-happyReduce_36 = happySpecReduce_0  35 happyReduction_36
-happyReduction_36  =  HappyAbsSyn35
+happyReduce_37 = happySpecReduce_0  36 happyReduction_37
+happyReduction_37  =  HappyAbsSyn36
 		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
 	)
 
-happyReduce_37 = happySpecReduce_1  35 happyReduction_37
-happyReduction_37 (HappyAbsSyn34  happy_var_1)
-	 =  HappyAbsSyn35
+happyReduce_38 = happySpecReduce_1  36 happyReduction_38
+happyReduction_38 (HappyAbsSyn35  happy_var_1)
+	 =  HappyAbsSyn36
 		 ((fst happy_var_1, (:[]) (snd happy_var_1))
 	)
-happyReduction_37 _  = notHappyAtAll 
+happyReduction_38 _  = notHappyAtAll 
 
-happyReduce_38 = happySpecReduce_3  35 happyReduction_38
-happyReduction_38 (HappyAbsSyn35  happy_var_3)
+happyReduce_39 = happySpecReduce_3  36 happyReduction_39
+happyReduction_39 (HappyAbsSyn36  happy_var_3)
 	_
-	(HappyAbsSyn34  happy_var_1)
-	 =  HappyAbsSyn35
+	(HappyAbsSyn35  happy_var_1)
+	 =  HappyAbsSyn36
 		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_3))
 	)
-happyReduction_38 _ _ _  = notHappyAtAll 
-
-happyReduce_39 = happyReduce 5 36 happyReduction_39
-happyReduction_39 (_ `HappyStk`
-	(HappyAbsSyn38  happy_var_4) `HappyStk`
-	(HappyAbsSyn32  happy_var_3) `HappyStk`
-	(HappyAbsSyn26  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn36
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.ATelescope (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_3) (snd happy_var_4))
-	) `HappyStk` happyRest
+happyReduction_39 _ _ _  = notHappyAtAll 
 
 happyReduce_40 = happyReduce 5 37 happyReduction_40
 happyReduction_40 (_ `HappyStk`
-	(HappyAbsSyn45  happy_var_4) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn26  happy_var_2) `HappyStk`
+	(HappyAbsSyn39  happy_var_4) `HappyStk`
+	(HappyAbsSyn33  happy_var_3) `HappyStk`
+	(HappyAbsSyn27  happy_var_2) `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
 	 = HappyAbsSyn37
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.ATelescope (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_3) (snd happy_var_4))
+	) `HappyStk` happyRest
+
+happyReduce_41 = happyReduce 5 38 happyReduction_41
+happyReduction_41 (_ `HappyStk`
+	(HappyAbsSyn46  happy_var_4) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn27  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn38
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.AParam (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
 	) `HappyStk` happyRest
 
-happyReduce_41 = happyReduce 7 37 happyReduction_41
-happyReduction_41 (_ `HappyStk`
-	(HappyAbsSyn45  happy_var_6) `HappyStk`
+happyReduce_42 = happyReduce 7 38 happyReduction_42
+happyReduction_42 (_ `HappyStk`
+	(HappyAbsSyn46  happy_var_6) `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn45  happy_var_4) `HappyStk`
+	(HappyAbsSyn46  happy_var_4) `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn26  happy_var_2) `HappyStk`
+	(HappyAbsSyn27  happy_var_2) `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
-	 = HappyAbsSyn37
+	 = HappyAbsSyn38
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.AManifest (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4) (snd happy_var_6))
 	) `HappyStk` happyRest
 
-happyReduce_42 = happySpecReduce_0  38 happyReduction_42
-happyReduction_42  =  HappyAbsSyn38
+happyReduce_43 = happySpecReduce_0  39 happyReduction_43
+happyReduction_43  =  HappyAbsSyn39
 		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
 	)
 
-happyReduce_43 = happySpecReduce_2  38 happyReduction_43
-happyReduction_43 (HappyAbsSyn38  happy_var_2)
-	(HappyAbsSyn37  happy_var_1)
-	 =  HappyAbsSyn38
-		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_2))
-	)
-happyReduction_43 _ _  = notHappyAtAll 
-
 happyReduce_44 = happySpecReduce_2  39 happyReduction_44
-happyReduction_44 (HappyAbsSyn26  happy_var_2)
-	(HappyTerminal happy_var_1)
+happyReduction_44 (HappyAbsSyn39  happy_var_2)
+	(HappyAbsSyn38  happy_var_1)
 	 =  HappyAbsSyn39
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.AnImport (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
+		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_2))
 	)
 happyReduction_44 _ _  = notHappyAtAll 
 
-happyReduce_45 = happySpecReduce_0  40 happyReduction_45
-happyReduction_45  =  HappyAbsSyn40
+happyReduce_45 = happySpecReduce_2  40 happyReduction_45
+happyReduction_45 (HappyAbsSyn27  happy_var_2)
+	(HappyTerminal happy_var_1)
+	 =  HappyAbsSyn40
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.AnImport (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
+	)
+happyReduction_45 _ _  = notHappyAtAll 
+
+happyReduce_46 = happySpecReduce_0  41 happyReduction_46
+happyReduction_46  =  HappyAbsSyn41
 		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
 	)
 
-happyReduce_46 = happySpecReduce_3  40 happyReduction_46
-happyReduction_46 (HappyAbsSyn40  happy_var_3)
+happyReduce_47 = happySpecReduce_3  41 happyReduction_47
+happyReduction_47 (HappyAbsSyn41  happy_var_3)
 	_
-	(HappyAbsSyn39  happy_var_1)
-	 =  HappyAbsSyn40
+	(HappyAbsSyn40  happy_var_1)
+	 =  HappyAbsSyn41
 		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_3))
 	)
-happyReduction_46 _ _ _  = notHappyAtAll 
+happyReduction_47 _ _ _  = notHappyAtAll 
 
-happyReduce_47 = happyReduce 7 41 happyReduction_47
-happyReduction_47 ((HappyAbsSyn45  happy_var_7) `HappyStk`
+happyReduce_48 = happyReduce 7 42 happyReduction_48
+happyReduction_48 ((HappyAbsSyn46  happy_var_7) `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn45  happy_var_5) `HappyStk`
+	(HappyAbsSyn46  happy_var_5) `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn43  happy_var_3) `HappyStk`
-	(HappyAbsSyn26  happy_var_2) `HappyStk`
+	(HappyAbsSyn44  happy_var_3) `HappyStk`
+	(HappyAbsSyn27  happy_var_2) `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
-	 = HappyAbsSyn41
+	 = HappyAbsSyn42
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclDef (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_3) (snd happy_var_5) (snd happy_var_7))
 	) `HappyStk` happyRest
 
-happyReduce_48 = happyReduce 8 41 happyReduction_48
-happyReduction_48 ((HappyAbsSyn45  happy_var_8) `HappyStk`
+happyReduce_49 = happyReduce 8 42 happyReduction_49
+happyReduction_49 ((HappyAbsSyn46  happy_var_8) `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn45  happy_var_6) `HappyStk`
+	(HappyAbsSyn46  happy_var_6) `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn43  happy_var_4) `HappyStk`
-	(HappyAbsSyn26  happy_var_3) `HappyStk`
+	(HappyAbsSyn44  happy_var_4) `HappyStk`
+	(HappyAbsSyn27  happy_var_3) `HappyStk`
 	_ `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
-	 = HappyAbsSyn41
+	 = HappyAbsSyn42
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclPrivateDef (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_4) (snd happy_var_6) (snd happy_var_8))
 	) `HappyStk` happyRest
 
-happyReduce_49 = happyReduce 6 41 happyReduction_49
-happyReduction_49 (_ `HappyStk`
-	(HappyAbsSyn42  happy_var_5) `HappyStk`
+happyReduce_50 = happyReduce 6 42 happyReduction_50
+happyReduction_50 (_ `HappyStk`
+	(HappyAbsSyn43  happy_var_5) `HappyStk`
 	_ `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn26  happy_var_2) `HappyStk`
+	(HappyAbsSyn27  happy_var_2) `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
-	 = HappyAbsSyn41
+	 = HappyAbsSyn42
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclNamespace (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_5))
 	) `HappyStk` happyRest
 
-happyReduce_50 = happySpecReduce_2  41 happyReduction_50
-happyReduction_50 (HappyAbsSyn26  happy_var_2)
+happyReduce_51 = happySpecReduce_2  42 happyReduction_51
+happyReduction_51 (HappyAbsSyn27  happy_var_2)
 	(HappyTerminal happy_var_1)
-	 =  HappyAbsSyn41
+	 =  HappyAbsSyn42
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclOpen (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
 	)
-happyReduction_50 _ _  = notHappyAtAll 
+happyReduction_51 _ _  = notHappyAtAll 
 
-happyReduce_51 = happyReduce 4 41 happyReduction_51
-happyReduction_51 ((HappyAbsSyn45  happy_var_4) `HappyStk`
+happyReduce_52 = happyReduce 4 42 happyReduction_52
+happyReduction_52 ((HappyAbsSyn46  happy_var_4) `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn45  happy_var_2) `HappyStk`
+	(HappyAbsSyn46  happy_var_2) `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
-	 = HappyAbsSyn41
+	 = HappyAbsSyn42
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclCheck (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
 	) `HappyStk` happyRest
 
-happyReduce_52 = happySpecReduce_2  41 happyReduction_52
-happyReduction_52 (HappyAbsSyn45  happy_var_2)
+happyReduce_53 = happySpecReduce_2  42 happyReduction_53
+happyReduction_53 (HappyAbsSyn46  happy_var_2)
 	(HappyTerminal happy_var_1)
-	 =  HappyAbsSyn41
+	 =  HappyAbsSyn42
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DeclCompute (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
 	)
-happyReduction_52 _ _  = notHappyAtAll 
+happyReduction_53 _ _  = notHappyAtAll 
 
-happyReduce_53 = happySpecReduce_0  42 happyReduction_53
-happyReduction_53  =  HappyAbsSyn42
+happyReduce_54 = happySpecReduce_0  43 happyReduction_54
+happyReduction_54  =  HappyAbsSyn43
 		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
 	)
 
-happyReduce_54 = happySpecReduce_1  42 happyReduction_54
-happyReduction_54 (HappyAbsSyn41  happy_var_1)
-	 =  HappyAbsSyn42
+happyReduce_55 = happySpecReduce_1  43 happyReduction_55
+happyReduction_55 (HappyAbsSyn42  happy_var_1)
+	 =  HappyAbsSyn43
 		 ((fst happy_var_1, (:[]) (snd happy_var_1))
 	)
-happyReduction_54 _  = notHappyAtAll 
+happyReduction_55 _  = notHappyAtAll 
 
-happyReduce_55 = happySpecReduce_3  42 happyReduction_55
-happyReduction_55 (HappyAbsSyn42  happy_var_3)
+happyReduce_56 = happySpecReduce_3  43 happyReduction_56
+happyReduction_56 (HappyAbsSyn43  happy_var_3)
 	_
-	(HappyAbsSyn41  happy_var_1)
-	 =  HappyAbsSyn42
+	(HappyAbsSyn42  happy_var_1)
+	 =  HappyAbsSyn43
 		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_3))
 	)
-happyReduction_55 _ _ _  = notHappyAtAll 
+happyReduction_56 _ _ _  = notHappyAtAll 
 
-happyReduce_56 = happySpecReduce_0  43 happyReduction_56
-happyReduction_56  =  HappyAbsSyn43
+happyReduce_57 = happySpecReduce_0  44 happyReduction_57
+happyReduction_57  =  HappyAbsSyn44
 		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, Language.MLTT.Syntax.Abs.NoDischarge Language.MLTT.Syntax.Abs.BNFC'NoPosition)
 	)
 
-happyReduce_57 = happyReduce 4 43 happyReduction_57
-happyReduction_57 (_ `HappyStk`
-	(HappyAbsSyn44  happy_var_3) `HappyStk`
+happyReduce_58 = happyReduce 4 44 happyReduction_58
+happyReduction_58 (_ `HappyStk`
+	(HappyAbsSyn45  happy_var_3) `HappyStk`
 	_ `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
-	 = HappyAbsSyn43
+	 = HappyAbsSyn44
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.DischargeOver (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3))
 	) `HappyStk` happyRest
 
-happyReduce_58 = happySpecReduce_0  44 happyReduction_58
-happyReduction_58  =  HappyAbsSyn44
+happyReduce_59 = happySpecReduce_0  45 happyReduction_59
+happyReduction_59  =  HappyAbsSyn45
 		 ((Language.MLTT.Syntax.Abs.BNFC'NoPosition, [])
 	)
 
-happyReduce_59 = happySpecReduce_1  44 happyReduction_59
-happyReduction_59 (HappyAbsSyn26  happy_var_1)
-	 =  HappyAbsSyn44
+happyReduce_60 = happySpecReduce_1  45 happyReduction_60
+happyReduction_60 (HappyAbsSyn27  happy_var_1)
+	 =  HappyAbsSyn45
 		 ((fst happy_var_1, (:[]) (snd happy_var_1))
 	)
-happyReduction_59 _  = notHappyAtAll 
+happyReduction_60 _  = notHappyAtAll 
 
-happyReduce_60 = happySpecReduce_3  44 happyReduction_60
-happyReduction_60 (HappyAbsSyn44  happy_var_3)
+happyReduce_61 = happySpecReduce_3  45 happyReduction_61
+happyReduction_61 (HappyAbsSyn45  happy_var_3)
 	_
-	(HappyAbsSyn26  happy_var_1)
-	 =  HappyAbsSyn44
+	(HappyAbsSyn27  happy_var_1)
+	 =  HappyAbsSyn45
 		 ((fst happy_var_1, (:) (snd happy_var_1) (snd happy_var_3))
 	)
-happyReduction_60 _ _ _  = notHappyAtAll 
+happyReduction_61 _ _ _  = notHappyAtAll 
 
-happyReduce_61 = happyReduce 8 45 happyReduction_61
-happyReduction_61 ((HappyAbsSyn48  happy_var_8) `HappyStk`
+happyReduce_62 = happyReduce 8 46 happyReduction_62
+happyReduction_62 ((HappyAbsSyn47  happy_var_8) `HappyStk`
 	_ `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn45  happy_var_5) `HappyStk`
+	(HappyAbsSyn46  happy_var_5) `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn49  happy_var_3) `HappyStk`
+	(HappyAbsSyn51  happy_var_3) `HappyStk`
 	_ `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
-	 = HappyAbsSyn45
+	 = HappyAbsSyn46
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Pi (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_8))
 	) `HappyStk` happyRest
 
-happyReduce_62 = happyReduce 8 45 happyReduction_62
-happyReduction_62 ((HappyAbsSyn48  happy_var_8) `HappyStk`
+happyReduce_63 = happyReduce 8 46 happyReduction_63
+happyReduction_63 ((HappyAbsSyn47  happy_var_8) `HappyStk`
 	_ `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn45  happy_var_5) `HappyStk`
+	(HappyAbsSyn46  happy_var_5) `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn49  happy_var_3) `HappyStk`
+	(HappyAbsSyn51  happy_var_3) `HappyStk`
 	_ `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
-	 = HappyAbsSyn45
+	 = HappyAbsSyn46
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Sigma (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_8))
 	) `HappyStk` happyRest
 
-happyReduce_63 = happyReduce 4 45 happyReduction_63
-happyReduction_63 ((HappyAbsSyn48  happy_var_4) `HappyStk`
+happyReduce_64 = happyReduce 4 46 happyReduction_64
+happyReduction_64 ((HappyAbsSyn47  happy_var_4) `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn49  happy_var_2) `HappyStk`
+	(HappyAbsSyn51  happy_var_2) `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
-	 = HappyAbsSyn45
+	 = HappyAbsSyn46
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Lam (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
 	) `HappyStk` happyRest
 
-happyReduce_64 = happyReduce 6 45 happyReduction_64
-happyReduction_64 ((HappyAbsSyn48  happy_var_6) `HappyStk`
+happyReduce_65 = happyReduce 6 46 happyReduction_65
+happyReduction_65 ((HappyAbsSyn47  happy_var_6) `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn45  happy_var_4) `HappyStk`
+	(HappyAbsSyn46  happy_var_4) `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn49  happy_var_2) `HappyStk`
+	(HappyAbsSyn51  happy_var_2) `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
-	 = HappyAbsSyn45
+	 = HappyAbsSyn46
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Let (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4) (snd happy_var_6))
 	) `HappyStk` happyRest
 
-happyReduce_65 = happySpecReduce_3  45 happyReduction_65
-happyReduction_65 (HappyAbsSyn45  happy_var_3)
+happyReduce_66 = happyReduce 4 46 happyReduction_66
+happyReduction_66 ((HappyAbsSyn47  happy_var_4) `HappyStk`
+	(HappyAbsSyn51  happy_var_3) `HappyStk`
+	(HappyAbsSyn51  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn46
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.lamMulti (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_3) (snd happy_var_4))
+	) `HappyStk` happyRest
+
+happyReduce_67 = happyReduce 9 46 happyReduction_67
+happyReduction_67 ((HappyAbsSyn47  happy_var_9) `HappyStk`
+	_ `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn46  happy_var_6) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn51  happy_var_4) `HappyStk`
+	(HappyAbsSyn51  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn46
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.piTwo (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_4) (snd happy_var_6) (snd happy_var_9))
+	) `HappyStk` happyRest
+
+happyReduce_68 = happyReduce 10 46 happyReduction_68
+happyReduction_68 ((HappyAbsSyn47  happy_var_10) `HappyStk`
+	_ `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn46  happy_var_7) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn51  happy_var_5) `HappyStk`
+	(HappyAbsSyn51  happy_var_4) `HappyStk`
+	(HappyAbsSyn51  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn46
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.piThree (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_4) (snd happy_var_5) (snd happy_var_7) (snd happy_var_10))
+	) `HappyStk` happyRest
+
+happyReduce_69 = happyReduce 11 46 happyReduction_69
+happyReduction_69 ((HappyAbsSyn47  happy_var_11) `HappyStk`
+	_ `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn46  happy_var_8) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn51  happy_var_6) `HappyStk`
+	(HappyAbsSyn51  happy_var_5) `HappyStk`
+	(HappyAbsSyn51  happy_var_4) `HappyStk`
+	(HappyAbsSyn51  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn46
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.piFour (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_4) (snd happy_var_5) (snd happy_var_6) (snd happy_var_8) (snd happy_var_11))
+	) `HappyStk` happyRest
+
+happyReduce_70 = happySpecReduce_3  46 happyReduction_70
+happyReduction_70 (HappyAbsSyn46  happy_var_3)
 	_
-	(HappyAbsSyn45  happy_var_1)
-	 =  HappyAbsSyn45
+	(HappyAbsSyn46  happy_var_1)
+	 =  HappyAbsSyn46
 		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.Arrow (fst happy_var_1) (snd happy_var_1) (snd happy_var_3))
 	)
-happyReduction_65 _ _ _  = notHappyAtAll 
+happyReduction_70 _ _ _  = notHappyAtAll 
 
-happyReduce_66 = happySpecReduce_3  45 happyReduction_66
-happyReduction_66 (HappyAbsSyn45  happy_var_3)
+happyReduce_71 = happySpecReduce_3  46 happyReduction_71
+happyReduction_71 (HappyAbsSyn46  happy_var_3)
 	_
-	(HappyAbsSyn45  happy_var_1)
-	 =  HappyAbsSyn45
+	(HappyAbsSyn46  happy_var_1)
+	 =  HappyAbsSyn46
 		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.Product (fst happy_var_1) (snd happy_var_1) (snd happy_var_3))
 	)
-happyReduction_66 _ _ _  = notHappyAtAll 
+happyReduction_71 _ _ _  = notHappyAtAll 
 
-happyReduce_67 = happySpecReduce_1  45 happyReduction_67
-happyReduction_67 (HappyAbsSyn45  happy_var_1)
-	 =  HappyAbsSyn45
+happyReduce_72 = happySpecReduce_1  46 happyReduction_72
+happyReduction_72 (HappyAbsSyn46  happy_var_1)
+	 =  HappyAbsSyn46
 		 ((fst happy_var_1, (snd happy_var_1))
-	)
-happyReduction_67 _  = notHappyAtAll 
-
-happyReduce_68 = happySpecReduce_2  46 happyReduction_68
-happyReduction_68 (HappyAbsSyn45  happy_var_2)
-	(HappyAbsSyn45  happy_var_1)
-	 =  HappyAbsSyn45
-		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.App (fst happy_var_1) (snd happy_var_1) (snd happy_var_2))
-	)
-happyReduction_68 _ _  = notHappyAtAll 
-
-happyReduce_69 = happySpecReduce_1  46 happyReduction_69
-happyReduction_69 (HappyAbsSyn45  happy_var_1)
-	 =  HappyAbsSyn45
-		 ((fst happy_var_1, (snd happy_var_1))
-	)
-happyReduction_69 _  = notHappyAtAll 
-
-happyReduce_70 = happySpecReduce_2  47 happyReduction_70
-happyReduction_70 (HappyAbsSyn45  happy_var_2)
-	(HappyTerminal happy_var_1)
-	 =  HappyAbsSyn45
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.First (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
-	)
-happyReduction_70 _ _  = notHappyAtAll 
-
-happyReduce_71 = happySpecReduce_2  47 happyReduction_71
-happyReduction_71 (HappyAbsSyn45  happy_var_2)
-	(HappyTerminal happy_var_1)
-	 =  HappyAbsSyn45
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Second (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
-	)
-happyReduction_71 _ _  = notHappyAtAll 
-
-happyReduce_72 = happySpecReduce_1  47 happyReduction_72
-happyReduction_72 (HappyTerminal happy_var_1)
-	 =  HappyAbsSyn45
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Universe (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
 	)
 happyReduction_72 _  = notHappyAtAll 
 
-happyReduce_73 = happySpecReduce_1  47 happyReduction_73
-happyReduction_73 (HappyTerminal happy_var_1)
-	 =  HappyAbsSyn45
+happyReduce_73 = happySpecReduce_2  47 happyReduction_73
+happyReduction_73 (HappyAbsSyn46  happy_var_2)
+	(HappyTerminal happy_var_1)
+	 =  HappyAbsSyn47
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.lamRestDone (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
+	)
+happyReduction_73 _ _  = notHappyAtAll 
+
+happyReduce_74 = happySpecReduce_2  47 happyReduction_74
+happyReduction_74 (HappyAbsSyn47  happy_var_2)
+	(HappyAbsSyn51  happy_var_1)
+	 =  HappyAbsSyn47
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.lamRestMore (fst happy_var_1) (snd happy_var_1) (snd happy_var_2))
+	)
+happyReduction_74 _ _  = notHappyAtAll 
+
+happyReduce_75 = happySpecReduce_2  48 happyReduction_75
+happyReduction_75 (HappyAbsSyn46  happy_var_2)
+	(HappyAbsSyn46  happy_var_1)
+	 =  HappyAbsSyn46
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.App (fst happy_var_1) (snd happy_var_1) (snd happy_var_2))
+	)
+happyReduction_75 _ _  = notHappyAtAll 
+
+happyReduce_76 = happySpecReduce_1  48 happyReduction_76
+happyReduction_76 (HappyAbsSyn46  happy_var_1)
+	 =  HappyAbsSyn46
+		 ((fst happy_var_1, (snd happy_var_1))
+	)
+happyReduction_76 _  = notHappyAtAll 
+
+happyReduce_77 = happySpecReduce_2  49 happyReduction_77
+happyReduction_77 (HappyAbsSyn46  happy_var_2)
+	(HappyTerminal happy_var_1)
+	 =  HappyAbsSyn46
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.First (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
+	)
+happyReduction_77 _ _  = notHappyAtAll 
+
+happyReduce_78 = happySpecReduce_2  49 happyReduction_78
+happyReduction_78 (HappyAbsSyn46  happy_var_2)
+	(HappyTerminal happy_var_1)
+	 =  HappyAbsSyn46
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Second (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2))
+	)
+happyReduction_78 _ _  = notHappyAtAll 
+
+happyReduce_79 = happySpecReduce_1  49 happyReduction_79
+happyReduction_79 (HappyTerminal happy_var_1)
+	 =  HappyAbsSyn46
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Universe (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
+	)
+happyReduction_79 _  = notHappyAtAll 
+
+happyReduce_80 = happySpecReduce_1  49 happyReduction_80
+happyReduction_80 (HappyTerminal happy_var_1)
+	 =  HappyAbsSyn46
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.UnitType (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
 	)
-happyReduction_73 _  = notHappyAtAll 
+happyReduction_80 _  = notHappyAtAll 
 
-happyReduce_74 = happySpecReduce_1  47 happyReduction_74
-happyReduction_74 (HappyTerminal happy_var_1)
-	 =  HappyAbsSyn45
+happyReduce_81 = happySpecReduce_1  49 happyReduction_81
+happyReduction_81 (HappyTerminal happy_var_1)
+	 =  HappyAbsSyn46
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.UnitVal (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
 	)
-happyReduction_74 _  = notHappyAtAll 
+happyReduction_81 _  = notHappyAtAll 
 
-happyReduce_75 = happySpecReduce_1  47 happyReduction_75
-happyReduction_75 (HappyAbsSyn26  happy_var_1)
-	 =  HappyAbsSyn45
+happyReduce_82 = happySpecReduce_1  49 happyReduction_82
+happyReduction_82 (HappyAbsSyn27  happy_var_1)
+	 =  HappyAbsSyn46
 		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.Var (fst happy_var_1) (snd happy_var_1))
-	)
-happyReduction_75 _  = notHappyAtAll 
-
-happyReduce_76 = happyReduce 8 47 happyReduction_76
-happyReduction_76 (_ `HappyStk`
-	(HappyAbsSyn45  happy_var_7) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn45  happy_var_5) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn45  happy_var_3) `HappyStk`
-	_ `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn45
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.IdType (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_7))
-	) `HappyStk` happyRest
-
-happyReduce_77 = happyReduce 4 47 happyReduction_77
-happyReduction_77 (_ `HappyStk`
-	(HappyAbsSyn45  happy_var_3) `HappyStk`
-	_ `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn45
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Refl (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3))
-	) `HappyStk` happyRest
-
-happyReduce_78 = happyReduce 8 47 happyReduction_78
-happyReduction_78 (_ `HappyStk`
-	(HappyAbsSyn45  happy_var_7) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn45  happy_var_5) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn45  happy_var_3) `HappyStk`
-	_ `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn45
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.J (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_7))
-	) `HappyStk` happyRest
-
-happyReduce_79 = happyReduce 5 47 happyReduction_79
-happyReduction_79 (_ `HappyStk`
-	(HappyAbsSyn45  happy_var_4) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn45  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn45
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Pair (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
-	) `HappyStk` happyRest
-
-happyReduce_80 = happyReduce 5 47 happyReduction_80
-happyReduction_80 (_ `HappyStk`
-	(HappyAbsSyn45  happy_var_4) `HappyStk`
-	_ `HappyStk`
-	(HappyAbsSyn45  happy_var_2) `HappyStk`
-	(HappyTerminal happy_var_1) `HappyStk`
-	happyRest)
-	 = HappyAbsSyn45
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Ann (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
-	) `HappyStk` happyRest
-
-happyReduce_81 = happySpecReduce_3  47 happyReduction_81
-happyReduction_81 _
-	(HappyAbsSyn45  happy_var_2)
-	(HappyTerminal happy_var_1)
-	 =  HappyAbsSyn45
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), (snd happy_var_2))
-	)
-happyReduction_81 _ _ _  = notHappyAtAll 
-
-happyReduce_82 = happySpecReduce_1  48 happyReduction_82
-happyReduction_82 (HappyAbsSyn45  happy_var_1)
-	 =  HappyAbsSyn48
-		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.AScopedTerm (fst happy_var_1) (snd happy_var_1))
 	)
 happyReduction_82 _  = notHappyAtAll 
 
-happyReduce_83 = happySpecReduce_1  49 happyReduction_83
-happyReduction_83 (HappyTerminal happy_var_1)
-	 =  HappyAbsSyn49
-		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.PatternWildcard (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
-	)
-happyReduction_83 _  = notHappyAtAll 
-
-happyReduce_84 = happySpecReduce_1  49 happyReduction_84
-happyReduction_84 (HappyAbsSyn26  happy_var_1)
-	 =  HappyAbsSyn49
-		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.PatternVar (fst happy_var_1) (snd happy_var_1))
-	)
-happyReduction_84 _  = notHappyAtAll 
-
-happyReduce_85 = happyReduce 5 49 happyReduction_85
-happyReduction_85 (_ `HappyStk`
-	(HappyAbsSyn49  happy_var_4) `HappyStk`
+happyReduce_83 = happyReduce 8 49 happyReduction_83
+happyReduction_83 (_ `HappyStk`
+	(HappyAbsSyn46  happy_var_7) `HappyStk`
 	_ `HappyStk`
-	(HappyAbsSyn49  happy_var_2) `HappyStk`
+	(HappyAbsSyn46  happy_var_5) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn46  happy_var_3) `HappyStk`
+	_ `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
-	 = HappyAbsSyn49
+	 = HappyAbsSyn46
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.IdType (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_7))
+	) `HappyStk` happyRest
+
+happyReduce_84 = happyReduce 4 49 happyReduction_84
+happyReduction_84 (_ `HappyStk`
+	(HappyAbsSyn46  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn46
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Refl (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3))
+	) `HappyStk` happyRest
+
+happyReduce_85 = happyReduce 8 49 happyReduction_85
+happyReduction_85 (_ `HappyStk`
+	(HappyAbsSyn46  happy_var_7) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn46  happy_var_5) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn46  happy_var_3) `HappyStk`
+	_ `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn46
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.J (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_3) (snd happy_var_5) (snd happy_var_7))
+	) `HappyStk` happyRest
+
+happyReduce_86 = happyReduce 5 49 happyReduction_86
+happyReduction_86 (_ `HappyStk`
+	(HappyAbsSyn46  happy_var_4) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn46  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn46
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Pair (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
+	) `HappyStk` happyRest
+
+happyReduce_87 = happyReduce 5 49 happyReduction_87
+happyReduction_87 (_ `HappyStk`
+	(HappyAbsSyn46  happy_var_4) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn46  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn46
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.Ann (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
+	) `HappyStk` happyRest
+
+happyReduce_88 = happySpecReduce_3  49 happyReduction_88
+happyReduction_88 _
+	(HappyAbsSyn46  happy_var_2)
+	(HappyTerminal happy_var_1)
+	 =  HappyAbsSyn46
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), (snd happy_var_2))
+	)
+happyReduction_88 _ _ _  = notHappyAtAll 
+
+happyReduce_89 = happySpecReduce_1  50 happyReduction_89
+happyReduction_89 (HappyAbsSyn46  happy_var_1)
+	 =  HappyAbsSyn47
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.AScopedTerm (fst happy_var_1) (snd happy_var_1))
+	)
+happyReduction_89 _  = notHappyAtAll 
+
+happyReduce_90 = happySpecReduce_1  51 happyReduction_90
+happyReduction_90 (HappyTerminal happy_var_1)
+	 =  HappyAbsSyn51
+		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.PatternWildcard (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)))
+	)
+happyReduction_90 _  = notHappyAtAll 
+
+happyReduce_91 = happySpecReduce_1  51 happyReduction_91
+happyReduction_91 (HappyAbsSyn27  happy_var_1)
+	 =  HappyAbsSyn51
+		 ((fst happy_var_1, Language.MLTT.Syntax.Abs.PatternVar (fst happy_var_1) (snd happy_var_1))
+	)
+happyReduction_91 _  = notHappyAtAll 
+
+happyReduce_92 = happyReduce 5 51 happyReduction_92
+happyReduction_92 (_ `HappyStk`
+	(HappyAbsSyn51  happy_var_4) `HappyStk`
+	_ `HappyStk`
+	(HappyAbsSyn51  happy_var_2) `HappyStk`
+	(HappyTerminal happy_var_1) `HappyStk`
+	happyRest)
+	 = HappyAbsSyn51
 		 ((uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1), Language.MLTT.Syntax.Abs.PatternPair (uncurry Language.MLTT.Syntax.Abs.BNFC'Position (tokenLineCol happy_var_1)) (snd happy_var_2) (snd happy_var_4))
 	) `HappyStk` happyRest
 
 happyNewToken action sts stk [] =
-	action 90 90 notHappyAtAll (HappyState action) sts stk []
+	action 92 92 notHappyAtAll (HappyState action) sts stk []
 
 happyNewToken action sts stk (tk:tks) =
 	let cont i = action i i tk (HappyState action) sts stk tks in
 	case tk of {
-	PT _ (TS _ 1) -> cont 50;
-	PT _ (TS _ 2) -> cont 51;
-	PT _ (TS _ 3) -> cont 52;
-	PT _ (TS _ 4) -> cont 53;
-	PT _ (TS _ 5) -> cont 54;
-	PT _ (TS _ 6) -> cont 55;
-	PT _ (TS _ 7) -> cont 56;
-	PT _ (TS _ 8) -> cont 57;
-	PT _ (TS _ 9) -> cont 58;
-	PT _ (TS _ 10) -> cont 59;
-	PT _ (TS _ 11) -> cont 60;
-	PT _ (TS _ 12) -> cont 61;
-	PT _ (TS _ 13) -> cont 62;
-	PT _ (TS _ 14) -> cont 63;
-	PT _ (TS _ 15) -> cont 64;
-	PT _ (TS _ 16) -> cont 65;
-	PT _ (TS _ 17) -> cont 66;
-	PT _ (TS _ 18) -> cont 67;
-	PT _ (TS _ 19) -> cont 68;
-	PT _ (TS _ 20) -> cont 69;
-	PT _ (TS _ 21) -> cont 70;
-	PT _ (TS _ 22) -> cont 71;
-	PT _ (TS _ 23) -> cont 72;
-	PT _ (TS _ 24) -> cont 73;
-	PT _ (TS _ 25) -> cont 74;
-	PT _ (TS _ 26) -> cont 75;
-	PT _ (TS _ 27) -> cont 76;
-	PT _ (TS _ 28) -> cont 77;
-	PT _ (TS _ 29) -> cont 78;
-	PT _ (TS _ 30) -> cont 79;
-	PT _ (TS _ 31) -> cont 80;
-	PT _ (TS _ 32) -> cont 81;
-	PT _ (TS _ 33) -> cont 82;
-	PT _ (TS _ 34) -> cont 83;
-	PT _ (TS _ 35) -> cont 84;
-	PT _ (TS _ 36) -> cont 85;
-	PT _ (TS _ 37) -> cont 86;
-	PT _ (TS _ 38) -> cont 87;
-	PT _ (TS _ 39) -> cont 88;
-	PT _ (T_VarIdent _) -> cont 89;
+	PT _ (TS _ 1) -> cont 52;
+	PT _ (TS _ 2) -> cont 53;
+	PT _ (TS _ 3) -> cont 54;
+	PT _ (TS _ 4) -> cont 55;
+	PT _ (TS _ 5) -> cont 56;
+	PT _ (TS _ 6) -> cont 57;
+	PT _ (TS _ 7) -> cont 58;
+	PT _ (TS _ 8) -> cont 59;
+	PT _ (TS _ 9) -> cont 60;
+	PT _ (TS _ 10) -> cont 61;
+	PT _ (TS _ 11) -> cont 62;
+	PT _ (TS _ 12) -> cont 63;
+	PT _ (TS _ 13) -> cont 64;
+	PT _ (TS _ 14) -> cont 65;
+	PT _ (TS _ 15) -> cont 66;
+	PT _ (TS _ 16) -> cont 67;
+	PT _ (TS _ 17) -> cont 68;
+	PT _ (TS _ 18) -> cont 69;
+	PT _ (TS _ 19) -> cont 70;
+	PT _ (TS _ 20) -> cont 71;
+	PT _ (TS _ 21) -> cont 72;
+	PT _ (TS _ 22) -> cont 73;
+	PT _ (TS _ 23) -> cont 74;
+	PT _ (TS _ 24) -> cont 75;
+	PT _ (TS _ 25) -> cont 76;
+	PT _ (TS _ 26) -> cont 77;
+	PT _ (TS _ 27) -> cont 78;
+	PT _ (TS _ 28) -> cont 79;
+	PT _ (TS _ 29) -> cont 80;
+	PT _ (TS _ 30) -> cont 81;
+	PT _ (TS _ 31) -> cont 82;
+	PT _ (TS _ 32) -> cont 83;
+	PT _ (TS _ 33) -> cont 84;
+	PT _ (TS _ 34) -> cont 85;
+	PT _ (TS _ 35) -> cont 86;
+	PT _ (TS _ 36) -> cont 87;
+	PT _ (TS _ 37) -> cont 88;
+	PT _ (TS _ 38) -> cont 89;
+	PT _ (TS _ 39) -> cont 90;
+	PT _ (T_VarIdent _) -> cont 91;
 	_ -> happyError' ((tk:tks), [])
 	}
 
-happyError_ explist 90 tk tks = happyError' (tks, explist)
+happyError_ explist 92 tk tks = happyError' (tks, explist)
 happyError_ explist _ tk tks = happyError' ((tk:tks), explist)
 
 happyThen :: () => Err a -> (a -> Err b) -> Err b
@@ -2329,73 +2668,76 @@ happyReturn1 = \a tks -> (return) a
 happyError' :: () => ([(Token)], [Prelude.String]) -> Err a
 happyError' = (\(tokens, _) -> happyError tokens)
 pProgram_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_0 tks) (\x -> case x of {HappyAbsSyn27 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_0 tks) (\x -> case x of {HappyAbsSyn28 z -> happyReturn z; _other -> notHappyAtAll })
 
 pListUnit_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_1 tks) (\x -> case x of {HappyAbsSyn28 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_1 tks) (\x -> case x of {HappyAbsSyn29 z -> happyReturn z; _other -> notHappyAtAll })
 
 pUnit_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_2 tks) (\x -> case x of {HappyAbsSyn29 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_2 tks) (\x -> case x of {HappyAbsSyn30 z -> happyReturn z; _other -> notHappyAtAll })
 
 pModule_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_3 tks) (\x -> case x of {HappyAbsSyn30 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_3 tks) (\x -> case x of {HappyAbsSyn31 z -> happyReturn z; _other -> notHappyAtAll })
 
 pInclude_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_4 tks) (\x -> case x of {HappyAbsSyn31 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_4 tks) (\x -> case x of {HappyAbsSyn32 z -> happyReturn z; _other -> notHappyAtAll })
 
 pListInclude_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_5 tks) (\x -> case x of {HappyAbsSyn32 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_5 tks) (\x -> case x of {HappyAbsSyn33 z -> happyReturn z; _other -> notHappyAtAll })
 
 pRefinement_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_6 tks) (\x -> case x of {HappyAbsSyn33 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_6 tks) (\x -> case x of {HappyAbsSyn34 z -> happyReturn z; _other -> notHappyAtAll })
 
 pFixed_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_7 tks) (\x -> case x of {HappyAbsSyn34 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_7 tks) (\x -> case x of {HappyAbsSyn35 z -> happyReturn z; _other -> notHappyAtAll })
 
 pListFixed_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_8 tks) (\x -> case x of {HappyAbsSyn35 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_8 tks) (\x -> case x of {HappyAbsSyn36 z -> happyReturn z; _other -> notHappyAtAll })
 
 pTelescopeDecl_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_9 tks) (\x -> case x of {HappyAbsSyn36 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_9 tks) (\x -> case x of {HappyAbsSyn37 z -> happyReturn z; _other -> notHappyAtAll })
 
 pParam_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_10 tks) (\x -> case x of {HappyAbsSyn37 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_10 tks) (\x -> case x of {HappyAbsSyn38 z -> happyReturn z; _other -> notHappyAtAll })
 
 pListParam_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_11 tks) (\x -> case x of {HappyAbsSyn38 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_11 tks) (\x -> case x of {HappyAbsSyn39 z -> happyReturn z; _other -> notHappyAtAll })
 
 pImport_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_12 tks) (\x -> case x of {HappyAbsSyn39 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_12 tks) (\x -> case x of {HappyAbsSyn40 z -> happyReturn z; _other -> notHappyAtAll })
 
 pListImport_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_13 tks) (\x -> case x of {HappyAbsSyn40 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_13 tks) (\x -> case x of {HappyAbsSyn41 z -> happyReturn z; _other -> notHappyAtAll })
 
 pDecl_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_14 tks) (\x -> case x of {HappyAbsSyn41 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_14 tks) (\x -> case x of {HappyAbsSyn42 z -> happyReturn z; _other -> notHappyAtAll })
 
 pListDecl_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_15 tks) (\x -> case x of {HappyAbsSyn42 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_15 tks) (\x -> case x of {HappyAbsSyn43 z -> happyReturn z; _other -> notHappyAtAll })
 
 pDischarge_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_16 tks) (\x -> case x of {HappyAbsSyn43 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_16 tks) (\x -> case x of {HappyAbsSyn44 z -> happyReturn z; _other -> notHappyAtAll })
 
 pListVarIdent_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_17 tks) (\x -> case x of {HappyAbsSyn44 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_17 tks) (\x -> case x of {HappyAbsSyn45 z -> happyReturn z; _other -> notHappyAtAll })
 
 pTerm_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_18 tks) (\x -> case x of {HappyAbsSyn45 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_18 tks) (\x -> case x of {HappyAbsSyn46 z -> happyReturn z; _other -> notHappyAtAll })
+
+pScopedTerm9_internal tks = happySomeParser where
+ happySomeParser = happyThen (happyParse action_19 tks) (\x -> case x of {HappyAbsSyn47 z -> happyReturn z; _other -> notHappyAtAll })
 
 pTerm1_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_19 tks) (\x -> case x of {HappyAbsSyn45 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_20 tks) (\x -> case x of {HappyAbsSyn46 z -> happyReturn z; _other -> notHappyAtAll })
 
 pTerm2_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_20 tks) (\x -> case x of {HappyAbsSyn45 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_21 tks) (\x -> case x of {HappyAbsSyn46 z -> happyReturn z; _other -> notHappyAtAll })
 
 pScopedTerm_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_21 tks) (\x -> case x of {HappyAbsSyn48 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_22 tks) (\x -> case x of {HappyAbsSyn47 z -> happyReturn z; _other -> notHappyAtAll })
 
 pPattern_internal tks = happySomeParser where
- happySomeParser = happyThen (happyParse action_22 tks) (\x -> case x of {HappyAbsSyn49 z -> happyReturn z; _other -> notHappyAtAll })
+ happySomeParser = happyThen (happyParse action_23 tks) (\x -> case x of {HappyAbsSyn51 z -> happyReturn z; _other -> notHappyAtAll })
 
 happySeq = happyDontSeq
 
@@ -2471,6 +2813,9 @@ pListVarIdent = fmap snd . pListVarIdent_internal
 
 pTerm :: [Token] -> Err Language.MLTT.Syntax.Abs.Term
 pTerm = fmap snd . pTerm_internal
+
+pScopedTerm9 :: [Token] -> Err Language.MLTT.Syntax.Abs.ScopedTerm
+pScopedTerm9 = fmap snd . pScopedTerm9_internal
 
 pTerm1 :: [Token] -> Err Language.MLTT.Syntax.Abs.Term
 pTerm1 = fmap snd . pTerm1_internal

--- a/haskell/mltt/test/Language/MLTT/SugarSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/SugarSpec.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Multi-binder sugar.
+--
+-- @λ a b c ⇒ e@ and @Π (a b c : T) → B@ are parse-time sugar for the nested
+-- forms: the grammar's @define@ rules construct nested nodes, so the abstract
+-- syntax never records which spelling was written. The property under test is
+-- exactly that indistinguishability.
+module Language.MLTT.SugarSpec (spec) where
+
+import           Language.MLTT.Impl
+import           Language.MLTT.Impl.Generated (SourceText (..))
+import           Test.Hspec
+
+-- | Interpret a program, reporting a parse error as a failed command.
+run :: String -> [CommandResult]
+run input = case interpret (SourceText input) of
+  Left err      -> [Failed ("parse error: " <> err)]
+  Right results -> results
+
+-- | The messages of every command that was rejected.
+failures :: [CommandResult] -> [String]
+failures results = [err | Failed err <- results]
+
+-- | The normal forms every @compute@ produced.
+computed :: [CommandResult] -> [RenderedTerm]
+computed results = [term | Computed term <- results]
+
+-- | A module around the given lines.
+inModule :: [String] -> String
+inModule ls = unlines ("module M" : ls)
+
+spec :: Spec
+spec = do
+  describe "multi-binder λ" $ do
+    it "means the nested λs, and nothing downstream can tell" $
+      computed (run (inModule
+        ["compute (λ a b ⇒ a : 𝟙 → 𝟙 → 𝟙)"]))
+        `shouldBe`
+      computed (run (inModule
+        ["compute (λ a ⇒ λ b ⇒ a : 𝟙 → 𝟙 → 𝟙)"]))
+
+    it "takes any number of binders" $
+      failures (run (inModule
+        [ "def pick : 𝟙 → 𝟙 → 𝟙 → 𝟙 → 𝟙 → 𝟙"
+        , "  := λ a b c d e ⇒ c" ]))
+        `shouldBe` []
+
+    it "admits any pattern in any position" $
+      failures (run (inModule
+        [ "def first : (𝟙 × 𝟙) → 𝟙 → 𝟙"
+        , "  := λ (a, b) c ⇒ a" ]))
+        `shouldBe` []
+
+  describe "a Π group" $ do
+    it "means the nested Πs with the type repeated at each binder" $
+      failures (run (inModule
+        [ "def diag : Π (x y z : 𝕌) → 𝕌 := λ x y z ⇒ y"
+        , "check diag : Π (x : 𝕌) → Π (y : 𝕌) → Π (z : 𝕌) → 𝕌" ]))
+        `shouldBe` []
+
+    it "takes up to four binders" $
+      failures (run (inModule
+        ["check (λ a b c d ⇒ tt : Π (a b c d : 𝟙) → 𝟙) : Π (a b c d : 𝟙) → 𝟙"]))
+        `shouldBe` []
+
+    it "may bind dependently within the group" $
+      -- The later binders of a group are in scope of the repeated type only,
+      -- but the body sees them all in order.
+      failures (run (inModule
+        ["check (λ A B f x ⇒ f x : Π (A B : 𝕌) → (A → B) → A → B)"
+          <> " : Π (A : 𝕌) → Π (B : 𝕌) → (A → B) → A → B"]))
+        `shouldBe` []


### PR DESCRIPTION
`λ a b c ⇒ e` now reads as the nested λs, at any number of binders, and `Π (a b c : T) → B` as the nested Πs with the type repeated, up to four binders in a group.

Both are grammar-level `define` rules, so they construct nested nodes at parse time: the abstract syntax is exactly as if the binders had been written out, nothing that free foil's Template Haskell consumes changes, and the printed form a content hash is taken over never records which spelling was written. The λ recursion goes through a numbered category sharing `ScopedTerm`'s type, which is what lets a define-only category produce plain scoped terms; a define cannot fold over a list, which is why the Π arities are written out.