### PR TITLE
Foil: lift the labelled telescope out of the mltt demo

### DIFF
--- a/haskell/free-foil/free-foil.cabal
+++ b/haskell/free-foil/free-foil.cabal
@@ -34,6 +34,7 @@ library
       Control.Monad.Foil.Internal
       Control.Monad.Foil.Internal.ValidNameBinders
       Control.Monad.Foil.Relative
+      Control.Monad.Foil.Telescope
       Control.Monad.Foil.TH
       Control.Monad.Foil.TH.MkFoilData
       Control.Monad.Foil.TH.MkFromFoil

--- a/haskell/free-foil/src/Control/Monad/Foil/Telescope.hs
+++ b/haskell/free-foil/src/Control/Monad/Foil/Telescope.hs
@@ -1,0 +1,243 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE InstanceSigs        #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+
+-- | The labelled telescope: a chain of binders, each carrying a label and a
+-- payload in the scope before it.
+--
+-- This is the pattern behind a module's parameter block, a record signature,
+-- or an algebraic theory: @(A : 𝕌) (m : A → A → A)@ is a two-step
+-- telescope whose second payload mentions the first binder. Because a
+-- telescope is a pattern ('CoSinkable', 'UnifiablePattern'), scope extension,
+-- the names of a block, and α-equivalence of blocks come from the pattern
+-- machinery, with the payloads compared through 'AlphaEquiv'.
+--
+-- What this module does not fix is what a payload /is/: the payload type is a
+-- parameter, and the operations that need to look inside one — the support a
+-- dependency closure needs, say — take the looking function as an argument.
+-- A client instantiates the labels and payloads to its own types; the mltt
+-- demo uses spellings and types, and closes declarations over the fields they
+-- use by 'closeOverTelescope' followed by 'withThinnedNameBinderList'.
+module Control.Monad.Foil.Telescope where
+
+import           Control.Monad.Foil.Internal
+import           Control.Monad.Foil.Relative (RelMonad, liftRM)
+
+-- | A labelled telescope: a chain of binders, each carrying a label and a
+-- payload in the scope before it.
+--
+-- The payload of a step lives in the scope the steps before it extend to, which
+-- is what makes this a telescope rather than a list. For a module's parameters
+-- the label is how the parameter is spelled and the payload is its type, so
+-- that @(A : 𝕌) (m : A → A → A)@ is a two-step telescope whose second payload
+-- mentions the first binder.
+--
+-- See 'NameBinderList', which this follows almost line for line. The type
+-- was proven in the mltt demo, as a module's parameter block, before moving
+-- here.
+data Telescope label e n l where
+  TelescopeEmpty :: Telescope label e n n
+  TelescopeCons
+    :: label                        -- ^ How the step is labelled.
+    -> e n                          -- ^ Its payload, in the scope before it.
+    -> NameBinder n i          -- ^ The binder it introduces.
+    -> Telescope label e i l        -- ^ The steps after it.
+    -> Telescope label e n l
+
+-- | A telescope is a pattern, so the foil's own machinery walks it.
+--
+-- 'coSinkabilityProof' is the interesting half. It is proof code (every
+-- call site goes through 'extendRenaming', which is a coercion), but it
+-- has to typecheck, and it only does because a payload is sunk by the renaming
+-- of the scope /before/ its binder rather than by the extended one.
+--
+-- 'withPattern' is written out rather than derived, and has to be: the
+-- generic implementation refuses a pattern with a field indexed by a scope,
+-- since it would leave a payload naming a refreshed binder pointing at the name
+-- that binder used to have. This follows the recipe in 'transportPayload':
+-- a 'PatternTransport' threaded through the traversal, each payload moved
+-- by the transport accumulated /before/ its own binder, since that is the scope
+-- the payload lives in.
+instance Sinkable e => CoSinkable (Telescope label e) where
+  coSinkabilityProof rename TelescopeEmpty cont = cont rename TelescopeEmpty
+  coSinkabilityProof rename (TelescopeCons label payload binder rest) cont =
+    coSinkabilityProof rename binder $ \rename' binder' ->
+      coSinkabilityProof rename' rest $ \rename'' rest' ->
+        cont rename''
+          (TelescopeCons label (sinkabilityProof rename payload) binder' rest')
+
+  withPattern
+    :: forall f o n l r. Distinct o
+    => (forall x y z r'. Distinct z
+          => Scope z
+          -> NameBinder x y
+          -> (forall z'. DExt z z' => f x y z z' -> NameBinder z z' -> r')
+          -> r')
+    -> (forall x z z'. DExt z z' => f x x z z')
+    -> (forall x y y' z z' z''. (DExt z z', DExt z' z'')
+          => f x y z z' -> f y y' z' z'' -> f x y' z z'')
+    -> Scope o
+    -> Telescope label e n l
+    -> (forall o'. DExt o o' => f n l o o' -> Telescope label e o o' -> r)
+    -> r
+  withPattern withBinder unit comp = go verbatimTransport
+    where
+      go :: forall n' l' o' r'. Distinct o'
+         => PatternTransport n' o'
+         -> Scope o'
+         -> Telescope label e n' l'
+         -> (forall o''. DExt o' o''
+               => f n' l' o' o'' -> Telescope label e o' o'' -> r')
+         -> r'
+      go _transport _scope TelescopeEmpty cont = cont unit TelescopeEmpty
+      go transport scope (TelescopeCons label payload binder rest) cont =
+        withBinder scope binder $ \fbinder binder' ->
+          go (transportUnderBinder transport binder binder')
+             (extendScope binder' scope)
+             rest $ \frest rest' ->
+            cont (comp fbinder frest)
+              (TelescopeCons label (transportPayload transport payload) binder' rest')
+
+-- | Two telescopes unify when their binders line up and their payloads agree.
+--
+-- Labels are ignored, which is what α-equivalence should do with a label: a
+-- parameter's spelling is no more relevant than a bound variable's. Payloads
+-- are not, since two telescopes agreeing on binders may well disagree on types.
+--
+-- 'unifyPatterns' is the binder-only approximation, which is all a caller
+-- without a scope can be given. 'unifyPatternsIn' is the real answer, and
+-- it is what the library's α-equivalence calls.
+instance (Sinkable e, AlphaEquiv e, RelMonad Name e)
+    => UnifiablePattern (Telescope label e) where
+  unifyPatterns TelescopeEmpty TelescopeEmpty =
+    SameNameBinders emptyNameBinders
+  unifyPatterns (TelescopeCons _ _ x xs) (TelescopeCons _ _ y ys) =
+    case (assertDistinct x, assertDistinct y) of
+      (Distinct, Distinct) ->
+        unifyNameBinders x y `andThenUnifyPatterns` (xs, ys)
+  -- Telescopes of different lengths bind different numbers of names.
+  unifyPatterns _ _ = NotUnifiable
+
+  unifyPatternsIn scope tele1 tele2
+    | payloadsAgree scope tele1 tele2 verdict = verdict
+    | otherwise                               = NotUnifiable
+    where
+      verdict = unifyPatterns tele1 tele2
+
+-- | The payloads of a telescope, each moved into its innermost scope.
+--
+-- Sinking is free, so putting them all in one scope costs nothing and lets a
+-- renaming be applied to the whole block at once.
+telescopePayloads
+  :: (Sinkable e, Distinct l) => Telescope label e n l -> [e l]
+telescopePayloads = map paramType . telescopeParams
+
+-- | Do the payloads of two telescopes agree, under the way their binders were
+-- unified?
+--
+-- The verdict speaks about binders only, so the renaming it prescribes has to
+-- be applied before the payloads are compared, which is exactly what
+-- 'Control.Monad.Free.alphaEquivScoped' does to the body of a scoped term.
+-- Comparing them as they stand would report @(A : 𝕌) (x : A)@ and
+-- @(B : 𝕌) (y : B)@ as different, since the second payloads name different
+-- binders until the first ones have been identified.
+payloadsAgree
+  :: forall label e n l r.
+     (Sinkable e, AlphaEquiv e, RelMonad Name e, Distinct n)
+  => Scope n
+  -> Telescope label e n l
+  -> Telescope label e n r
+  -> UnifyNameBinders (Telescope label e) n l r
+  -> Bool
+payloadsAgree scope tele1 tele2 verdict =
+  case (assertDistinct tele1, assertDistinct tele2) of
+    (Distinct, Distinct) ->
+      let payloads1 = telescopePayloads tele1
+          payloads2 = telescopePayloads tele2
+       in case verdict of
+            NotUnifiable -> False
+            -- The binders are the same, so the payloads already compare.
+            SameNameBinders{} ->
+              agree (extendScopePattern tele1 scope) payloads1 payloads2
+            -- The left telescope's binders become the right's, so its payloads
+            -- have to follow them before they can be compared.
+            RenameLeftNameBinder _ renameL ->
+              let scope' = extendScopePattern tele2 scope
+               in agree scope' (map (rename scope' renameL) payloads1) payloads2
+            RenameRightNameBinder _ renameR ->
+              let scope' = extendScopePattern tele1 scope
+               in agree scope' payloads1 (map (rename scope' renameR) payloads2)
+            -- Neither side's binders survive, so both blocks move to the
+            -- unified ones.
+            RenameBothBinders binders renameL renameR ->
+              case assertDistinct binders of
+                Distinct ->
+                  let scope' = extendScopePattern binders scope
+                   in agree scope' (map (rename scope' renameL) payloads1)
+                                   (map (rename scope' renameR) payloads2)
+  where
+    -- Lengths cannot disagree here: a verdict other than 'NotUnifiable'
+    -- says the two telescopes bind the same number of names.
+    agree :: forall m. Distinct m => Scope m -> [e m] -> [e m] -> Bool
+    agree scope' xs ys = and (zipWith (alphaEquivIn scope') xs ys)
+
+    rename
+      :: forall i m. Distinct m
+      => Scope m -> (NameBinder n i -> NameBinder n m) -> e i -> e m
+    rename scope' f = liftRM scope' (fromNameBinderRenaming f)
+
+-- | One step of a telescope, with everything about it moved into the innermost
+-- scope.
+--
+-- Sinking is free, so this is the convenient form for anything that has to
+-- compare parameters with the names of a term checked under all of them.
+data Param label e l = Param
+  { paramLabel :: label
+  , paramName  :: Name l
+  , paramType  :: e l
+  }
+
+-- | The steps of a telescope, outermost first.
+telescopeParams
+  :: (Sinkable e, Distinct l)
+  => Telescope label e n l -> [Param label e l]
+telescopeParams TelescopeEmpty = []
+telescopeParams (TelescopeCons label ty binder rest) =
+  case (assertExt binder, assertExt rest) of
+    (Ext, Ext) ->
+      Param label (sink (nameOf binder)) (sink ty)
+        : telescopeParams rest
+
+-- | The chain of binders a telescope forms.
+--
+-- This is 'nameBinderListOf' at a telescope, written out: the general one
+-- goes through 'withPattern' and so rebuilds the telescope only to throw
+-- it away, and this is on the checking path.
+telescopeBinders :: Telescope label e n l -> NameBinderList n l
+telescopeBinders TelescopeEmpty = NameBinderListEmpty
+telescopeBinders (TelescopeCons _ _ binder rest) =
+  NameBinderListCons binder (telescopeBinders rest)
+
+-- | Close a set of parameters under the parameters their payloads need.
+--
+-- Keeping a parameter puts its payload into the result, so whatever that
+-- payload mentions has to be kept too. A payload mentions only the parameters
+-- before it, so working from the inside out settles it in one pass.
+--
+-- The support of a payload is the caller's to supply, since the library does
+-- not know what a payload is; for terms of the free foil it is
+-- 'Control.Monad.Free.Foil.supportOf'.
+closeOverTelescope
+  :: Distinct l
+  => (e l -> NameSet l)  -- ^ The support of a payload.
+  -> [Param label e l] -> NameSet l -> NameSet l
+closeOverTelescope supportOfPayload params wanted = foldr close wanted params
+  where
+    close p keep
+      | nameSetMember (paramName p) keep = keep <> supportOfPayload (paramType p)
+      | otherwise                        = keep
+

