### PR TITLE
Foil: lift the stripe registry out of the mltt demo

### DIFF
--- a/haskell/free-foil/free-foil.cabal
+++ b/haskell/free-foil/free-foil.cabal
@@ -33,6 +33,7 @@ library
       Control.Monad.Foil.Example
       Control.Monad.Foil.Internal
       Control.Monad.Foil.Internal.ValidNameBinders
+      Control.Monad.Foil.Registry
       Control.Monad.Foil.Relative
       Control.Monad.Foil.TH
       Control.Monad.Foil.TH.MkFoilData

--- a/haskell/free-foil/src/Control/Monad/Foil/Registry.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/Registry.hs
@@ -23,6 +23,7 @@ module Control.Monad.Foil.Registry (
   -- * Stripe indices
   StripeIndex (..),
   -- * Layouts
+  StripeSize (..),
   StripeLayout (..),
   stripesBelowZero,
   stripesAbove,
@@ -37,7 +38,7 @@ import           Data.Binary                 (Binary)
 import           Data.Map                    (Map)
 import qualified Data.Map                    as Map
 
-import           Control.Monad.Foil.Internal (NameRange (..))
+import           Control.Monad.Foil.Internal (NameRange (..), RawName)
 
 -- $setup
 -- >>> import Control.Monad.Foil.Internal
@@ -47,6 +48,12 @@ import           Control.Monad.Foil.Internal (NameRange (..))
 -- a count, or an offset.
 newtype StripeIndex = StripeIndex Int
   deriving newtype (Eq, Ord, Show, Read, Binary)
+
+-- | How many names a unit may declare: the width of every stripe a layout
+-- hands out. Its own type, so that a size cannot be confused with a name, an
+-- index, or a base.
+newtype StripeSize = StripeSize Int
+  deriving newtype (Eq, Ord, Show, Read)
 
 -- | Where stripe @i@ lies on the raw-name line.
 --
@@ -70,27 +77,25 @@ newtype StripeLayout = StripeLayout
 -- names, which is what
 -- <https://github.com/fizruk/free-foil the mltt demo> uses it for.
 --
--- >>> stripeRange (stripesBelowZero 100) (StripeIndex 0)
+-- >>> stripeRange (stripesBelowZero (StripeSize 100)) (StripeIndex 0)
 -- NameRange {nameRangeLo = -100, nameRangeHi = -1}
--- >>> stripeRange (stripesBelowZero 100) (StripeIndex 2)
+-- >>> stripeRange (stripesBelowZero (StripeSize 100)) (StripeIndex 2)
 -- NameRange {nameRangeLo = -300, nameRangeHi = -201}
-stripesBelowZero
-  :: Int  -- ^ How many names a unit may declare.
-  -> StripeLayout
-stripesBelowZero size = StripeLayout $ \(StripeIndex i) ->
+stripesBelowZero :: StripeSize -> StripeLayout
+stripesBelowZero (StripeSize size) = StripeLayout $ \(StripeIndex i) ->
   let hi = negate (i * size) - 1
    in NameRange (hi - size + 1) hi
 
 -- | Stripe @i@ is the @i@-th run of @size@ names at or above a base,
 -- counting upwards, so stripe 0 is @[base .. base + size - 1]@.
 --
--- >>> stripeRange (stripesAbove 0 100) (StripeIndex 1)
+-- >>> stripeRange (stripesAbove 0 (StripeSize 100)) (StripeIndex 1)
 -- NameRange {nameRangeLo = 100, nameRangeHi = 199}
 stripesAbove
-  :: Int  -- ^ The base: the low end of stripe 0.
-  -> Int  -- ^ How many names a unit may declare.
+  :: RawName     -- ^ The base: the low end of stripe 0.
+  -> StripeSize
   -> StripeLayout
-stripesAbove base size = StripeLayout $ \(StripeIndex i) ->
+stripesAbove base (StripeSize size) = StripeLayout $ \(StripeIndex i) ->
   let lo = base + i * size
    in NameRange lo (lo + size - 1)
 
@@ -110,7 +115,7 @@ registrySize = Map.size
 
 -- | The stripe of a unit, assigning the next one on first use.
 --
--- >>> let layout = stripesBelowZero 10
+-- >>> let layout = stripesBelowZero (StripeSize 10)
 -- >>> let (r1, rangeA) = registerUnit layout "A" emptyRegistry
 -- >>> rangeA
 -- NameRange {nameRangeLo = -10, nameRangeHi = -1}

--- a/haskell/free-foil/src/Control/Monad/Foil/Registry.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/Registry.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- | Deterministic stripe assignment for separately checked units.
+--
+-- A module system wants each unit to allocate its top-level names inside its
+-- own reservation (see "Control.Monad.Foil.Blocks"), and it wants the
+-- assignment of reservations to be /deterministic/: a unit's declarations are
+-- numbered @base@, @base + 1@, … in declaration order, whatever else is
+-- checked around it. Determinism is what makes raw names cacheable — a unit
+-- checked today and a unit loaded tomorrow agree name for name — and what
+-- discharges the trust obligation of 'Control.Monad.Foil.Blocks.checkExtScope',
+-- which compares raw names across independently built worlds.
+--
+-- The registry is that assignment: an append-only map from unit names to
+-- stripe indices, handing out the next index on first use. In a real build it
+-- is persisted beside the build products, because cached artifacts survive
+-- changes elsewhere in the build exactly when the assignment does not move.
+-- Where the stripes lie on the raw-name line is a 'StripeLayout', a client
+-- policy: the library is region-agnostic, and the allocator admits negative
+-- names.
+module Control.Monad.Foil.Registry (
+  -- * Stripe indices
+  StripeIndex (..),
+  -- * Layouts
+  StripeLayout (..),
+  stripesBelowZero,
+  stripesAbove,
+  -- * The registry
+  Registry,
+  emptyRegistry,
+  registrySize,
+  registerUnit,
+) where
+
+import           Data.Binary                 (Binary)
+import           Data.Map                    (Map)
+import qualified Data.Map                    as Map
+
+import           Control.Monad.Foil.Internal (NameRange (..))
+
+-- $setup
+-- >>> import Control.Monad.Foil.Internal
+
+-- | A stripe's position in the registry: which run of names a unit draws
+-- from. Its own type, so that a stripe index cannot be confused with a name,
+-- a count, or an offset.
+newtype StripeIndex = StripeIndex Int
+  deriving newtype (Eq, Ord, Show, Read, Binary)
+
+-- | Where stripe @i@ lies on the raw-name line.
+--
+-- The library does not choose: whether stripes descend below zero, ascend
+-- from some base, or interleave with other reservations is a policy of the
+-- client, and everything in "Control.Monad.Foil.Blocks" works from the
+-- resulting 'NameRange's alone. A layout should give disjoint ranges to
+-- distinct indices; nothing checks this here, but
+-- 'Control.Monad.Foil.Blocks.withDisjointUnion' refuses the overlap at the
+-- point where it would do harm.
+newtype StripeLayout = StripeLayout
+  { stripeRange :: StripeIndex -> NameRange
+  }
+
+-- | Stripe @i@ is the @i@-th run of @size@ names below zero, counting
+-- downwards, so stripe 0 is @[-size .. -1]@. Within a stripe, allocation
+-- still ascends (see 'Control.Monad.Foil.withFreshIn'), so declaration order
+-- is ascending name order.
+--
+-- This layout leaves the whole non-negative range free for a client's local
+-- names, which is what
+-- <https://github.com/fizruk/free-foil the mltt demo> uses it for.
+--
+-- >>> stripeRange (stripesBelowZero 100) (StripeIndex 0)
+-- NameRange {nameRangeLo = -100, nameRangeHi = -1}
+-- >>> stripeRange (stripesBelowZero 100) (StripeIndex 2)
+-- NameRange {nameRangeLo = -300, nameRangeHi = -201}
+stripesBelowZero
+  :: Int  -- ^ How many names a unit may declare.
+  -> StripeLayout
+stripesBelowZero size = StripeLayout $ \(StripeIndex i) ->
+  let hi = negate (i * size) - 1
+   in NameRange (hi - size + 1) hi
+
+-- | Stripe @i@ is the @i@-th run of @size@ names at or above a base,
+-- counting upwards, so stripe 0 is @[base .. base + size - 1]@.
+--
+-- >>> stripeRange (stripesAbove 0 100) (StripeIndex 1)
+-- NameRange {nameRangeLo = 100, nameRangeHi = 199}
+stripesAbove
+  :: Int  -- ^ The base: the low end of stripe 0.
+  -> Int  -- ^ How many names a unit may declare.
+  -> StripeLayout
+stripesAbove base size = StripeLayout $ \(StripeIndex i) ->
+  let lo = base + i * size
+   in NameRange lo (lo + size - 1)
+
+-- | Which stripe each unit's declarations live in, by the unit's name.
+--
+-- Append-only: a name, once registered, keeps its stripe for the lifetime of
+-- the registry, and the next stripe index is always the registry's size.
+type Registry name = Map name StripeIndex
+
+-- | The registry before any unit has ever been checked.
+emptyRegistry :: Registry name
+emptyRegistry = Map.empty
+
+-- | How many units have been registered, which is also the next free stripe.
+registrySize :: Registry name -> Int
+registrySize = Map.size
+
+-- | The stripe of a unit, assigning the next one on first use.
+--
+-- >>> let layout = stripesBelowZero 10
+-- >>> let (r1, rangeA) = registerUnit layout "A" emptyRegistry
+-- >>> rangeA
+-- NameRange {nameRangeLo = -10, nameRangeHi = -1}
+-- >>> snd (registerUnit layout "B" r1)
+-- NameRange {nameRangeLo = -20, nameRangeHi = -11}
+--
+-- Registration is idempotent, which is the determinism a cache rests on:
+--
+-- >>> snd (registerUnit layout "A" r1) == rangeA
+-- True
+registerUnit
+  :: Ord name
+  => StripeLayout -> name -> Registry name -> (Registry name, NameRange)
+registerUnit layout name registry = case Map.lookup name registry of
+  Just i  -> (registry, stripeRange layout i)
+  Nothing ->
+    let i = StripeIndex (Map.size registry)
+     in (Map.insert name i registry, stripeRange layout i)

--- a/haskell/mltt/src/Language/MLTT/Build.hs
+++ b/haskell/mltt/src/Language/MLTT/Build.hs
@@ -51,6 +51,7 @@ import           Control.Exception        (evaluate)
 import           Control.Monad            (foldM, forM, forM_, unless, when)
 import qualified Control.Monad.Foil       as Foil
 import qualified Control.Monad.Foil.Blocks as Blocks
+import           Control.Monad.Foil.Registry (StripeIndex (..))
 import qualified Data.ByteString          as BS
 import qualified Data.ByteString.Lazy     as BSL
 import           Data.Char                (isSpace)

--- a/haskell/mltt/src/Language/MLTT/Impl.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl.hs
@@ -45,10 +45,11 @@
 module Language.MLTT.Impl where
 
 import           Control.DeepSeq              (NFData)
-import           Data.Binary                  (Binary)
 import           Control.Monad                (foldM)
 import qualified Control.Monad.Foil           as Foil
 import qualified Control.Monad.Foil.Blocks    as Blocks
+import           Control.Monad.Foil.Registry  (StripeIndex (..))
+import qualified Control.Monad.Foil.Registry  as Registry
 import           Data.Functor.Compose         (Compose (..))
 import           Data.Functor.Identity        (Identity (..))
 import           Control.Monad.Free.Foil      (AST (Var), UnresolvedName (..))
@@ -408,42 +409,29 @@ stripeSize = 0x100000
 localRegion :: Foil.NameRange
 localRegion = Foil.NameRange 0 maxBound
 
--- | A stripe's position in the registry: which run of 'stripeSize' names a
--- module draws from. Its own type, so that a stripe index cannot be confused
--- with a name, a count, or an offset.
-newtype StripeIndex = StripeIndex Int
-  deriving newtype (Eq, Ord, Show, Read, Binary)
+-- | The demo's stripe layout: runs of 'stripeSize' names below zero,
+-- descending, per "Control.Monad.Foil.Registry". The registry machinery
+-- itself lives in the library now; what stays here is this policy.
+mlttStripes :: Registry.StripeLayout
+mlttStripes = Registry.stripesBelowZero stripeSize
 
--- | Which stripe each module's declarations live in.
---
--- The assignment is what makes raw names deterministic: a module's
--- declarations are numbered @base@, @base + 1@, … in declaration order,
--- whatever else is checked around it. In a real build this map is persistent
--- — written beside the build products and loaded at start — because cached
--- artefacts survive changes elsewhere in the module graph exactly when the
--- assignment does not move. Here it is threaded through one run, and a test
--- (or a driver) can seed it.
-type Registry = Map Raw.VarIdent StripeIndex
+-- | Which stripe each module's declarations live in; see
+-- "Control.Monad.Foil.Registry" for why the assignment is persistent and
+-- append-only. Here it is threaded through one run, and a test (or a driver)
+-- can seed it.
+type Registry = Registry.Registry Raw.VarIdent
 
 -- | The registry before any module has ever been checked.
 emptyRegistry :: Registry
-emptyRegistry = Map.empty
+emptyRegistry = Registry.emptyRegistry
 
 -- | The stripe of a module, assigning the next one on first use.
--- The registry is append-only, so the next stripe index is its size.
 registerModule :: Raw.VarIdent -> Registry -> (Registry, Foil.NameRange)
-registerModule name registry = case Map.lookup name registry of
-  Just i  -> (registry, stripeRange i)
-  Nothing -> let i = StripeIndex (Map.size registry)
-              in (Map.insert name i registry, stripeRange i)
+registerModule = Registry.registerUnit mlttStripes
 
--- | Stripe @i@ is the @i@-th run of 'stripeSize' names below zero, counting
--- downwards, so stripe 0 is @[-stripeSize .. -1]@. Within a stripe,
--- allocation still ascends, so declaration order is ascending name order.
+-- | Where stripe @i@ lies, under the demo's layout.
 stripeRange :: StripeIndex -> Foil.NameRange
-stripeRange (StripeIndex i) = Foil.NameRange (hi - stripeSize + 1) hi
-  where
-    hi = negate (i * stripeSize) - 1
+stripeRange = Registry.stripeRange mlttStripes
 
 -- * Interpreting a program
 

--- a/haskell/mltt/src/Language/MLTT/Impl.hs
+++ b/haskell/mltt/src/Language/MLTT/Impl.hs
@@ -386,8 +386,8 @@ resolveUnits units
 -- stays out of their region.
 
 -- | How many top-level names a module may declare.
-stripeSize :: Int
-stripeSize = 0x100000
+stripeSize :: Registry.StripeSize
+stripeSize = Registry.StripeSize 0x100000
 
 -- | The region module parameters and elaboration-time binders live in: every
 -- non-negative name, now that the stripes lie below zero.

--- a/haskell/mltt/test/Language/MLTT/ArtifactSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ArtifactSpec.hs
@@ -8,6 +8,7 @@
 -- and check a client on top.
 module Language.MLTT.ArtifactSpec (spec) where
 
+import           Control.Monad.Foil.Registry (StripeIndex (..))
 import qualified Control.Monad.Foil           as Foil
 import           Data.Map                     (Map)
 import qualified Data.Map                     as Map

--- a/haskell/mltt/test/Language/MLTT/LinkSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/LinkSpec.hs
@@ -9,6 +9,7 @@
 -- with the shared import identified rather than renamed apart.
 module Language.MLTT.LinkSpec (spec) where
 
+import           Control.Monad.Foil.Registry (StripeIndex (..))
 import           Control.Concurrent           (forkIO, newEmptyMVar, putMVar,
                                                takeMVar)
 import           Control.Exception            (evaluate)

--- a/haskell/mltt/test/Language/MLTT/ReplImportSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ReplImportSpec.hs
@@ -6,6 +6,7 @@
 -- modes (unknown module, missing artifact, stale chain).
 module Language.MLTT.ReplImportSpec (spec) where
 
+import           Control.Monad.Foil.Registry (StripeIndex (..))
 import qualified Control.Monad.Foil           as Foil
 import           Data.List                    (isInfixOf)
 import           System.Directory             (getTemporaryDirectory,

--- a/haskell/mltt/test/Language/MLTT/ReplSpec.hs
+++ b/haskell/mltt/test/Language/MLTT/ReplSpec.hs
@@ -4,6 +4,7 @@
 -- environment carried from step to step.
 module Language.MLTT.ReplSpec (spec) where
 
+import           Control.Monad.Foil.Registry (StripeIndex (..))
 import           Test.Hspec
 
 import           Language.MLTT.Impl


### PR DESCRIPTION
The registry is what makes raw names deterministic, and determinism is what `checkExtScope`'s trust obligation and every cached artifact rest on, so it belongs beside the `Blocks` machinery rather than in a demo.

`Control.Monad.Foil.Registry` carries the stripe indices, the append-only assignment (`registerUnit`), and the layout as an explicit client policy (`StripeLayout`), with the demo's below-zero descending layout and an ascending one as the stock choices. The unit-name type is a parameter, so a client keys the registry by whatever it names modules with.

The demo keeps its policy (the stripe size and the local region) and rewires `registerModule` and `stripeRange` onto the library.