--- a/haskell/mltt/src/Language/MLTT/Telescope.hs
+++ b/haskell/mltt/src/Language/MLTT/Telescope.hs
@@ -2,11 +2,16 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE InstanceSigs        #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
--- | The labelled telescope, module parameters as an instance of it, and closing
--- a declaration over the parameters it uses.
+-- | Module parameters as a labelled telescope, and closing a declaration over
+-- the parameters it uses.
+--
+-- The telescope itself — the type, its pattern instances, and the dependency
+-- closure — lives in the library ("Control.Monad.Foil.Telescope"), where it
+-- moved after being proven here. What stays in the demo is the
+-- instantiation: labels are spellings, payloads are types, and 'discharge'
+-- folds the closed type into @Π@s and the value into @λ@s.
 --
 -- A parametrised module
 --
@@ -21,25 +26,21 @@
 -- optional @over (…)@ clause states that set in the source, and is checked
 -- against the computed one by 'checkDischarge'.
 --
--- The parameters may come from an @include@ rather than be written out; that is
--- resolved before a module is checked (see 'Language.MLTT.Impl.resolveUnits'),
--- so nothing here can tell the difference.
---
 -- == Where the scope restriction is
 --
--- This is the place the demo needs free-foil's scope /restriction/ rather than
+-- This is the place the demo needs free-foil\'s scope /restriction/ rather than
 -- its extension. Checking happens in the scope @p@ that the parameters extend
--- the module's scope @n@ to; the result has to come back to @n@, because @n@ is
--- where the module's exports live and where the next module starts.
+-- the module\'s scope @n@ to; the result has to come back to @n@, because @n@ is
+-- where the module\'s exports live and where the next module starts.
 --
 -- It is done in three steps, and the point of the arrangement is that the term
 -- is walked a fixed number of times rather than once per parameter:
 --
 -- 1. 'supportOf' the type and the value, once each.
--- 2. 'closeOverTelescope' closes that set under the parameter types. Keeping
---    @(x : A)@ puts @A@ into the result, so @A@ has to be kept as well. One
---    pass from the inside out is enough, since a parameter's type mentions only
---    the parameters before it.
+-- 2. 'Foil.closeOverTelescope' closes that set under the parameter types.
+--    Keeping @(x : A)@ puts @A@ into the result, so @A@ has to be kept as
+--    well. One pass from the inside out is enough, since a parameter\'s type
+--    mentions only the parameters before it.
 -- 3. 'Foil.withThinnedNameBinderList' cuts the chain of binders down to that
 --    set in one step, and 'discharge' rebuilds the abstractions along the
 --    thinned chain, restricting each parameter type and the body into it.
@@ -47,227 +48,24 @@
 -- The alternative, asking 'unsinkAST' at every parameter whether the term can
 -- do without it, is shorter to write and walks the whole term once per
 -- parameter.
-module Language.MLTT.Telescope where
+module Language.MLTT.Telescope (
+  module Control.Monad.Foil.Telescope,
+  ParamTelescope,
+  Discharged (..),
+  discharge,
+  checkDischarge,
+) where
 
 import qualified Control.Monad.Foil           as Foil
-import           Control.Monad.Foil.Relative  (RelMonad, liftRM)
+import           Control.Monad.Foil.Telescope
 import           Control.Monad.Free.Foil      (supportOf, unsinkAST)
 import           Data.List                    (intercalate, sort)
 import           Language.MLTT.Impl.Generated
 import           Language.MLTT.Resolve        (prettyVarIdent)
 import qualified Language.MLTT.Syntax.Abs     as Raw
 
--- | A labelled telescope: a chain of binders, each carrying a label and a
--- payload in the scope before it.
---
--- The payload of a step lives in the scope the steps before it extend to, which
--- is what makes this a telescope rather than a list. For a module's parameters
--- the label is how the parameter is spelled and the payload is its type, so
--- that @(A : 𝕌) (m : A → A → A)@ is a two-step telescope whose second payload
--- mentions the first binder.
---
--- Nothing here is specific to MLTT, and the intention is to lift the type and
--- its instances into free-foil once they have been proven in the demo. See
--- 'Foil.NameBinderList', which this follows almost line for line.
-data Telescope label e n l where
-  TelescopeEmpty :: Telescope label e n n
-  TelescopeCons
-    :: label                        -- ^ How the step is labelled.
-    -> e n                          -- ^ Its payload, in the scope before it.
-    -> Foil.NameBinder n i          -- ^ The binder it introduces.
-    -> Telescope label e i l        -- ^ The steps after it.
-    -> Telescope label e n l
-
--- | A module's parameters: the labels are spellings, the payloads are types.
+-- | A module\'s parameters: the labels are spellings, the payloads are types.
 type ParamTelescope a = Telescope Raw.VarIdent (Term' a)
-
--- | A telescope is a pattern, so the foil's own machinery walks it.
---
--- 'Foil.coSinkabilityProof' is the interesting half. It is proof code (every
--- call site goes through 'Foil.extendRenaming', which is a coercion), but it
--- has to typecheck, and it only does because a payload is sunk by the renaming
--- of the scope /before/ its binder rather than by the extended one.
---
--- 'Foil.withPattern' is written out rather than derived, and has to be: the
--- generic implementation refuses a pattern with a field indexed by a scope,
--- since it would leave a payload naming a refreshed binder pointing at the name
--- that binder used to have. This follows the recipe in 'Foil.transportPayload':
--- a 'Foil.PatternTransport' threaded through the traversal, each payload moved
--- by the transport accumulated /before/ its own binder, since that is the scope
--- the payload lives in.
-instance Foil.Sinkable e => Foil.CoSinkable (Telescope label e) where
-  coSinkabilityProof rename TelescopeEmpty cont = cont rename TelescopeEmpty
-  coSinkabilityProof rename (TelescopeCons label payload binder rest) cont =
-    Foil.coSinkabilityProof rename binder $ \rename' binder' ->
-      Foil.coSinkabilityProof rename' rest $ \rename'' rest' ->
-        cont rename''
-          (TelescopeCons label (Foil.sinkabilityProof rename payload) binder' rest')
-
-  withPattern
-    :: forall f o n l r. Foil.Distinct o
-    => (forall x y z r'. Foil.Distinct z
-          => Foil.Scope z
-          -> Foil.NameBinder x y
-          -> (forall z'. Foil.DExt z z' => f x y z z' -> Foil.NameBinder z z' -> r')
-          -> r')
-    -> (forall x z z'. Foil.DExt z z' => f x x z z')
-    -> (forall x y y' z z' z''. (Foil.DExt z z', Foil.DExt z' z'')
-          => f x y z z' -> f y y' z' z'' -> f x y' z z'')
-    -> Foil.Scope o
-    -> Telescope label e n l
-    -> (forall o'. Foil.DExt o o' => f n l o o' -> Telescope label e o o' -> r)
-    -> r
-  withPattern withBinder unit comp = go Foil.verbatimTransport
-    where
-      go :: forall n' l' o' r'. Foil.Distinct o'
-         => Foil.PatternTransport n' o'
-         -> Foil.Scope o'
-         -> Telescope label e n' l'
-         -> (forall o''. Foil.DExt o' o''
-               => f n' l' o' o'' -> Telescope label e o' o'' -> r')
-         -> r'
-      go _transport _scope TelescopeEmpty cont = cont unit TelescopeEmpty
-      go transport scope (TelescopeCons label payload binder rest) cont =
-        withBinder scope binder $ \fbinder binder' ->
-          go (Foil.transportUnderBinder transport binder binder')
-             (Foil.extendScope binder' scope)
-             rest $ \frest rest' ->
-            cont (comp fbinder frest)
-              (TelescopeCons label (Foil.transportPayload transport payload) binder' rest')
-
--- | Two telescopes unify when their binders line up and their payloads agree.
---
--- Labels are ignored, which is what α-equivalence should do with a label: a
--- parameter's spelling is no more relevant than a bound variable's. Payloads
--- are not, since two telescopes agreeing on binders may well disagree on types.
---
--- 'Foil.unifyPatterns' is the binder-only approximation, which is all a caller
--- without a scope can be given. 'Foil.unifyPatternsIn' is the real answer, and
--- it is what the library's α-equivalence calls.
-instance (Foil.Sinkable e, Foil.AlphaEquiv e, RelMonad Foil.Name e)
-    => Foil.UnifiablePattern (Telescope label e) where
-  unifyPatterns TelescopeEmpty TelescopeEmpty =
-    Foil.SameNameBinders Foil.emptyNameBinders
-  unifyPatterns (TelescopeCons _ _ x xs) (TelescopeCons _ _ y ys) =
-    case (Foil.assertDistinct x, Foil.assertDistinct y) of
-      (Foil.Distinct, Foil.Distinct) ->
-        Foil.unifyNameBinders x y `Foil.andThenUnifyPatterns` (xs, ys)
-  -- Telescopes of different lengths bind different numbers of names.
-  unifyPatterns _ _ = Foil.NotUnifiable
-
-  unifyPatternsIn scope tele1 tele2
-    | payloadsAgree scope tele1 tele2 verdict = verdict
-    | otherwise                               = Foil.NotUnifiable
-    where
-      verdict = Foil.unifyPatterns tele1 tele2
-
--- | The payloads of a telescope, each moved into its innermost scope.
---
--- Sinking is free, so putting them all in one scope costs nothing and lets a
--- renaming be applied to the whole block at once.
-telescopePayloads
-  :: (Foil.Sinkable e, Foil.Distinct l) => Telescope label e n l -> [e l]
-telescopePayloads = map paramType . telescopeParams
-
--- | Do the payloads of two telescopes agree, under the way their binders were
--- unified?
---
--- The verdict speaks about binders only, so the renaming it prescribes has to
--- be applied before the payloads are compared, which is exactly what
--- 'Control.Monad.Free.Foil.alphaEquivScoped' does to the body of a scoped term.
--- Comparing them as they stand would report @(A : 𝕌) (x : A)@ and
--- @(B : 𝕌) (y : B)@ as different, since the second payloads name different
--- binders until the first ones have been identified.
-payloadsAgree
-  :: forall label e n l r.
-     (Foil.Sinkable e, Foil.AlphaEquiv e, RelMonad Foil.Name e, Foil.Distinct n)
-  => Foil.Scope n
-  -> Telescope label e n l
-  -> Telescope label e n r
-  -> Foil.UnifyNameBinders (Telescope label e) n l r
-  -> Bool
-payloadsAgree scope tele1 tele2 verdict =
-  case (Foil.assertDistinct tele1, Foil.assertDistinct tele2) of
-    (Foil.Distinct, Foil.Distinct) ->
-      let payloads1 = telescopePayloads tele1
-          payloads2 = telescopePayloads tele2
-       in case verdict of
-            Foil.NotUnifiable -> False
-            -- The binders are the same, so the payloads already compare.
-            Foil.SameNameBinders{} ->
-              agree (Foil.extendScopePattern tele1 scope) payloads1 payloads2
-            -- The left telescope's binders become the right's, so its payloads
-            -- have to follow them before they can be compared.
-            Foil.RenameLeftNameBinder _ renameL ->
-              let scope' = Foil.extendScopePattern tele2 scope
-               in agree scope' (map (rename scope' renameL) payloads1) payloads2
-            Foil.RenameRightNameBinder _ renameR ->
-              let scope' = Foil.extendScopePattern tele1 scope
-               in agree scope' payloads1 (map (rename scope' renameR) payloads2)
-            -- Neither side's binders survive, so both blocks move to the
-            -- unified ones.
-            Foil.RenameBothBinders binders renameL renameR ->
-              case Foil.assertDistinct binders of
-                Foil.Distinct ->
-                  let scope' = Foil.extendScopePattern binders scope
-                   in agree scope' (map (rename scope' renameL) payloads1)
-                                   (map (rename scope' renameR) payloads2)
-  where
-    -- Lengths cannot disagree here: a verdict other than 'Foil.NotUnifiable'
-    -- says the two telescopes bind the same number of names.
-    agree :: forall m. Foil.Distinct m => Foil.Scope m -> [e m] -> [e m] -> Bool
-    agree scope' xs ys = and (zipWith (Foil.alphaEquivIn scope') xs ys)
-
-    rename
-      :: forall i m. Foil.Distinct m
-      => Foil.Scope m -> (Foil.NameBinder n i -> Foil.NameBinder n m) -> e i -> e m
-    rename scope' f = liftRM scope' (Foil.fromNameBinderRenaming f)
-
--- | One step of a telescope, with everything about it moved into the innermost
--- scope.
---
--- Sinking is free, so this is the convenient form for anything that has to
--- compare parameters with the names of a term checked under all of them.
-data Param label e l = Param
-  { paramLabel :: label
-  , paramName  :: Foil.Name l
-  , paramType  :: e l
-  }
-
--- | The steps of a telescope, outermost first.
-telescopeParams
-  :: (Foil.Sinkable e, Foil.Distinct l)
-  => Telescope label e n l -> [Param label e l]
-telescopeParams TelescopeEmpty = []
-telescopeParams (TelescopeCons label ty binder rest) =
-  case (Foil.assertExt binder, Foil.assertExt rest) of
-    (Foil.Ext, Foil.Ext) ->
-      Param label (Foil.sink (Foil.nameOf binder)) (Foil.sink ty)
-        : telescopeParams rest
-
--- | The chain of binders a telescope forms.
---
--- This is 'Foil.nameBinderListOf' at a telescope, written out: the general one
--- goes through 'Foil.withPattern' and so rebuilds the telescope only to throw
--- it away, and this is on the checking path.
-telescopeBinders :: Telescope label e n l -> Foil.NameBinderList n l
-telescopeBinders TelescopeEmpty = Foil.NameBinderListEmpty
-telescopeBinders (TelescopeCons _ _ binder rest) =
-  Foil.NameBinderListCons binder (telescopeBinders rest)
-
--- | Close a set of parameters under the parameters their types need.
---
--- Keeping a parameter puts its type into the result, so whatever that type
--- mentions has to be kept too. A parameter's type mentions only the parameters
--- before it, so working from the inside out settles it in one pass.
-closeOverTelescope
-  :: Foil.Distinct l
-  => [Param label (Term' a) l] -> Foil.NameSet l -> Foil.NameSet l
-closeOverTelescope params wanted = foldr close wanted params
-  where
-    close p keep
-      | Foil.nameSetMember (paramName p) keep = keep <> supportOf (paramType p)
-      | otherwise                             = keep
 
 -- | A declaration after being closed over the module's parameters.
 data Discharged a n = Discharged
@@ -316,7 +114,7 @@ discharge loc scope tele declared ty value
 
     -- The support of the declaration, closed under the parameter types. Two
     -- walks of the term, whatever the number of parameters.
-    needed = closeOverTelescope params (supportOf ty <> supportOf value)
+    needed = closeOverTelescope supportOf params (supportOf ty <> supportOf value)
 
     keep = case declared of
       Nothing -> needed


### PR DESCRIPTION
The type, its `CoSinkable` and `UnifiablePattern` instances, the payload comparison under a unification verdict, and the dependency closure move to `Control.Monad.Foil.Telescope`, as the demo's haddock always said they should once proven there. The closure takes the payload-support function as an argument, since the library does not know what a payload is; for free foil terms it is `supportOf`.

What stays in the demo is the instantiation: labels as spellings, payloads as types, and `discharge` folding the closed type into Πs and the value into λs. Call sites are unchanged through re-exports, and the specs did not move.